### PR TITLE
fix undefined env variables throwing in tsup build

### DIFF
--- a/apps/website/sw.tsup.config.ts
+++ b/apps/website/sw.tsup.config.ts
@@ -29,9 +29,9 @@ export default defineConfig((options) => ({
         process.env.VERCEL_URL ?? "localhost"
       ),
       ...Object.fromEntries(
-        Object.entries(env).map(([key, value]) => {
-          return [`process.env.${key}`, JSON.stringify(value)];
-        })
+        Object.entries(env)
+          .filter(([, value]) => value !== undefined)
+          .map(([key, value]) => [`process.env.${key}`, JSON.stringify(value)])
       ),
     };
   },


### PR DESCRIPTION
esbuild expects string values for environment variables. instead of defining undefined env variables with the value `undefined` we just skip them

Resolves #166