### PR TITLE
Use typescript checking for some js config files, remove unnecessary react aria Proivder

### DIFF
--- a/apps/website/next-sitemap.config.cjs
+++ b/apps/website/next-sitemap.config.cjs
@@ -1,3 +1,4 @@
+// @ts-check
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   // If there is a NEXT_PUBLIC_VERCEL_URL set, use that like NextAuth.js does

--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -1,10 +1,21 @@
+// @ts-check
 import { resolve } from "path";
 import { withSuperjson } from "next-superjson";
+
 import ambassadorSlugs from "./src/data/generated/ambassador-slugs.json" assert { type: "json" };
 import animalQuestEpisodes from "./src/data/generated/animal-quest-episodes.json" assert { type: "json" };
 
-// @ts-check
 import "./src/env/index.mjs";
+
+/** @type {Array<import("next/dist/shared/lib/image-config").RemotePattern>} */
+const cdnImagesRemotePattern = process.env.FILE_STORAGE_CDN_URL
+  ? [
+      {
+        protocol: "https",
+        hostname: process.env.FILE_STORAGE_CDN_URL.replace(/^https?:\/\//, ""),
+      },
+    ]
+  : [];
 
 /** @type {import("next").NextConfig} */
 const config = {
@@ -42,17 +53,7 @@ const config = {
         hostname: "www.alveussanctuary.org",
       },
       // S3 - Configured CDN
-      ...(process.env.FILE_STORAGE_CDN_URL
-        ? [
-            {
-              protocol: "https",
-              hostname: process.env.FILE_STORAGE_CDN_URL.replace(
-                /^https?:\/\//,
-                ""
-              ),
-            },
-          ]
-        : []),
+      ...cdnImagesRemotePattern,
       // S3 - Production CDN CNAME
       {
         protocol: "https",
@@ -249,7 +250,8 @@ const config = {
             [
               "frame-src 'self'",
               // Allow vercel preview helper (if not in production):
-              ["development", "preview"].includes(process.env.VERCEL_ENV) &&
+              process.env.VERCEL_ENV &&
+                ["development", "preview"].includes(process.env.VERCEL_ENV) &&
                 "https://vercel.live/",
               // Twitch embeds:
               "https://embed.twitch.tv/ https://player.twitch.tv/ https://www.twitch.tv/",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -93,6 +93,7 @@
     "@types/node": "^18.16.16",
     "@types/node-forge": "^1.3.2",
     "@types/oauth": "^0.9.1",
+    "@types/prettier": "^2.7.3",
     "@types/probe-image-size": "^7.2.0",
     "@types/react": "^18.2.9",
     "@types/react-dom": "^18.2.4",

--- a/apps/website/prettier.config.cjs
+++ b/apps/website/prettier.config.cjs
@@ -1,3 +1,4 @@
+// @ts-check
 /** @type {import("prettier").Config} */
 module.exports = {
   plugins: [require.resolve("prettier-plugin-tailwindcss")],

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 import { type AppType } from "next/app";
 import { type Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
-import { SSRProvider } from "react-aria";
 import { Analytics } from "@vercel/analytics/react";
 
 import { trpc } from "@/utils/trpc";
@@ -18,14 +17,12 @@ const AlveusGgWebsiteApp: AppType<{ session: Session | null }> = ({
 }) => {
   return (
     <SessionProvider session={session}>
-      <SSRProvider>
-        <ConsentProvider>
-          <Layout>
-            <Component {...pageProps} />
-            <Analytics />
-          </Layout>
-        </ConsentProvider>
-      </SSRProvider>
+      <ConsentProvider>
+        <Layout>
+          <Component {...pageProps} />
+          <Analytics />
+        </Layout>
+      </ConsentProvider>
     </SessionProvider>
   );
 };

--- a/apps/website/tailwind.config.cjs
+++ b/apps/website/tailwind.config.cjs
@@ -1,3 +1,4 @@
+// @ts-check
 const { fontFamily } = require("tailwindcss/defaultTheme");
 const colors = require("tailwindcss/colors");
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "packageManager": "pnpm@8.6.0",
   "devDependencies": {
+    "@types/prettier": "^2.7.3",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.2",
     "prettier": "^2.8.8"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "packageManager": "pnpm@8.6.0",
   "devDependencies": {
-    "@types/prettier": "^2.7.3",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.2",
     "prettier": "^2.8.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      '@types/prettier':
-        specifier: ^2.7.3
-        version: 2.7.3
       husky:
         specifier: ^8.0.3
         version: 8.0.3
@@ -219,6 +216,9 @@ importers:
       '@types/oauth':
         specifier: ^0.9.1
         version: 0.9.1
+      '@types/prettier':
+        specifier: ^2.7.3
+        version: 2.7.3
       '@types/probe-image-size':
         specifier: ^7.2.0
         version: 7.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@types/prettier':
+        specifier: ^2.7.3
+        version: 2.7.3
       husky:
         specifier: ^8.0.3
         version: 8.0.3
@@ -3920,6 +3923,10 @@ packages:
     resolution: {integrity: sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==}
     dependencies:
       '@types/node': 18.16.16
+    dev: true
+
+  /@types/prettier@2.7.3:
+    resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
     dev: true
 
   /@types/probe-image-size@7.2.0:


### PR DESCRIPTION
- `react-aria` does not need a SSRProvider with React 18
- add `@ts-check` directives to some js config files to enable typescript type checking, add `@types/prettier` for prettier config