### PR TITLE
Add native to information on ambassador pages

### DIFF
--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -1,7 +1,7 @@
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Image from "next/image";
 import PhotoSwipeLightbox from "photoswipe/lightbox";
-import React, { useEffect, useId, useMemo } from "react";
+import React, { useEffect, useId, useMemo, Fragment } from "react";
 
 import ambassadors, {
   type Ambassador,
@@ -88,6 +88,78 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
   merchImage,
   animalQuest,
 }) => {
+  const stats = useMemo(
+    () => [
+      {
+        title: "Species",
+        value: (
+          <>
+            <p>{ambassador.species}</p>
+            <p className="italic text-alveus-green-700">
+              {ambassador.scientific} (
+              <Link
+                href={`/ambassadors#classification:${convertToSlug(
+                  getClassification(ambassador.class),
+                )}`}
+              >
+                {getClassification(ambassador.class)}
+              </Link>
+              )
+            </p>
+          </>
+        ),
+      },
+      {
+        title: "Conservation Status",
+        value: (
+          <p>
+            {ambassador.iucn.id ? (
+              <Link
+                href={`https://apiv3.iucnredlist.org/api/v3/taxonredirect/${ambassador.iucn.id}`}
+                external
+              >
+                IUCN: {getIUCNStatus(ambassador.iucn.status)}
+              </Link>
+            ) : (
+              <>IUCN: {getIUCNStatus(ambassador.iucn.status)}</>
+            )}
+          </p>
+        ),
+      },
+      {
+        title: "Native To",
+        value: <p>{ambassador.native.text}</p>,
+      },
+      {
+        title: "Date of Birth",
+        value: <p>{formatPartialDateString(ambassador.birth)}</p>,
+      },
+      {
+        title: "Sex",
+        value: <p>{ambassador.sex || "Unknown"}</p>,
+      },
+      {
+        title: "Arrived at Alveus",
+        value: <p>{formatPartialDateString(ambassador.arrival)}</p>,
+      },
+      {
+        title: "Enclosure",
+        value: (
+          <p>
+            <Link
+              href={`/ambassadors#enclosures:${camelToKebab(
+                ambassador.enclosure,
+              )}`}
+            >
+              {enclosure.name}
+            </Link>
+          </p>
+        ),
+      },
+    ],
+    [ambassador, enclosure],
+  );
+
   const photoswipe = `photoswipe-${useId().replace(/\W/g, "")}`;
   useEffect(() => {
     const lightbox = new PhotoSwipeLightbox({
@@ -176,88 +248,18 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
               <p className="my-2">{ambassador.mission}</p>
             </div>
 
-            <div className="mb-4 flex flex-wrap">
-              <div className="basis-full py-2 lg:basis-1/2 lg:px-2">
-                <Heading level={2}>Species:</Heading>
-
-                <div className="ml-4">
-                  <p className="text-xl">{ambassador.species}</p>
-                  <p className="text-xl italic text-alveus-green-700">
-                    {ambassador.scientific} (
-                    <Link
-                      href={`/ambassadors#classification:${convertToSlug(
-                        getClassification(ambassador.class),
-                      )}`}
-                    >
-                      {getClassification(ambassador.class)}
-                    </Link>
-                    )
-                  </p>
-                </div>
-              </div>
-
-              <div className="basis-full py-2 lg:basis-1/2 lg:px-2">
-                <Heading level={2}>Conservation Status:</Heading>
-
-                <div className="ml-4">
-                  <p className="text-xl">
-                    {ambassador.iucn.id ? (
-                      <Link
-                        href={`https://apiv3.iucnredlist.org/api/v3/taxonredirect/${ambassador.iucn.id}`}
-                        external
-                      >
-                        IUCN: {getIUCNStatus(ambassador.iucn.status)}
-                      </Link>
-                    ) : (
-                      <>IUCN: {getIUCNStatus(ambassador.iucn.status)}</>
-                    )}
-                  </p>
-                </div>
-              </div>
-
-              <div className="basis-full py-2 lg:basis-1/2 lg:px-2">
-                <Heading level={2}>Sex:</Heading>
-
-                <div className="ml-4">
-                  <p className="text-xl">{ambassador.sex || "Unknown"}</p>
-                </div>
-              </div>
-
-              <div className="basis-full py-2 lg:basis-1/2 lg:px-2">
-                <Heading level={2}>Date of Birth:</Heading>
-
-                <div className="ml-4">
-                  <p className="text-xl">
-                    {formatPartialDateString(ambassador.birth)}
-                  </p>
-                </div>
-              </div>
-
-              <div className="basis-full py-2 lg:basis-1/2 lg:px-2">
-                <Heading level={2}>Arrived at Alveus:</Heading>
-
-                <div className="ml-4">
-                  <p className="text-xl">
-                    {formatPartialDateString(ambassador.arrival)}
-                  </p>
-                </div>
-              </div>
-
-              <div className="basis-full py-2 lg:basis-1/2 lg:px-2">
-                <Heading level={2}>Enclosure:</Heading>
-
-                <div className="ml-4">
-                  <p className="text-xl">
-                    <Link
-                      href={`/ambassadors#enclosures:${camelToKebab(
-                        ambassador.enclosure,
-                      )}`}
-                    >
-                      {enclosure.name}
-                    </Link>
-                  </p>
-                </div>
-              </div>
+            <div className="mb-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2">
+              {stats.map(({ title, value }, idx) => (
+                <Fragment key={title}>
+                  {idx !== 0 && (
+                    <div className="col-span-full my-2 h-px bg-alveus-green opacity-10" />
+                  )}
+                  <Heading level={2} className="self-center">
+                    {title}
+                  </Heading>
+                  <div className="mx-2 my-2 self-center text-xl">{value}</div>
+                </Fragment>
+              ))}
             </div>
 
             {animalQuest && (

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -248,19 +248,19 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
               <p className="my-2">{ambassador.mission}</p>
             </div>
 
-            <div className="mb-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2">
+            <dl className="mb-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2">
               {stats.map(({ title, value }, idx) => (
                 <Fragment key={title}>
                   {idx !== 0 && (
                     <div className="col-span-full my-2 h-px bg-alveus-green opacity-10" />
                   )}
-                  <Heading level={2} className="self-center">
+                  <dt className="my-2 self-center text-2xl font-bold">
                     {title}
-                  </Heading>
-                  <div className="mx-2 my-2 self-center text-xl">{value}</div>
+                  </dt>
+                  <dd className="mx-2 my-2 self-center text-xl">{value}</dd>
                 </Fragment>
               ))}
-            </div>
+            </dl>
 
             {animalQuest && (
               <Link


### PR DESCRIPTION
## Describe your changes

cc https://github.com/alveusgg/data/pull/22

Adds "native to" information to ambassador pages, and restyles the stats/facts section of the ambassador page to more closely resemble a table rather than a side-by-side section which made the information feel rather cluttered.

## Notes for testing your change

All ambassadors' native to information seems correct.