### PR TITLE
Remove reliance on negative margin in socials

### DIFF
--- a/apps/website/src/components/layout/footer/Socials.tsx
+++ b/apps/website/src/components/layout/footer/Socials.tsx
@@ -27,9 +27,9 @@ const Socials: React.FC = () => {
 
   return (
     <Section dark className="z-0 pb-0">
-      <div className="flex flex-wrap-reverse items-center">
-        <div className="basis-full md:basis-1/2 md:pr-8 md:pt-0">
-          <div className="relative mx-auto aspect-[1.1/1] h-full w-full max-w-lg overflow-hidden lg:-mt-10">
+      <div className="flex flex-wrap-reverse">
+        <div className="mt-auto basis-full md:basis-1/2 md:pr-8 md:pt-0">
+          <div className="relative mx-auto aspect-[1.1/1] h-full w-full max-w-lg overflow-hidden">
             <Link
               href="https://www.instagram.com/p/CoIq_hvOxiQ/"
               rel="noreferrer"
@@ -75,7 +75,7 @@ const Socials: React.FC = () => {
           </div>
         </div>
 
-        <div className="basis-full pb-16 md:basis-1/2 md:py-4">
+        <div className="my-auto basis-full pb-16 md:basis-1/2 md:py-4">
           <Heading level={2}>Stay Updated!</Heading>
 
           <p className="mb-2 mt-4">

--- a/apps/website/src/components/layout/footer/Socials.tsx
+++ b/apps/website/src/components/layout/footer/Socials.tsx
@@ -26,9 +26,9 @@ const Socials: React.FC = () => {
   const reducedMotion = usePrefersReducedMotion();
 
   return (
-    <Section dark className="z-0 pb-0">
-      <div className="flex flex-wrap-reverse">
-        <div className="mt-auto basis-full md:basis-1/2 md:pr-8 md:pt-0">
+    <Section dark className="z-0 py-0">
+      <div className="flex flex-wrap-reverse gap-y-4 pt-8">
+        <div className="mt-auto basis-full md:basis-1/2 md:pr-8">
           <div className="relative mx-auto aspect-[1.1/1] h-full w-full max-w-lg overflow-hidden">
             <Link
               href="https://www.instagram.com/p/CoIq_hvOxiQ/"
@@ -75,7 +75,7 @@ const Socials: React.FC = () => {
           </div>
         </div>
 
-        <div className="my-auto basis-full pb-16 md:basis-1/2 md:py-4">
+        <div className="my-auto basis-full py-4 md:basis-1/2">
           <Heading level={2}>Stay Updated!</Heading>
 
           <p className="mb-2 mt-4">


### PR DESCRIPTION
## Describe your changes

Follow-up to #363, just so that we don't continue to have reliance on a negative margin that breaks if the size of the content changes.

## Notes for testing your change

This change should keep the video pinned to the bottom no matter how large the content on the right is:

![image](https://github.com/alveusgg/alveusgg/assets/12371363/cd23c257-8750-4865-83a1-6764453aac83)

And should keep the content on the right pinned to the center no matter how small it is compared to the video:

![image](https://github.com/alveusgg/alveusgg/assets/12371363/029aabb9-d96b-4d38-a96d-cb1b4b44f49c)