### PR TITLE
Pin alveusgg/data version

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -28,7 +28,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@alveusgg/data": "github:alveusgg/data",
+    "@alveusgg/data": "github:alveusgg/data#0.18.1",
     "@aws-sdk/client-s3": "^3.348.0",
     "@aws-sdk/s3-request-presigner": "^3.348.0",
     "@headlessui/react": "^1.7.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -27,8 +27,8 @@ importers:
   apps/website:
     dependencies:
       '@alveusgg/data':
-        specifier: github:alveusgg/data
-        version: github.com/alveusgg/data/29346f8fc70878272d4c01d0143c29bd7dcc20d2
+        specifier: github:alveusgg/data#0.18.1
+        version: github.com/alveusgg/data/16fa6a031097b61b6394fb0facc32a69dc1ec4d0
       '@aws-sdk/client-s3':
         specifier: ^3.348.0
         version: 3.348.0
@@ -9794,8 +9794,8 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/alveusgg/data/29346f8fc70878272d4c01d0143c29bd7dcc20d2:
-    resolution: {tarball: https://codeload.github.com/alveusgg/data/tar.gz/29346f8fc70878272d4c01d0143c29bd7dcc20d2}
+  github.com/alveusgg/data/16fa6a031097b61b6394fb0facc32a69dc1ec4d0:
+    resolution: {tarball: https://codeload.github.com/alveusgg/data/tar.gz/16fa6a031097b61b6394fb0facc32a69dc1ec4d0}
     name: '@alveusgg/data'
-    version: 0.18.0
+    version: 0.18.1
     dev: false


### PR DESCRIPTION
## Describe your changes

Further follow-up to #365 and #353, this implements version pinning for the alveusgg/data dependency using tags (https://github.com/alveusgg/data/pull/32), so that we don't have the same issue of an accidental version bump again.

## Notes for testing your change

N/A