### PR TITLE
Update Zoil collab video

### DIFF
--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -38,7 +38,8 @@ const collaborations = {
     name: "Zoil",
     link: "https://www.twitch.tv/zoil",
     date: new Date("2023-06-13"),
-    videoId: "n4KpVaUmrSE",
+    videoId: "8M_qtYuSrys",
+    vodId: "n4KpVaUmrSE",
   },
   peachJars: {
     name: "PeachJars and Jessica Nigri",


### PR DESCRIPTION
## Describe your changes

Produced video is now live for Zoil's collab, so we can use that as the main video instead of the VoD.

## Notes for testing your change

Video works + embeds, VoD link works.