### PR TITLE
Chatbot/Notifications: Do not split text on slash

### DIFF
--- a/apps/chatbot/src/bot/commands/notification.ts
+++ b/apps/chatbot/src/bot/commands/notification.ts
@@ -115,7 +115,7 @@ function parseOptionalStartAndEnd(params: string[]): {
 }
 
 function parseTitleAndText(params: string[]) {
-  const textParts = params.join(" ").split(/[|\/]/);
+  const textParts = params.join(" ").split("|");
   const title = textParts[0]?.trim();
   const text = textParts.slice(1).join("/").trim();
   return { title, text };


### PR DESCRIPTION
## Describe your changes

<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->

Instead of splitting notification text on slashes as well as pipes, only split on pipes to allow text like "Projects w/ Connor".

## Notes for testing your change

Try `!notify Projects w/ Connor` in chat. It should _not_ split `Projects w/ Connor`. 
