### PR TITLE
Add keyboard navigation and focus management to Show and Tell

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -111,7 +111,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.27",
     "postcss-nesting": "^12.0.1",
-    "prettier-plugin-tailwindcss": "^0.5.2",
+    "prettier-plugin-tailwindcss": "^0.5.3",
     "prisma": "^5.1.1",
     "tailwindcss": "^3.3.3",
     "tsup": "^7.2.0",

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -177,7 +177,7 @@ export const ShowAndTellEntry = forwardRef<
     <article
       key={entry.id}
       className={
-        "relative flex flex-shrink-0 flex-col transition-opacity delay-500 duration-500 " +
+        "relative flex flex-shrink-0 flex-col transition-opacity delay-500 duration-500 focus:outline-none " +
         (isPresentationView
           ? "h-[calc(100svh-6em)] h-[calc(100vh-6em)] w-[80%] select-none snap-center overflow-hidden bg-alveus-green text-white shadow-xl"
           : "min-h-[70svh] min-h-[70vh] justify-center border-t border-alveus-green/50 first:border-t-0")

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -190,6 +190,8 @@ export const ShowAndTellEntry = forwardRef<
           });
       }}
       ref={handleRef}
+      data-show-and-tell-entry={entry.id}
+      tabIndex={-1}
     >
       {isPresentationView && featureImageUrl && (
         <div className="absolute top-0 z-0 h-full w-full overflow-hidden rounded-xl">

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "husky": "^8.0.3",
     "lint-staged": "^14.0.0",
-    "prettier": "^3.0.1"
+    "prettier": "^3.0.2"
   },
   "scripts": {
     "prepare": "husky install"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       prettier:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
 
   apps/chatbot:
     dependencies:
@@ -323,8 +323,8 @@ importers:
         specifier: ^12.0.1
         version: 12.0.1(postcss@8.4.27)
       prettier-plugin-tailwindcss:
-        specifier: ^0.5.2
-        version: 0.5.2(prettier@3.0.1)
+        specifier: ^0.5.3
+        version: 0.5.3(prettier@3.0.2)
       prisma:
         specifier: ^5.1.1
         version: 5.1.1
@@ -8301,8 +8301,8 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-tailwindcss@0.5.2(prettier@3.0.1):
-    resolution: {integrity: sha512-i4swJk4f8YWK99BRPX3DdDNwMr6U1X8y9rvxGeX5zf090+SsHpPSVjgOb041Hh6/nZJWPi/JYno9UgBDm+/RxA==}
+  /prettier-plugin-tailwindcss@0.5.3(prettier@3.0.2):
+    resolution: {integrity: sha512-M5K80V21yM+CTm/FEFYRv9/9LyInYbCSXpIoPAKMm8zy89IOwdiA2e4JVbcO7tvRtAQWz32zdj7/WKcsmFyAVg==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
@@ -8353,11 +8353,11 @@ packages:
       prettier-plugin-twig-melody:
         optional: true
     dependencies:
-      prettier: 3.0.1
+      prettier: 3.0.2
     dev: true
 
-  /prettier@3.0.1:
-    resolution: {integrity: sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==}
+  /prettier@3.0.2:
+    resolution: {integrity: sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true


### PR DESCRIPTION
## Describe your changes

This will move the focus to the current ShowAndTellEntry when scrolling to it, allowing better keyboard accessibility and moving the focus to within the gallery component so we can bind a `keydown` handler to handle arrow keys. For the infinite loading we see if a new page has been added and move the focus to the first new entry, once its rendered. For this we save the id in a ref when the new data has loaded and use an DOM attribute to find it (instead of keeping a ref to every item).

## Notes for testing your change

Go to `/show-and-tell` and test that scrolling and arrow buttons work as expected and also, once focus has been set by tabbing into the gallery, clicking an entry or entering presentation mode (fullscreen), check that arrow keys will move the focus to the next/prev entry and scroll it into view.
