### PR TITLE
Fix host name on Animal Quest pages

### DIFF
--- a/apps/website/src/components/content/Link.tsx
+++ b/apps/website/src/components/content/Link.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import NextLink from "next/link";
 
 import { classes } from "@/utils/classes";
@@ -6,43 +6,50 @@ import { classes } from "@/utils/classes";
 import IconExternal from "@/icons/IconExternal";
 
 type LinkProps = {
-  href: string;
-  children: React.ReactNode;
-  onClick?: () => void;
-  className?: string;
   external?: boolean;
   custom?: boolean;
   dark?: boolean;
-  prefetch?: boolean;
-};
+} & React.ComponentProps<typeof NextLink>;
 
 const Link: React.FC<LinkProps> = ({
-  href,
-  children,
-  onClick,
-  className,
   external = false,
   custom = false,
   dark = false,
-  prefetch,
+  className,
+  target,
+  rel,
+  children,
+  ...props
 }) => {
-  const props = {
-    href,
-    onClick,
-    prefetch,
-    className: classes(
-      !custom && "transition-colors hover:underline",
-      !custom &&
-        (dark
-          ? "text-red-200 hover:text-blue-200"
-          : "text-red-600 hover:text-blue-600"),
-      className
-    ),
-    ...(external ? { target: "_blank", rel: "noreferrer" } : {}),
-  };
+  const computedClassName = useMemo(
+    () =>
+      classes(
+        !custom && "transition-colors hover:underline",
+        !custom &&
+          (dark
+            ? "text-red-200 hover:text-blue-200"
+            : "text-red-600 hover:text-blue-600"),
+        className
+      ),
+    [custom, dark, className]
+  );
+
+  const computedTarget = useMemo(
+    () => (external ? "_blank" : target),
+    [external, target]
+  );
+  const computedRel = useMemo(
+    () => (external ? "noreferrer" : rel),
+    [external, rel]
+  );
 
   return (
-    <NextLink {...props}>
+    <NextLink
+      {...props}
+      className={computedClassName}
+      target={computedTarget}
+      rel={computedRel}
+    >
       {children}
       {external && !custom && (
         <IconExternal

--- a/apps/website/src/pages/animal-quest/[episodeName].tsx
+++ b/apps/website/src/pages/animal-quest/[episodeName].tsx
@@ -168,6 +168,7 @@ const AnimalQuestEpisodePage: NextPage<AnimalQuestEpisodePageProps> = ({
             href={`/ambassadors/${camelToKebab(key)}`}
             draggable={false}
             className="group text-center transition-colors hover:text-alveus-green-900"
+            custom
           >
             <Image
               src={images[0].src}

--- a/apps/website/src/pages/animal-quest/[episodeName].tsx
+++ b/apps/website/src/pages/animal-quest/[episodeName].tsx
@@ -1,9 +1,9 @@
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Image from "next/image";
-import Link from "next/link";
 import React, { Fragment, useEffect, useMemo, useState } from "react";
 
 import animalQuest, {
+  hosts,
   type AnimalQuestWithEpisode,
 } from "@alveusgg/data/src/animal-quest";
 import ambassadors from "@alveusgg/data/src/ambassadors/core";
@@ -13,8 +13,9 @@ import { getAmbassadorImages } from "@alveusgg/data/src/ambassadors/images";
 import Meta from "@/components/content/Meta";
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";
-import Consent from "@/components/Consent";
 import Carousel from "@/components/content/Carousel";
+import Link from "@/components/content/Link";
+import Consent from "@/components/Consent";
 import { ambassadorImageHover } from "@/pages/ambassadors";
 
 import { camelToKebab, sentenceToKebab } from "@/utils/string-case";
@@ -196,6 +197,19 @@ const AnimalQuestEpisodePage: NextPage<AnimalQuestEpisodePageProps> = ({
       };
     }, {});
 
+  const host = useMemo(() => {
+    const data = hosts[episode.host];
+    const link = data.link.replace(
+      /^https?:\/\/(www.)?alveussanctuary.org/,
+      ""
+    );
+    return {
+      ...data,
+      link,
+      external: /^https?:\/\//.test(link),
+    };
+  }, [episode.host]);
+
   return (
     <>
       <Meta
@@ -309,10 +323,7 @@ const AnimalQuestEpisodePage: NextPage<AnimalQuestEpisodePageProps> = ({
                       <Fragment key={key}>
                         {/* Retired ambassadors don't have pages */}
                         {isActiveAmbassadorKey(key) ? (
-                          <Link
-                            href={`/ambassadors/${camelToKebab(key)}`}
-                            className="hover:underline"
-                          >
+                          <Link href={`/ambassadors/${camelToKebab(key)}`} dark>
                             {ambassador.name}
                           </Link>
                         ) : (
@@ -331,7 +342,11 @@ const AnimalQuestEpisodePage: NextPage<AnimalQuestEpisodePageProps> = ({
                 <Heading level={3} className="text-2xl">
                   Host:
                 </Heading>
-                <p>{episode.host}</p>
+                <p>
+                  <Link href={host.link} external={host.external} dark>
+                    {host.name}
+                  </Link>
+                </p>
               </div>
 
               <div className="w-full min-[430px]:w-1/2 md:w-full lg:w-1/2">
@@ -350,6 +365,7 @@ const AnimalQuestEpisodePage: NextPage<AnimalQuestEpisodePageProps> = ({
             <Link
               href="/animal-quest"
               className="text-md mt-8 inline-block rounded-full border-2 border-white px-4 py-2 transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
+              custom
             >
               Discover more episodes
             </Link>
@@ -412,6 +428,7 @@ const AnimalQuestEpisodePage: NextPage<AnimalQuestEpisodePageProps> = ({
           <Link
             href="/animal-quest"
             className="text-md inline-block rounded-full border-2 border-white px-4 py-2 transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
+            custom
           >
             Discover more episodes
           </Link>


### PR DESCRIPTION
## Describe your changes

#353 accidentally bumped `@alveusgg/data` to `0.18.0`, which included a change to how Animal Quest hosts are stored (https://github.com/alveusgg/data/pull/31).

This PR fixes how we render those hosts, so that the page uses the new `hosts` object to get the host data (name, etc.).

## Notes for testing your change

Access an Animal Quest page, confirm host's name shows as expected.