### PR TITLE
Define sizes on slideshow images to generate larger srcset

### DIFF
--- a/apps/website/src/components/content/Link.tsx
+++ b/apps/website/src/components/content/Link.tsx
@@ -12,6 +12,7 @@ type LinkProps = {
   className?: string;
   external?: boolean;
   custom?: boolean;
+  prefetch?: boolean;
 };
 
 const Link: React.FC<LinkProps> = ({
@@ -21,10 +22,12 @@ const Link: React.FC<LinkProps> = ({
   className,
   external = false,
   custom = false,
+  prefetch = true,
 }) => {
   const props = {
     href,
     onClick,
+    prefetch,
     className: classes(
       !custom &&
         "text-red-600 transition-colors hover:text-blue-600 hover:underline",

--- a/apps/website/src/components/content/Slideshow.tsx
+++ b/apps/website/src/components/content/Slideshow.tsx
@@ -122,6 +122,8 @@ const Slideshow: React.FC<SlideshowProps> = ({
           <Image
             src={src}
             alt={alt}
+            sizes="100vw"
+            quality={100}
             priority={idx === 0}
             placeholder="blur"
             className="h-full w-full object-cover"

--- a/apps/website/src/hooks/consent.tsx
+++ b/apps/website/src/hooks/consent.tsx
@@ -252,7 +252,7 @@ const ConsentDialog: React.FC<{ context: ConsentContext }> = ({ context }) => {
             <p className="mt-6">
               You can find out more about how we, and third parties, use your
               data in our{" "}
-              <Link href="/privacy-policy" onClick={close}>
+              <Link href="/privacy-policy" onClick={close} prefetch={false}>
                 Privacy Policy
               </Link>
               .


### PR DESCRIPTION
Much as the image is always full width, it looks like we can abuse setting https://nextjs.org/docs/api-reference/next/image#sizes to force Next.js to generate a larger `srcset` with more widths that are better optimized for mobile etc.

In production currently, the homepage slideshow images have an `srcset` with just `1920px` and `3840px` variants. By setting `sizes`, Next.js suddenly generates an `srcset` with `640px`, `750px`, `828px`, `1080px`, `1200px`, `1920px`, `2048px` and `3840px` variants (matching https://nextjs.org/docs/api-reference/next/image#device-sizes).

This should help load times on mobile (and a lot of desktop devices too), and improve the pagespeed score a bit me thinks.

(Also disabling prefetching on the privacy policy link in the consent modal, as pagespeed complains about that too)