### PR TITLE
Remove root service worker

### DIFF
--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -6,10 +6,10 @@ import { SSRProvider } from "react-aria";
 import { trpc } from "@/utils/trpc";
 import "@/styles/globals.css";
 import Layout from "@/components/layout/Layout";
-import registerServiceWorker from "@/utils/sw";
+import { unregisterServiceWorker } from "@/utils/sw";
 import { ConsentProvider } from "@/hooks/consent";
 
-registerServiceWorker("/RootServiceWorker.js");
+unregisterServiceWorker("/RootServiceWorker.js");
 
 const AlveusGgWebsiteApp: AppType<{ session: Session | null }> = ({
   Component,

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -9,7 +9,7 @@ import Layout from "@/components/layout/Layout";
 import { unregisterServiceWorker } from "@/utils/sw";
 import { ConsentProvider } from "@/hooks/consent";
 
-unregisterServiceWorker("/RootServiceWorker.js");
+unregisterServiceWorker();
 
 const AlveusGgWebsiteApp: AppType<{ session: Session | null }> = ({
   Component,

--- a/apps/website/src/utils/sw.ts
+++ b/apps/website/src/utils/sw.ts
@@ -1,4 +1,4 @@
-export default function registerServiceWorker(path: string, scope = "/") {
+export function registerServiceWorker(path: string, scope = "/") {
   if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
     navigator.serviceWorker
       .register(path, {
@@ -10,5 +10,15 @@ export default function registerServiceWorker(path: string, scope = "/") {
           registration.scope
         );
       });
+  }
+}
+
+export function unregisterServiceWorker(path: string, scope = "/") {
+  if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+    navigator.serviceWorker.getRegistration(scope).then((registration) => {
+      if (registration) {
+        registration.unregister();
+      }
+    });
   }
 }

--- a/apps/website/src/utils/sw.ts
+++ b/apps/website/src/utils/sw.ts
@@ -13,7 +13,7 @@ export function registerServiceWorker(path: string, scope = "/") {
   }
 }
 
-export function unregisterServiceWorker(path: string, scope = "/") {
+export function unregisterServiceWorker(scope = "/") {
   if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
     navigator.serviceWorker.getRegistration(scope).then((registration) => {
       if (registration) {

--- a/apps/website/sw.tsup.config.ts
+++ b/apps/website/sw.tsup.config.ts
@@ -10,7 +10,7 @@ const vapidPublicB64 = Buffer.from(
 export default defineConfig((options) => ({
   entry: {
     "push/alveus/PushServiceWorker": "src/sw/PushServiceWorker.ts",
-    RootServiceWorker: "src/sw/RootServiceWorker.ts",
+    //RootServiceWorker: "src/sw/RootServiceWorker.ts",
   },
   splitting: false,
   sourcemap: true,


### PR DESCRIPTION
Apple does not require a full PWA for web push so we do not need to have a SW. The manifest is enough and the push service worker is registered separately.