### PR TITLE
Fix merch scroller sizing on mobile

### DIFF
--- a/apps/website/src/components/content/Merch.tsx
+++ b/apps/website/src/components/content/Merch.tsx
@@ -79,7 +79,7 @@ const merch = Object.entries({
             alt={pip.alt}
             draggable={false}
             width={80}
-            className="absolute -bottom-8 -right-8 h-auto w-full max-w-[5rem] drop-shadow"
+            className="absolute -bottom-2 -right-2 h-auto w-1/2 max-w-[5rem] drop-shadow"
           />
         )}
       </div>


### PR DESCRIPTION
On mobile, the PiP images were overflowing and colliding with other items. Each item has a padding of 2, so we can safely move the image -2 into the corner without it overlapping. This also ensures the PiP remains half the width of the main image.