### PR TITLE
Chatbot: Add log level and improve docker setup

### DIFF
--- a/apps/chatbot/.env.example
+++ b/apps/chatbot/.env.example
@@ -2,6 +2,9 @@
 BOT_USER_ID=858050963
 BOT_CHANNEL_NAMES=alveusgg
 
+## Loggging (CRITICAL, ERROR, WARNING, INFO, DEBUG, TRACE), defaults to ERROR
+BOT_LOGLEVEL=ERROR
+
 # Users
 MODERATOR_USER_NAMES=alveusgg
 
@@ -9,7 +12,7 @@ MODERATOR_USER_NAMES=alveusgg
 API_BASE_URL=http://localhost:3000/api/
 API_SECRET=
 
-# Database
+# Database (@planetscale/database HTTP URL)
 DATABASE_URL=https://user:pscale_pw_xxx@aws.connect.psdb.cloud
 
 # Twitch OAuth

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -1,13 +1,22 @@
 FROM node:18.15.0-alpine
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+WORKDIR /app
 
-RUN npm install -g pnpm
-
+## Copy root files
 COPY package.json .
+COPY pnpm-lock.yaml .
+COPY pnpm-workspace.yaml .
 
-RUN pnpm install
+## Copy chatbot files
+WORKDIR apps/chatbot
+COPY ./apps/chatbot/tsconfig.json .
+COPY ./apps/chatbot/package.json .
+COPY ./apps/chatbot/.env .
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile --filter "." --ignore-scripts
 
-COPY src/ src/
-COPY tsconfig.json .
-COPY .env .
+## Copy code
+COPY ./apps/chatbot/src/ src/
 
 CMD ["pnpm", "start"]

--- a/apps/chatbot/docker-compose.yaml
+++ b/apps/chatbot/docker-compose.yaml
@@ -2,8 +2,8 @@ version: "3.3"
 services:
   chatbot:
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: ../..
+      dockerfile: apps/chatbot/Dockerfile
     restart: always
     environment:
       - CHATBOT_REF_SHA=$CHATBOT_REF_SHA

--- a/apps/chatbot/src/bot/index.ts
+++ b/apps/chatbot/src/bot/index.ts
@@ -18,6 +18,11 @@ export async function startBot() {
         createVersionCommands(),
       ])
     ).flat(),
+    chatClientOptions: {
+      logger: {
+        minLevel: env.BOT_LOGLEVEL,
+      },
+    },
   });
 
   bot.onJoin(async (e) => {

--- a/apps/chatbot/src/env.ts
+++ b/apps/chatbot/src/env.ts
@@ -1,3 +1,4 @@
+import { LogLevel } from "@twurple/chat";
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 import "dotenv/config";
@@ -25,6 +26,13 @@ export const env = createEnv({
     // Chatbot
     BOT_USER_ID: z.string().default("858050963"),
     BOT_CHANNEL_NAMES: namesSchema.default(["AlveusGG"].join(",")),
+    BOT_LOGLEVEL: z
+      .string()
+      .trim()
+      .toUpperCase()
+      .default("ERROR" satisfies keyof typeof LogLevel)
+      .transform((level) => LogLevel[level as keyof typeof LogLevel])
+      .refine((level) => level !== undefined),
 
     // Users
     MODERATOR_USER_NAMES: namesSchema.default(

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": "^18.15.0",
     "pnpm": "^8.6.0"
   },
-  "packageManager": "pnpm@8.6.0",
+  "packageManager": "pnpm@8.6.12",
   "devDependencies": {
     "husky": "^8.0.3",
     "lint-staged": "^14.0.0",


### PR DESCRIPTION
## Describe your changes

<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->

- Adds a log level environment variable for the chat bot. That level will be passed through `@twurple/easy-bot` to `ircv3`.
- Improve docker setup for chatbot:
    - Use the root `package.json`,`pnpm-workspace.yaml` and `pnpm-lockfile.yaml` to get locked dependencies
    - Use [corepack](https://nodejs.org/api/corepack.html) to use the exact pnpm version specified in the `package.json`
    - Use a [cache mount](https://docs.docker.com/build/guide/mounts/#add-a-cache-mount) for the pnpm install (see https://pnpm.io/docker)

## Notes for testing your change

Set `LOG_LEVEL=debug` when starting the chatbot and enjoy all them logs.