### PR TITLE
Fix outstanding eslint warnings

### DIFF
--- a/apps/website/src/components/admin/forms/FormForm.tsx
+++ b/apps/website/src/components/admin/forms/FormForm.tsx
@@ -39,6 +39,14 @@ export function FormForm({ action, form }: FormFormProps) {
   const router = useRouter();
   const submit = trpc.adminForms.createOrEditForm.useMutation();
 
+  const defaultConfig = calcFormConfig(form?.config);
+  const [intro, setIntro] = useState(defaultConfig.intro || "");
+  const [rules, setRules] = useState(defaultConfig.rules || "");
+  const [label, setLabel] = useState(form?.label || "");
+  const [askMarketingEmails, setAskMarketingEmails] = useState(
+    defaultConfig.askMarketingEmails || false
+  );
+
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -97,15 +105,7 @@ export function FormForm({ action, form }: FormFormProps) {
         );
       }
     },
-    [action, form, router, submit]
-  );
-
-  const defaultConfig = calcFormConfig(form?.config);
-  const [intro, setIntro] = useState(defaultConfig.intro || "");
-  const [rules, setRules] = useState(defaultConfig.rules || "");
-  const [label, setLabel] = useState(form?.label || "");
-  const [askMarketingEmails, setAskMarketingEmails] = useState(
-    defaultConfig.askMarketingEmails || false
+    [action, form, router, submit, askMarketingEmails]
   );
 
   return (

--- a/apps/website/src/utils/escape-links-for-discord.ts
+++ b/apps/website/src/utils/escape-links-for-discord.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-named-as-default
 import LinkifyIt from "linkify-it";
 
 export function escapeLinksForDiscord(text: string) {


### PR DESCRIPTION
## Describe your changes

Fix two outstanding ESLint warnings.

For the LinkifyIt warning, ESLint wants `import { LinkifyIt }` I believe, but TypeScript won't allow that, so I have just disabled the rule.

## Notes for testing your change

Is eslint happy?