### PR TITLE
Small polish of notifications/updates

### DIFF
--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -103,7 +103,7 @@ export function DesktopMenu() {
 
               <DropdownMenuItems>
                 <Menu.Item disabled>
-                  <div className="px-5 py-3">
+                  <div className="px-5 py-2">
                     <ProfileInfo full />
                   </div>
                 </Menu.Item>
@@ -114,9 +114,7 @@ export function DesktopMenu() {
 
                 {showAdminLink && (
                   <Menu.Item>
-                    <NavLinkSub className="px-5 py-3" href="/admin/dashboard">
-                      Admin
-                    </NavLinkSub>
+                    <NavLinkSub href="/admin/dashboard">Admin</NavLinkSub>
                   </Menu.Item>
                 )}
 

--- a/apps/website/src/components/layout/navbar/MobileMenu.tsx
+++ b/apps/website/src/components/layout/navbar/MobileMenu.tsx
@@ -59,11 +59,7 @@ export function MobileMenu() {
                 <li>
                   <div className="my-3 w-full border-t opacity-30"></div>
 
-                  <Disclosure.Button
-                    as={NavLinkSub}
-                    className="px-5 py-3"
-                    href="/admin/dashboard"
-                  >
+                  <Disclosure.Button as={NavLinkSub} href="/admin/dashboard">
                     Admin
                   </Disclosure.Button>
                 </li>
@@ -71,7 +67,7 @@ export function MobileMenu() {
               <li>
                 <div className="my-3 w-full border-t opacity-30"></div>
 
-                <div className="px-5 py-3">
+                <div className="px-5 py-2">
                   <ProfileInfo full />
                 </div>
 

--- a/apps/website/src/components/notifications/NotificationCategoryCheckbox.tsx
+++ b/apps/website/src/components/notifications/NotificationCategoryCheckbox.tsx
@@ -1,5 +1,9 @@
 import type { ChangeEvent } from "react";
 
+import { classes } from "@/utils/classes";
+
+import { navLinkClassesSub } from "@/components/layout/navbar/NavLink";
+
 export const NotificationCategoryCheckbox: React.FC<{
   tag: string;
   label: string;
@@ -12,7 +16,10 @@ export const NotificationCategoryCheckbox: React.FC<{
   return (
     <label
       htmlFor={`tag-${tag}`}
-      className="relative flex cursor-pointer items-start rounded-xl p-2 hover:bg-black/30"
+      className={classes(
+        navLinkClassesSub,
+        "relative flex cursor-pointer items-start"
+      )}
     >
       <div className="flex h-5 items-center">
         <input

--- a/apps/website/src/components/notifications/NotificationSettings.tsx
+++ b/apps/website/src/components/notifications/NotificationSettings.tsx
@@ -64,7 +64,7 @@ export function NotificationSettings() {
       <p className="p-4 leading-tight">Notification settings</p>
 
       {isInstallAsPWARequired && (
-        <div className="px-4 pb-4">
+        <div className="min-w-[320px] px-4 pb-4">
           <p>
             You can receive notifications if you add this site to your Home
             Screen.

--- a/apps/website/src/components/notifications/NotificationSettings.tsx
+++ b/apps/website/src/components/notifications/NotificationSettings.tsx
@@ -61,10 +61,10 @@ export function NotificationSettings() {
 
   return (
     <div className="flex flex-col">
-      <p className="p-4 leading-tight">Notification settings</p>
+      <p className="px-7 pb-2 pt-4 leading-tight">Notification settings</p>
 
       {isInstallAsPWARequired && (
-        <div className="min-w-[320px] px-4 pb-4">
+        <div className="min-w-[300px] px-7 pb-4">
           <p>
             You can receive notifications if you add this site to your Home
             Screen.
@@ -101,7 +101,7 @@ export function NotificationSettings() {
       )}
 
       {!isClientSupported && !isInstallAsPWARequired && (
-        <NotificationErrorMessage className="m-2 flex flex-col gap-2">
+        <NotificationErrorMessage className="m-3 flex flex-col gap-2">
           <p>Your browser does not support push notifications!</p>
 
           {getIsIos() && !getIsSafari() && (

--- a/apps/website/src/components/notifications/NotificationSettingsForm.tsx
+++ b/apps/website/src/components/notifications/NotificationSettingsForm.tsx
@@ -65,7 +65,7 @@ export function NotificationSettingsForm({
     <form
       onSubmit={submitHandler}
       className={
-        "pb-4 transition-opacity " +
+        "pb-2 transition-opacity " +
         (enableSettings
           ? ""
           : "pointer-none cursor-default select-none opacity-50")

--- a/apps/website/src/components/notifications/NotificationsButton.tsx
+++ b/apps/website/src/components/notifications/NotificationsButton.tsx
@@ -6,11 +6,13 @@ import { classes } from "@/utils/classes";
 import IconNotification from "@/icons/IconNotification";
 import IconNotificationOn from "@/icons/IconNotificationOn";
 import IconNotificationOff from "@/icons/IconNotificationOff";
+import IconAngleRight from "@/icons/IconAngleRight";
+
 import {
   NotificationSettings,
   useNotificationStatus,
 } from "@/components/notifications/NotificationSettings";
-import IconAngleRight from "@/icons/IconAngleRight";
+import { navLinkClassesSub } from "@/components/layout/navbar/NavLink";
 
 export const NotificationsButton = ({
   openDirectionX = "left",
@@ -63,7 +65,7 @@ export const NotificationsButton = ({
       >
         <Popover.Panel
           className={classes(
-            `absolute z-30 -mt-0.5 flex min-w-[240px] max-w-[calc(80vw-50px)] flex-col rounded border border-black/20 bg-alveus-green-900 text-gray-200 shadow-lg`,
+            `absolute z-30 -mt-0.5 flex min-w-[240px] max-w-[calc(80vw-50px)] flex-col gap-0.5 rounded border border-black/20 bg-alveus-green-900 text-gray-200 shadow-lg`,
             openDirectionX === "left" ? "right-0" : "left-0",
             openDirectionY === "top" ? "bottom-full" : "top-full"
           )}
@@ -72,10 +74,14 @@ export const NotificationsButton = ({
 
           <div className="mx-2 border-t opacity-30"></div>
 
-          <p className="p-4">
-            <Popover.Button as={Link} href="/updates" className="block">
+          <p className="px-2 pb-2">
+            <Popover.Button
+              as={Link}
+              href="/updates"
+              className={navLinkClassesSub}
+            >
               Show all updates
-              <IconAngleRight className="ml-1 inline-block" size={20} />
+              <IconAngleRight className="-mt-px ml-1 inline-block" size={18} />
             </Popover.Button>
           </p>
         </Popover.Panel>

--- a/apps/website/src/components/notifications/NotificationsButton.tsx
+++ b/apps/website/src/components/notifications/NotificationsButton.tsx
@@ -63,14 +63,17 @@ export const NotificationsButton = ({
       >
         <Popover.Panel
           className={classes(
-            `absolute z-30 -mt-0.5 flex w-[320px] max-w-[calc(80vw-50px)] flex-col rounded border border-black/20 bg-alveus-green-900 text-gray-200 shadow-lg`,
+            `absolute z-30 -mt-0.5 flex min-w-[240px] max-w-[calc(80vw-50px)] flex-col rounded border border-black/20 bg-alveus-green-900 text-gray-200 shadow-lg`,
             openDirectionX === "left" ? "right-0" : "left-0",
             openDirectionY === "top" ? "bottom-full" : "top-full"
           )}
         >
           <NotificationSettings />
-          <p className="border-t p-4">
-            <Popover.Button as={Link} href="/updates">
+
+          <div className="mx-2 border-t opacity-30"></div>
+
+          <p className="p-4">
+            <Popover.Button as={Link} href="/updates" className="block">
               Show all updates
               <IconAngleRight className="ml-1 inline-block" size={20} />
             </Popover.Button>

--- a/apps/website/src/pages/updates.tsx
+++ b/apps/website/src/pages/updates.tsx
@@ -16,19 +16,16 @@ const notificationTags = ["stream"];
 const UpdatesPage: NextPage = () => {
   return (
     <>
-      <Meta
-        title="Updates"
-        description="Announcements, Updates and Stream schedule"
-      />
+      <Meta title="Updates" description="Announcements and Updates" />
 
       {/* Nav background */}
       <div className="-mt-40 hidden h-40 bg-alveus-green-900 lg:block" />
 
       <Section dark className="z-10">
-        <Heading>Announcements, Updates and Stream schedule</Heading>
+        <Heading>Announcements and Updates</Heading>
 
         <p className="mt-6">
-          Keep up-to-date using one of our announcement channels:
+          Stay updated using one of our announcement channels:
         </p>
 
         <div className="mt-4 flex flex-col items-center gap-1 md:flex-row md:gap-4">


### PR DESCRIPTION
Tweak some styles and texts:

- match divider style of user menu
- reuse subnav link styles, make them consistent
- tidy up spacing to match other user menu
- make notification popover take less width by default

<table>
<tr>
 <td> <img src="https://github.com/alveusgg/alveusgg/assets/684458/7f448a21-4581-4f48-90a5-7c23195e720c" />
 <td> <img src="https://github.com/alveusgg/alveusgg/assets/684458/ccf3abe1-6281-477f-aba5-fdd5dcfbafce" />
<tr>
 <td>Before
 <td>After
</table>