### PR TITLE
Use new The Giving Block embed api

### DIFF
--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -271,8 +271,8 @@ const config = {
               "https://streamable.com/",
               // Prezi embeds:
               "https://prezi.com/",
-              // The Giving Block (crypto donations):
-              "https://tgbwidget.com/",
+              // The Giving Block (donation widget):
+              "https://widget.thegivingblock.com/",
               // Imgur embeds:
               //"http://imgur.com/ https://imgur.com/ https://imgur.io/",
             ]

--- a/apps/website/src/components/TwitchEmbed.tsx
+++ b/apps/website/src/components/TwitchEmbed.tsx
@@ -14,7 +14,7 @@ export const TwitchEmbed: React.FC = () => {
     statusRef.current = "active";
 
     // https://dev.twitch.tv/docs/embed/everything
-    const embed = new Twitch.Embed(`twitch-embed-${id}`, {
+    const embed = new window.Twitch.Embed(`twitch-embed-${id}`, {
       width: "100%",
       height: "100%",
       channel: "alveussanctuary",
@@ -25,11 +25,11 @@ export const TwitchEmbed: React.FC = () => {
       autoplay: true,
       muted: false,
     });
-    embed.addEventListener(Twitch.Embed.VIDEO_PLAY, function () {
+    embed.addEventListener(window.Twitch.Embed.VIDEO_PLAY, function () {
       const player = embed.getPlayer();
       console.log("The video is playing", player);
     });
-    embed.addEventListener(Twitch.Embed.VIDEO_READY, function () {
+    embed.addEventListener(window.Twitch.Embed.VIDEO_READY, function () {
       const player = embed.getPlayer();
       console.log("The video is ready", player);
     });

--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -1,0 +1,22 @@
+import Script from "next/script";
+import React, { useEffect } from "react";
+
+import { theGivingBlockConfig } from "@/config/the-giving-block";
+
+const TheGivingBlockEmbed: React.FC = () => {
+  useEffect(() => {
+    window.tgbWidgetOptions = theGivingBlockConfig;
+  }, []);
+
+  return (
+    <>
+      <div id="tgb-widget-script"></div>
+      <Script
+        src="https://widget.thegivingblock.com/widget/script.js"
+        async={true}
+      ></Script>
+    </>
+  );
+};
+
+export default TheGivingBlockEmbed;

--- a/apps/website/src/config/the-giving-block.ts
+++ b/apps/website/src/config/the-giving-block.ts
@@ -1,0 +1,21 @@
+export type TheGivingBlockConfig = {
+  id: string;
+  apiUserUuid: string;
+  domain: string;
+  buttonId: string;
+  scriptId: string;
+  uiVersion: string;
+  donationFlow: string;
+  fundraiserId: string;
+};
+
+export const theGivingBlockConfig = {
+  id: "861772907",
+  apiUserUuid: "e6cf7d18-41b6-4a6c-954a-338578fd90b0",
+  domain: "https://widget.thegivingblock.com",
+  buttonId: "tgb-widget-button",
+  scriptId: "tgb-widget-script",
+  uiVersion: "2",
+  donationFlow: "crypto,card,stock,daf",
+  fundraiserId: "",
+} as const satisfies TheGivingBlockConfig;

--- a/apps/website/src/pages/donate.tsx
+++ b/apps/website/src/pages/donate.tsx
@@ -8,6 +8,7 @@ import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";
 import Meta from "@/components/content/Meta";
 import Consent from "@/components/Consent";
+import TheGivingBlockEmbed from "@/components/content/TheGivingBlockEmbed";
 
 import IconAmazon from "@/icons/IconAmazon";
 import IconPayPal from "@/icons/IconPayPal";
@@ -109,12 +110,7 @@ const DonatePage: NextPage = () => {
           {!consent.givingBlock && <DonateItem link={givingBlock} />}
 
           <Consent item="donation widget" consent="givingBlock">
-            <iframe
-              src="https://tgbwidget.com/?charityID=861772907"
-              width="100%"
-              height="604px"
-              frameBorder="0"
-            />
+            <TheGivingBlockEmbed />
           </Consent>
         </div>
       </Section>

--- a/apps/website/src/types/globals.d.ts
+++ b/apps/website/src/types/globals.d.ts
@@ -1,0 +1,12 @@
+import type { TheGivingBlockConfig } from "@/config/the-giving-block";
+
+declare global {
+  interface Window {
+    // Twitch API
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    Twitch: any;
+
+    // The Giving Block Donation Widget
+    tgbWidgetOptions: TheGivingBlockConfig;
+  }
+}

--- a/apps/website/src/types/twitch-embed.d.ts
+++ b/apps/website/src/types/twitch-embed.d.ts
@@ -1,8 +1,0 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-declare let Twitch: any;
-
-declare global {
-  interface Window {
-    Twitch: any;
-  }
-}


### PR DESCRIPTION
To give their script access to the site and allow apple pay.

## Describe your changes

<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->

Replaces the iframe widget from The Giving Block with a script based embed as requested by them. This should allow Apple Pay to work.

## Notes for testing your change

Go to `/donate` and see if the widget loads and works when consent is given. It should not load any (new) third-party requests if no consent was given.