### PR TITLE
Cleanup React imports + FC usage

### DIFF
--- a/apps/website/src/components/Consent.tsx
+++ b/apps/website/src/components/Consent.tsx
@@ -1,4 +1,9 @@
-import React, { useCallback, type MouseEventHandler } from "react";
+import {
+  useCallback,
+  type MouseEventHandler,
+  type ReactNode,
+  type FC,
+} from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -15,10 +20,10 @@ type ConsentProps = {
   item: string;
   consent: ConsentKey;
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
-const Consent: React.FC<ConsentProps> = ({
+const Consent: FC<ConsentProps> = ({
   item,
   consent: key,
   className,

--- a/apps/website/src/components/Consent.tsx
+++ b/apps/website/src/components/Consent.tsx
@@ -1,9 +1,4 @@
-import {
-  useCallback,
-  type MouseEventHandler,
-  type ReactNode,
-  type FC,
-} from "react";
+import { useCallback, type MouseEventHandler, type ReactNode } from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -23,12 +18,7 @@ type ConsentProps = {
   children: ReactNode;
 };
 
-const Consent: FC<ConsentProps> = ({
-  item,
-  consent: key,
-  className,
-  children,
-}) => {
+const Consent = ({ item, consent: key, className, children }: ConsentProps) => {
   const { consent, update, loaded } = useConsent();
   const clicked = useCallback<MouseEventHandler<HTMLButtonElement>>(
     (e) => {

--- a/apps/website/src/components/DefaultPageLayout.tsx
+++ b/apps/website/src/components/DefaultPageLayout.tsx
@@ -1,15 +1,12 @@
-import React from "react";
+import { type FC, type ReactNode, type JSX } from "react";
 import Heading from "./content/Heading";
 
 export type DefaultPageLayoutProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
   title: string | JSX.Element;
 };
 
-const DefaultPageLayout: React.FC<DefaultPageLayoutProps> = ({
-  children,
-  title,
-}) => {
+const DefaultPageLayout: FC<DefaultPageLayoutProps> = ({ children, title }) => {
   return (
     <div className="p-4">
       <header className="container mx-auto">

--- a/apps/website/src/components/DefaultPageLayout.tsx
+++ b/apps/website/src/components/DefaultPageLayout.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactNode, type JSX } from "react";
+import { type ReactNode, type JSX } from "react";
 import Heading from "./content/Heading";
 
 export type DefaultPageLayoutProps = {
@@ -6,7 +6,7 @@ export type DefaultPageLayoutProps = {
   title: string | JSX.Element;
 };
 
-const DefaultPageLayout: FC<DefaultPageLayoutProps> = ({ children, title }) => {
+const DefaultPageLayout = ({ children, title }: DefaultPageLayoutProps) => {
   return (
     <div className="p-4">
       <header className="container mx-auto">

--- a/apps/website/src/components/admin/AdminPageLayout.tsx
+++ b/apps/website/src/components/admin/AdminPageLayout.tsx
@@ -2,7 +2,6 @@ import {
   type AnchorHTMLAttributes,
   type RefAttributes,
   type ReactNode,
-  type FC,
 } from "react";
 import Link, { type LinkProps } from "next/link";
 
@@ -27,7 +26,7 @@ type NavLinkProps = Omit<
   LinkProps & {
     children?: ReactNode;
   } & RefAttributes<HTMLAnchorElement>;
-const NavLink: FC<NavLinkProps> = (props) => {
+const NavLink = (props: NavLinkProps) => {
   const isActive = useIsActivePath(props.href);
 
   return (
@@ -42,12 +41,12 @@ const NavLink: FC<NavLinkProps> = (props) => {
   );
 };
 
-export const AdminPageLayout: FC<AdminPageLayoutProps> = ({
+export const AdminPageLayout = ({
   children,
   title,
   menuItems,
   ...props
-}) => {
+}: AdminPageLayoutProps) => {
   return (
     <>
       {/* Nav background */}

--- a/apps/website/src/components/admin/AdminPageLayout.tsx
+++ b/apps/website/src/components/admin/AdminPageLayout.tsx
@@ -1,4 +1,9 @@
-import React from "react";
+import {
+  type AnchorHTMLAttributes,
+  type RefAttributes,
+  type ReactNode,
+  type FC,
+} from "react";
 import Link, { type LinkProps } from "next/link";
 
 import { classes } from "@/utils/classes";
@@ -16,13 +21,13 @@ export type AdminPageLayoutProps = DefaultPageLayoutProps & {
 };
 
 type NavLinkProps = Omit<
-  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  AnchorHTMLAttributes<HTMLAnchorElement>,
   keyof LinkProps
 > &
   LinkProps & {
-    children?: React.ReactNode;
-  } & React.RefAttributes<HTMLAnchorElement>;
-const NavLink: React.FC<NavLinkProps> = (props) => {
+    children?: ReactNode;
+  } & RefAttributes<HTMLAnchorElement>;
+const NavLink: FC<NavLinkProps> = (props) => {
   const isActive = useIsActivePath(props.href);
 
   return (
@@ -37,7 +42,7 @@ const NavLink: React.FC<NavLinkProps> = (props) => {
   );
 };
 
-export const AdminPageLayout: React.FC<AdminPageLayoutProps> = ({
+export const AdminPageLayout: FC<AdminPageLayoutProps> = ({
   children,
   title,
   menuItems,

--- a/apps/website/src/components/admin/Headline.tsx
+++ b/apps/website/src/components/admin/Headline.tsx
@@ -1,5 +1,5 @@
-import React from "react";
+import { type ReactNode } from "react";
 
-export function Headline({ children }: { children: React.ReactNode }) {
+export function Headline({ children }: { children: ReactNode }) {
   return <h2 className="my-3 text-lg font-bold">{children}</h2>;
 }

--- a/apps/website/src/components/admin/Panel.tsx
+++ b/apps/website/src/components/admin/Panel.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import { type ReactNode } from "react";
 
 export function Panel({
   children,
   lightMode = false,
 }: {
-  children?: React.ReactNode | React.ReactNode[];
+  children?: ReactNode | ReactNode[];
   lightMode?: boolean;
 }) {
   return (

--- a/apps/website/src/components/admin/activity-feed/outgoing-webhook-feed-entry.tsx
+++ b/apps/website/src/components/admin/activity-feed/outgoing-webhook-feed-entry.tsx
@@ -1,4 +1,3 @@
-import { type FC } from "react";
 import type { FormEntry, OutgoingWebhook, User } from "@prisma/client";
 
 import { trpc } from "@/utils/trpc";
@@ -9,9 +8,12 @@ type OutgoingWebhookWithFormEntry = OutgoingWebhook & {
   user: User | null;
   formEntry: FormEntry | null;
 };
-export const OutgoingWebhookFeedEntry: FC<{
+
+export const OutgoingWebhookFeedEntry = ({
+  item,
+}: {
   item: OutgoingWebhookWithFormEntry;
-}> = ({ item }) => {
+}) => {
   let details = <>{item.body}</>;
   let label = item.type;
 

--- a/apps/website/src/components/admin/activity-feed/outgoing-webhook-feed-entry.tsx
+++ b/apps/website/src/components/admin/activity-feed/outgoing-webhook-feed-entry.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type FC } from "react";
 import type { FormEntry, OutgoingWebhook, User } from "@prisma/client";
 
 import { trpc } from "@/utils/trpc";
@@ -9,7 +9,7 @@ type OutgoingWebhookWithFormEntry = OutgoingWebhook & {
   user: User | null;
   formEntry: FormEntry | null;
 };
-export const OutgoingWebhookFeedEntry: React.FC<{
+export const OutgoingWebhookFeedEntry: FC<{
   item: OutgoingWebhookWithFormEntry;
 }> = ({ item }) => {
   let details = <>{item.body}</>;

--- a/apps/website/src/components/admin/forms/Forms.tsx
+++ b/apps/website/src/components/admin/forms/Forms.tsx
@@ -1,6 +1,6 @@
 import type { inferRouterOutputs } from "@trpc/server";
 import Link from "next/link";
-import React, { useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import { Menu } from "@headlessui/react";
 
 import type { AppRouter } from "@/server/trpc/router/_app";

--- a/apps/website/src/components/admin/notifications/NotificationsLive.tsx
+++ b/apps/website/src/components/admin/notifications/NotificationsLive.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 
 import { trpc } from "@/utils/trpc";
 

--- a/apps/website/src/components/admin/notifications/SendNotificationForm.tsx
+++ b/apps/website/src/components/admin/notifications/SendNotificationForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, type FormEvent } from "react";
 import { Duration } from "luxon";
 
 import {
@@ -65,7 +65,7 @@ export function SendNotificationForm() {
   const [isScheduled, setIsScheduled] = useState(false);
 
   const submit = useCallback(
-    (event: React.FormEvent<HTMLFormElement>) => {
+    (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       const data = new FormData(event.currentTarget);
       const imageUrl = image?.status === "upload.done" ? image.url : undefined;

--- a/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntriesPanel.tsx
+++ b/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntriesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback } from "react";
+import { Fragment, useCallback } from "react";
 import type { inferRouterOutputs } from "@trpc/server";
 import { trpc } from "@/utils/trpc";
 import { Button } from "@/components/shared/Button";

--- a/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
+++ b/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ShowAndTellEntry, User } from "@prisma/client";
 
 import { getEntityStatus } from "@/utils/entity-helpers";

--- a/apps/website/src/components/admin/twitch/ChannelConfig.tsx
+++ b/apps/website/src/components/admin/twitch/ChannelConfig.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { DateTime } from "luxon";
 import type { inferProcedureOutput } from "@trpc/server";
 

--- a/apps/website/src/components/admin/twitch/EventSubscriptions.tsx
+++ b/apps/website/src/components/admin/twitch/EventSubscriptions.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { trpc } from "@/utils/trpc";
 
 export function EventSubscriptions() {

--- a/apps/website/src/components/admin/twitch/ProvideAuth.tsx
+++ b/apps/website/src/components/admin/twitch/ProvideAuth.tsx
@@ -1,5 +1,4 @@
 import { signIn } from "next-auth/react";
-import React from "react";
 
 import { botScope, defaultScope, scopeLabels } from "@/config/twitch";
 import { trpc } from "@/utils/trpc";

--- a/apps/website/src/components/content/Carousel.tsx
+++ b/apps/website/src/components/content/Carousel.tsx
@@ -1,4 +1,12 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type FC,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -9,14 +17,14 @@ import IconChevronRight from "@/icons/IconChevronRight";
 
 type CarouselProps = {
   id?: string;
-  items: Record<string, React.ReactNode>;
+  items: Record<string, ReactNode>;
   auto?: number | null;
   className?: string;
   wrapperClassName?: string;
   itemClassName?: string;
 };
 
-const Carousel: React.FC<CarouselProps> = ({
+const Carousel: FC<CarouselProps> = ({
   items,
   auto = 2000,
   id,
@@ -126,7 +134,7 @@ const Carousel: React.FC<CarouselProps> = ({
 
   // Allow the user to drag to scroll
   const drag = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
+    (event: ReactMouseEvent<HTMLDivElement>) => {
       const { current } = ref;
       if (!current) return;
 

--- a/apps/website/src/components/content/Carousel.tsx
+++ b/apps/website/src/components/content/Carousel.tsx
@@ -4,7 +4,6 @@ import {
   useRef,
   useState,
   type ReactNode,
-  type FC,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 
@@ -24,14 +23,14 @@ type CarouselProps = {
   itemClassName?: string;
 };
 
-const Carousel: FC<CarouselProps> = ({
+const Carousel = ({
   items,
   auto = 2000,
   id,
   className = "",
   wrapperClassName = "",
   itemClassName = "basis-full sm:basis-1/2 lg:basis-1/3 p-4",
-}) => {
+}: CarouselProps) => {
   const reducedMotion = usePrefersReducedMotion();
 
   // Allow the user to scroll to the next/previous image

--- a/apps/website/src/components/content/DateTime.tsx
+++ b/apps/website/src/components/content/DateTime.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState, type FC } from "react";
 
 import { formatDateTimeLocal, type DateTimeFormat } from "@/utils/datetime";
 
@@ -7,7 +7,7 @@ type DateTimeProps = {
   format?: Partial<DateTimeFormat>;
 };
 
-const DateTime: React.FC<DateTimeProps> = ({ date, format }) => {
+const DateTime: FC<DateTimeProps> = ({ date, format }) => {
   // On client load, and when the settings change, reformat the date
   const [formattedDate, setFormattedDate] = useState<string>(
     formatDateTimeLocal(date, format),

--- a/apps/website/src/components/content/DateTime.tsx
+++ b/apps/website/src/components/content/DateTime.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FC } from "react";
+import { useEffect, useState } from "react";
 
 import { formatDateTimeLocal, type DateTimeFormat } from "@/utils/datetime";
 
@@ -7,7 +7,7 @@ type DateTimeProps = {
   format?: Partial<DateTimeFormat>;
 };
 
-const DateTime: FC<DateTimeProps> = ({ date, format }) => {
+const DateTime = ({ date, format }: DateTimeProps) => {
   // On client load, and when the settings change, reformat the date
   const [formattedDate, setFormattedDate] = useState<string>(
     formatDateTimeLocal(date, format),

--- a/apps/website/src/components/content/Heading.tsx
+++ b/apps/website/src/components/content/Heading.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode, type FC } from "react";
+import { useMemo, type ReactNode } from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -13,14 +13,14 @@ export type HeadingProps = {
   linkClassName?: string;
 };
 
-const Heading: FC<HeadingProps> = ({
+const Heading = ({
   children,
   level = 1,
   className,
   id,
   link = false,
   linkClassName,
-}) => {
+}: HeadingProps) => {
   const Tag = level === -1 ? "p" : (`h${level}` as keyof JSX.IntrinsicElements);
   const headingClass = useMemo(
     () =>

--- a/apps/website/src/components/content/Heading.tsx
+++ b/apps/website/src/components/content/Heading.tsx
@@ -1,11 +1,11 @@
-import React, { useMemo } from "react";
+import { useMemo, type ReactNode, type FC } from "react";
 
 import { classes } from "@/utils/classes";
 
 import Link from "@/components/content/Link";
 
 export type HeadingProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
   level?: 1 | 2 | 3 | 4 | 5 | 6 | -1;
   className?: string;
   id?: string;
@@ -13,7 +13,7 @@ export type HeadingProps = {
   linkClassName?: string;
 };
 
-const Heading: React.FC<HeadingProps> = ({
+const Heading: FC<HeadingProps> = ({
   children,
   level = 1,
   className,

--- a/apps/website/src/components/content/Link.tsx
+++ b/apps/website/src/components/content/Link.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo, type ComponentProps, type FC } from "react";
 import NextLink from "next/link";
 
 import { classes } from "@/utils/classes";
@@ -9,9 +9,9 @@ type LinkProps = {
   external?: boolean;
   custom?: boolean;
   dark?: boolean;
-} & React.ComponentProps<typeof NextLink>;
+} & ComponentProps<typeof NextLink>;
 
-const Link: React.FC<LinkProps> = ({
+const Link: FC<LinkProps> = ({
   external = false,
   custom = false,
   dark = false,

--- a/apps/website/src/components/content/Link.tsx
+++ b/apps/website/src/components/content/Link.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ComponentProps, type FC } from "react";
+import { useMemo, type ComponentProps } from "react";
 import NextLink from "next/link";
 
 import { classes } from "@/utils/classes";
@@ -11,7 +11,7 @@ type LinkProps = {
   dark?: boolean;
 } & ComponentProps<typeof NextLink>;
 
-const Link: FC<LinkProps> = ({
+const Link = ({
   external = false,
   custom = false,
   dark = false,
@@ -20,7 +20,7 @@ const Link: FC<LinkProps> = ({
   rel,
   children,
   ...props
-}) => {
+}: LinkProps) => {
   const computedClassName = useMemo(
     () =>
       classes(

--- a/apps/website/src/components/content/Markdown.tsx
+++ b/apps/website/src/components/content/Markdown.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo, type FC } from "react";
 import ReactMarkdown, { type Components, type Options } from "react-markdown";
 import headingId from "remark-heading-id";
 
@@ -7,7 +7,7 @@ import { classes } from "@/utils/classes";
 import Heading, { type HeadingProps } from "@/components/content/Heading";
 import Link from "@/components/content/Link";
 
-const MarkdownHeading: React.FC<HeadingProps> = ({
+const MarkdownHeading: FC<HeadingProps> = ({
   level,
   className,
   children,
@@ -28,7 +28,7 @@ type MarkdownProps = {
   dark?: boolean;
 };
 
-const Markdown: React.FC<MarkdownProps> = ({ content, dark = false }) => {
+const Markdown: FC<MarkdownProps> = ({ content, dark = false }) => {
   const components: Components = useMemo(
     () => ({
       h1: ({ children, id }) => (

--- a/apps/website/src/components/content/Markdown.tsx
+++ b/apps/website/src/components/content/Markdown.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type FC } from "react";
+import { useMemo } from "react";
 import ReactMarkdown, { type Components, type Options } from "react-markdown";
 import headingId from "remark-heading-id";
 
@@ -7,12 +7,7 @@ import { classes } from "@/utils/classes";
 import Heading, { type HeadingProps } from "@/components/content/Heading";
 import Link from "@/components/content/Link";
 
-const MarkdownHeading: FC<HeadingProps> = ({
-  level,
-  className,
-  children,
-  id,
-}) => (
+const MarkdownHeading = ({ level, className, children, id }: HeadingProps) => (
   <Heading
     level={level}
     className={classes(className, "break-words")}
@@ -28,7 +23,7 @@ type MarkdownProps = {
   dark?: boolean;
 };
 
-const Markdown: FC<MarkdownProps> = ({ content, dark = false }) => {
+const Markdown = ({ content, dark = false }: MarkdownProps) => {
   const components: Components = useMemo(
     () => ({
       h1: ({ children, id }) => (

--- a/apps/website/src/components/content/Meta.tsx
+++ b/apps/website/src/components/content/Meta.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { type ReactNode, type FC } from "react";
+import { type ReactNode } from "react";
 
 import headerImage from "@/assets/header.png";
 import { createImageUrl } from "@/utils/image";
@@ -15,7 +15,7 @@ type MetaProps = {
 // Get our base URL, which will either be specifically set, or from Vercel for preview deployments
 const BASE_URL = env.NEXT_PUBLIC_BASE_URL;
 
-const Meta: FC<MetaProps> = ({ title, description, image, children }) => {
+const Meta = ({ title, description, image, children }: MetaProps) => {
   const defaultTitle = "Alveus Sanctuary";
   const defaultDescription =
     "Alveus is a 501(c)(3) nonprofit organization functioning as a wildlife sanctuary & virtual education center following the journeys of our non-releasable ambassadors, aiming to educate and spark an appreciation for them and their wild counterparts.";

--- a/apps/website/src/components/content/Meta.tsx
+++ b/apps/website/src/components/content/Meta.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import React from "react";
+import { type ReactNode, type FC } from "react";
 
 import headerImage from "@/assets/header.png";
 import { createImageUrl } from "@/utils/image";
@@ -9,13 +9,13 @@ type MetaProps = {
   title?: string;
   description?: string;
   image?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 // Get our base URL, which will either be specifically set, or from Vercel for preview deployments
 const BASE_URL = env.NEXT_PUBLIC_BASE_URL;
 
-const Meta: React.FC<MetaProps> = ({ title, description, image, children }) => {
+const Meta: FC<MetaProps> = ({ title, description, image, children }) => {
   const defaultTitle = "Alveus Sanctuary";
   const defaultDescription =
     "Alveus is a 501(c)(3) nonprofit organization functioning as a wildlife sanctuary & virtual education center following the journeys of our non-releasable ambassadors, aiming to educate and spark an appreciation for them and their wild counterparts.";

--- a/apps/website/src/components/content/People.tsx
+++ b/apps/website/src/components/content/People.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type FC } from "react";
+import { type ReactNode } from "react";
 import Image, { type ImageProps } from "next/image";
 
 import { classes } from "@/utils/classes";
@@ -19,7 +19,7 @@ type PeopleProps = {
   align?: "left" | "center";
 };
 
-const People: FC<PeopleProps> = ({ people, columns = 1, align = "left" }) => (
+const People = ({ people, columns = 1, align = "left" }: PeopleProps) => (
   <ul
     className={classes(
       "flex flex-wrap",

--- a/apps/website/src/components/content/People.tsx
+++ b/apps/website/src/components/content/People.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type ReactNode, type FC } from "react";
 import Image, { type ImageProps } from "next/image";
 
 import { classes } from "@/utils/classes";
@@ -12,18 +12,14 @@ type PeopleProps = {
       image: ImageProps["src"];
       name: string;
       title: string;
-      description: React.ReactNode;
+      description: ReactNode;
     }
   >;
   columns?: 1 | 2;
   align?: "left" | "center";
 };
 
-const People: React.FC<PeopleProps> = ({
-  people,
-  columns = 1,
-  align = "left",
-}) => (
+const People: FC<PeopleProps> = ({ people, columns = 1, align = "left" }) => (
   <ul
     className={classes(
       "flex flex-wrap",

--- a/apps/website/src/components/content/Section.tsx
+++ b/apps/website/src/components/content/Section.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type ReactNode, type FC } from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -6,14 +6,14 @@ import topographyTexture from "@/assets/textures/topography.svg";
 import dustTexture from "@/assets/textures/dust.svg";
 
 type SectionProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
   dark?: boolean;
   offsetParent?: boolean;
   className?: string;
   containerClassName?: string;
 };
 
-const Section: React.FC<SectionProps> = ({
+const Section: FC<SectionProps> = ({
   children,
   dark,
   offsetParent = true,

--- a/apps/website/src/components/content/Section.tsx
+++ b/apps/website/src/components/content/Section.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type FC } from "react";
+import { type ReactNode } from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -13,13 +13,13 @@ type SectionProps = {
   containerClassName?: string;
 };
 
-const Section: FC<SectionProps> = ({
+const Section = ({
   children,
   dark,
   offsetParent = true,
   className,
   containerClassName,
-}) => {
+}: SectionProps) => {
   // Determine the texture to use
   const opacity = dark ? "opacity-[0.06]" : "opacity-[0.03]";
   const texture = dark ? dustTexture.src : topographyTexture.src;

--- a/apps/website/src/components/content/Select.tsx
+++ b/apps/website/src/components/content/Select.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment, type FC, type JSX } from "react";
 import { Listbox, Transition } from "@headlessui/react";
 
 import { typeSafeObjectEntries } from "@/utils/helpers";
@@ -16,7 +16,7 @@ type SelectProps = {
   className?: string;
 };
 
-const Select: React.FC<SelectProps> = ({
+const Select: FC<SelectProps> = ({
   options,
   value,
   onChange,

--- a/apps/website/src/components/content/Select.tsx
+++ b/apps/website/src/components/content/Select.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type FC, type JSX } from "react";
+import { Fragment, type JSX } from "react";
 import { Listbox, Transition } from "@headlessui/react";
 
 import { typeSafeObjectEntries } from "@/utils/helpers";
@@ -16,7 +16,7 @@ type SelectProps = {
   className?: string;
 };
 
-const Select: FC<SelectProps> = ({
+const Select = ({
   options,
   value,
   onChange,
@@ -24,7 +24,7 @@ const Select: FC<SelectProps> = ({
   dark = false,
   align = "left",
   className,
-}) => {
+}: SelectProps) => {
   return (
     <Listbox value={value} onChange={onChange}>
       <div className={classes("relative mt-1 flex flex-col", className)}>

--- a/apps/website/src/components/content/Slideshow.tsx
+++ b/apps/website/src/components/content/Slideshow.tsx
@@ -1,6 +1,12 @@
 import type { ImageProps } from "next/image";
 import Image from "next/image";
-import React, { type CSSProperties, useCallback, useId, useMemo } from "react";
+import {
+  type CSSProperties,
+  useCallback,
+  useId,
+  useMemo,
+  type FC,
+} from "react";
 
 import { camelToKebab } from "@/utils/string-case";
 import { createImageUrl, type ImageLoaderProps } from "@/utils/image";
@@ -28,7 +34,7 @@ const objToCss = (obj: Record<string, CSSProperties> | CSSProperties): string =>
     })
     .join(" ");
 
-const Slideshow: React.FC<SlideshowProps> = ({
+const Slideshow: FC<SlideshowProps> = ({
   images,
   timing = { fade: 500, delay: 5000 },
   scale = { from: 1.1, to: 1.2 },

--- a/apps/website/src/components/content/Slideshow.tsx
+++ b/apps/website/src/components/content/Slideshow.tsx
@@ -1,12 +1,6 @@
 import type { ImageProps } from "next/image";
 import Image from "next/image";
-import {
-  type CSSProperties,
-  useCallback,
-  useId,
-  useMemo,
-  type FC,
-} from "react";
+import { type CSSProperties, useCallback, useId, useMemo } from "react";
 
 import { camelToKebab } from "@/utils/string-case";
 import { createImageUrl, type ImageLoaderProps } from "@/utils/image";
@@ -34,11 +28,11 @@ const objToCss = (obj: Record<string, CSSProperties> | CSSProperties): string =>
     })
     .join(" ");
 
-const Slideshow: FC<SlideshowProps> = ({
+const Slideshow = ({
   images,
   timing = { fade: 500, delay: 5000 },
   scale = { from: 1.1, to: 1.2 },
-}) => {
+}: SlideshowProps) => {
   // Define the animation keyframes
   const id = useId().replace(/:/g, "");
   const animation = useMemo<{

--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -1,9 +1,9 @@
 import Script from "next/script";
-import React, { useEffect } from "react";
+import { useEffect, type FC } from "react";
 
 import { theGivingBlockConfig } from "@/config/the-giving-block";
 
-const TheGivingBlockEmbed: React.FC = () => {
+const TheGivingBlockEmbed: FC = () => {
   useEffect(() => {
     window.tgbWidgetOptions = theGivingBlockConfig;
   }, []);

--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -1,9 +1,9 @@
 import Script from "next/script";
-import { useEffect, type FC } from "react";
+import { useEffect } from "react";
 
 import { theGivingBlockConfig } from "@/config/the-giving-block";
 
-const TheGivingBlockEmbed: FC = () => {
+const TheGivingBlockEmbed = () => {
   useEffect(() => {
     window.tgbWidgetOptions = theGivingBlockConfig;
   }, []);

--- a/apps/website/src/components/content/Timeline.tsx
+++ b/apps/website/src/components/content/Timeline.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type ReactNode, type FC } from "react";
 
 import IconCalendar from "@/icons/IconCalendar";
 
@@ -8,13 +8,13 @@ type TimelineProps = {
   items: {
     key: string;
     date: string;
-    content: React.ReactNode;
+    content: ReactNode;
   }[];
   before?: string;
   after?: string;
 };
 
-const Timeline: React.FC<TimelineProps> = ({ items, before, after }) => (
+const Timeline: FC<TimelineProps> = ({ items, before, after }) => (
   <div className="relative z-0 mx-auto max-w-6xl">
     <div
       className={classes(

--- a/apps/website/src/components/content/Timeline.tsx
+++ b/apps/website/src/components/content/Timeline.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type FC } from "react";
+import { type ReactNode } from "react";
 
 import IconCalendar from "@/icons/IconCalendar";
 
@@ -14,7 +14,7 @@ type TimelineProps = {
   after?: string;
 };
 
-const Timeline: FC<TimelineProps> = ({ items, before, after }) => (
+const Timeline = ({ items, before, after }: TimelineProps) => (
   <div className="relative z-0 mx-auto max-w-6xl">
     <div
       className={classes(

--- a/apps/website/src/components/content/Video.tsx
+++ b/apps/website/src/components/content/Video.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, type FC } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { createImageUrl } from "@/utils/image";
 
@@ -17,7 +17,7 @@ type VideoProps = {
   threshold?: number;
 };
 
-const Video: FC<VideoProps> = ({
+const Video = ({
   autoPlay = false,
   loop = false,
   muted = false,
@@ -27,7 +27,7 @@ const Video: FC<VideoProps> = ({
   poster,
   sources,
   threshold = 0.1,
-}) => {
+}: VideoProps) => {
   const [seen, setSeen] = useState(false);
   const observer = useRef<IntersectionObserver>();
   const ref = useCallback(

--- a/apps/website/src/components/content/Video.tsx
+++ b/apps/website/src/components/content/Video.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, type FC } from "react";
 
 import { createImageUrl } from "@/utils/image";
 
@@ -17,7 +17,7 @@ type VideoProps = {
   threshold?: number;
 };
 
-const Video: React.FC<VideoProps> = ({
+const Video: FC<VideoProps> = ({
   autoPlay = false,
   loop = false,
   muted = false,

--- a/apps/website/src/components/content/YouTube.tsx
+++ b/apps/website/src/components/content/YouTube.tsx
@@ -1,10 +1,12 @@
-import React, {
+import {
   cloneElement,
   useCallback,
   useEffect,
   useId,
   useMemo,
   useState,
+  type ReactNode,
+  type FC,
 } from "react";
 import PhotoSwipeLightbox from "photoswipe/lightbox";
 
@@ -51,11 +53,11 @@ type TriggerProps = {
   videoId: string;
   caption?: string;
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 const createTrigger = (id: string) => {
-  const Trigger: React.FC<TriggerProps> = ({
+  const Trigger: FC<TriggerProps> = ({
     videoId,
     caption,
     className,
@@ -90,7 +92,7 @@ const imgSrc = (id: string, type: string) =>
     quality: 100,
   });
 
-export const Preview: React.FC<PreviewProps> = ({ videoId, className }) => {
+export const Preview: FC<PreviewProps> = ({ videoId, className }) => {
   // Handle falling back to hq if there isn't a maxres image
   const [type, setType] = useState<"maxresdefault" | "hqdefault">(
     "maxresdefault",
@@ -130,14 +132,10 @@ type LightboxCtxProps = {
 type LightboxProps = {
   id?: string;
   className?: string;
-  children: React.ReactNode | ((ctx: LightboxCtxProps) => React.ReactNode);
+  children: ReactNode | ((ctx: LightboxCtxProps) => ReactNode);
 };
 
-export const Lightbox: React.FC<LightboxProps> = ({
-  id,
-  className,
-  children,
-}) => {
+export const Lightbox: FC<LightboxProps> = ({ id, className, children }) => {
   const { update: updateConsent } = useConsent();
 
   const defaultId = useId().replace(/\W/g, "").toLowerCase();

--- a/apps/website/src/components/content/YouTube.tsx
+++ b/apps/website/src/components/content/YouTube.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useState,
   type ReactNode,
-  type FC,
 } from "react";
 import PhotoSwipeLightbox from "photoswipe/lightbox";
 
@@ -57,12 +56,7 @@ type TriggerProps = {
 };
 
 const createTrigger = (id: string) => {
-  const Trigger: FC<TriggerProps> = ({
-    videoId,
-    caption,
-    className,
-    children,
-  }) => {
+  const Trigger = ({ videoId, caption, className, children }: TriggerProps) => {
     return (
       <a
         href={`https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`}
@@ -92,7 +86,7 @@ const imgSrc = (id: string, type: string) =>
     quality: 100,
   });
 
-export const Preview: FC<PreviewProps> = ({ videoId, className }) => {
+export const Preview = ({ videoId, className }: PreviewProps) => {
   // Handle falling back to hq if there isn't a maxres image
   const [type, setType] = useState<"maxresdefault" | "hqdefault">(
     "maxresdefault",
@@ -135,7 +129,7 @@ type LightboxProps = {
   children: ReactNode | ((ctx: LightboxCtxProps) => ReactNode);
 };
 
-export const Lightbox: FC<LightboxProps> = ({ id, className, children }) => {
+export const Lightbox = ({ id, className, children }: LightboxProps) => {
   const { update: updateConsent } = useConsent();
 
   const defaultId = useId().replace(/\W/g, "").toLowerCase();

--- a/apps/website/src/components/forms/ConsentFieldset.tsx
+++ b/apps/website/src/components/forms/ConsentFieldset.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { PLACEHOLDER_ASK_MARKETING_EMAILS_LABEL } from "@/utils/forms";
 
 import Link from "../content/Link";

--- a/apps/website/src/components/forms/ContactFieldset.tsx
+++ b/apps/website/src/components/forms/ContactFieldset.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Fieldset } from "../shared/form/Fieldset";
 import { TextField } from "../shared/form/TextField";
 

--- a/apps/website/src/components/forms/EntryForm.tsx
+++ b/apps/website/src/components/forms/EntryForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import { useCallback, type FC, type FormEvent } from "react";
 import { useSession } from "next-auth/react";
 import type { Form } from "@prisma/client";
 
@@ -24,7 +24,7 @@ import { ContactFieldset } from "./ContactFieldset";
 import { EntryRulesFieldset } from "./EntryRulesFieldset";
 import { Promos } from "./Promos";
 
-export const EntryForm: React.FC<{
+export const EntryForm: FC<{
   form: Form;
   existingEntry: FormEntryWithAddress | null;
 }> = ({ form, existingEntry }) => {
@@ -34,7 +34,7 @@ export const EntryForm: React.FC<{
   const enterForm = trpc.forms.enterForm.useMutation();
 
   const handleSubmit = useCallback(
-    async (e: React.FormEvent<HTMLFormElement>) => {
+    async (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
 
       const data = new FormData(e.currentTarget);

--- a/apps/website/src/components/forms/EntryForm.tsx
+++ b/apps/website/src/components/forms/EntryForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type FC, type FormEvent } from "react";
+import { useCallback, type FormEvent } from "react";
 import { useSession } from "next-auth/react";
 import type { Form } from "@prisma/client";
 
@@ -24,10 +24,13 @@ import { ContactFieldset } from "./ContactFieldset";
 import { EntryRulesFieldset } from "./EntryRulesFieldset";
 import { Promos } from "./Promos";
 
-export const EntryForm: FC<{
+export const EntryForm = ({
+  form,
+  existingEntry,
+}: {
   form: Form;
   existingEntry: FormEntryWithAddress | null;
-}> = ({ form, existingEntry }) => {
+}) => {
   const { data: session } = useSession();
 
   const config = calcFormConfig(form.config);

--- a/apps/website/src/components/forms/EntryRulesFieldset.tsx
+++ b/apps/website/src/components/forms/EntryRulesFieldset.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { Form } from "@prisma/client";
 import Link from "next/link";
 

--- a/apps/website/src/components/forms/GiveawayChecks.tsx
+++ b/apps/website/src/components/forms/GiveawayChecks.tsx
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useState,
-  type ReactNode,
-  type FC,
-  type MouseEvent,
-} from "react";
+import { useCallback, useState, type ReactNode, type MouseEvent } from "react";
 import Link from "next/link";
 
 import IconTwitch from "@/icons/IconTwitch";
@@ -16,12 +10,17 @@ import IconShoppingCart from "@/icons/IconShoppingCart";
 
 import { classes } from "@/utils/classes";
 
-const GiveawayCheck: FC<{
+const GiveawayCheck = ({
+  name,
+  label,
+  children,
+  url,
+}: {
   name: string;
   label: string;
   children: ReactNode;
   url?: string;
-}> = ({ name, label, children, url }) => {
+}) => {
   const [isClicked, setIsClicked] = useState(false);
   const hasLink = url !== undefined;
 
@@ -108,7 +107,7 @@ const GiveawayCheck: FC<{
   );
 };
 
-export const GiveawayChecks: FC = () => (
+export const GiveawayChecks = () => (
   <div className="flex flex-col gap-5">
     <GiveawayCheck
       name="twitter"

--- a/apps/website/src/components/forms/GiveawayChecks.tsx
+++ b/apps/website/src/components/forms/GiveawayChecks.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useState } from "react";
+import {
+  useCallback,
+  useState,
+  type ReactNode,
+  type FC,
+  type MouseEvent,
+} from "react";
 import Link from "next/link";
 
 import IconTwitch from "@/icons/IconTwitch";
@@ -10,10 +16,10 @@ import IconShoppingCart from "@/icons/IconShoppingCart";
 
 import { classes } from "@/utils/classes";
 
-const GiveawayCheck: React.FC<{
+const GiveawayCheck: FC<{
   name: string;
   label: string;
-  children: React.ReactNode;
+  children: ReactNode;
   url?: string;
 }> = ({ name, label, children, url }) => {
   const [isClicked, setIsClicked] = useState(false);
@@ -40,7 +46,7 @@ const GiveawayCheck: React.FC<{
   // Disable the checkbox if this is a link, and the user hasn't clicked yet
   const disabled = hasLink && !isClicked;
   const handleCheckboxClick = useCallback(
-    (e: React.MouseEvent<HTMLInputElement>) => {
+    (e: MouseEvent<HTMLInputElement>) => {
       if (disabled) {
         e.preventDefault();
       }
@@ -102,7 +108,7 @@ const GiveawayCheck: React.FC<{
   );
 };
 
-export const GiveawayChecks: React.FC = () => (
+export const GiveawayChecks: FC = () => (
   <div className="flex flex-col gap-5">
     <GiveawayCheck
       name="twitter"

--- a/apps/website/src/components/forms/NameFieldset.tsx
+++ b/apps/website/src/components/forms/NameFieldset.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { TextField } from "../shared/form/TextField";
 import { FieldGroup } from "../shared/form/FieldGroup";
 import { Fieldset } from "../shared/form/Fieldset";

--- a/apps/website/src/components/forms/ShippingAddressFieldset.tsx
+++ b/apps/website/src/components/forms/ShippingAddressFieldset.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type FC } from "react";
 
 import {
   DEFAULT_COUNTRY_CODE,
@@ -11,7 +11,7 @@ import { FieldGroup } from "../shared/form/FieldGroup";
 import { TextField } from "../shared/form/TextField";
 import { SelectBoxField } from "../shared/form/SelectBoxField";
 
-export const ShippingAddressFieldset: React.FC = () => {
+export const ShippingAddressFieldset: FC = () => {
   return (
     <Fieldset legend="Shipping address">
       <FieldGroup>

--- a/apps/website/src/components/forms/ShippingAddressFieldset.tsx
+++ b/apps/website/src/components/forms/ShippingAddressFieldset.tsx
@@ -1,5 +1,3 @@
-import { type FC } from "react";
-
 import {
   DEFAULT_COUNTRY_CODE,
   commonCountries,
@@ -11,7 +9,7 @@ import { FieldGroup } from "../shared/form/FieldGroup";
 import { TextField } from "../shared/form/TextField";
 import { SelectBoxField } from "../shared/form/SelectBoxField";
 
-export const ShippingAddressFieldset: FC = () => {
+export const ShippingAddressFieldset = () => {
   return (
     <Fieldset legend="Shipping address">
       <FieldGroup>

--- a/apps/website/src/components/layout/Layout.tsx
+++ b/apps/website/src/components/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode, type FC } from "react";
+import { useEffect, type ReactNode } from "react";
 import { PT_Sans, PT_Serif } from "next/font/google";
 import Head from "next/head";
 
@@ -24,7 +24,7 @@ const ptSerif = PT_Serif({
 
 const fonts = `${ptSans.variable} ${ptSerif.variable} font-sans`;
 
-const Layout: FC<LayoutProps> = ({ children }) => {
+const Layout = ({ children }: LayoutProps) => {
   // Add fonts to body for portals that do not attach to #app
   useEffect(() => {
     document.body.classList.add(...fonts.split(" "));

--- a/apps/website/src/components/layout/Layout.tsx
+++ b/apps/website/src/components/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect, type ReactNode, type FC } from "react";
 import { PT_Sans, PT_Serif } from "next/font/google";
 import Head from "next/head";
 
@@ -7,7 +7,7 @@ import { Navbar } from "./navbar/Navbar";
 import { Footer } from "./footer/Footer";
 
 type LayoutProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 const ptSans = PT_Sans({
@@ -24,7 +24,7 @@ const ptSerif = PT_Serif({
 
 const fonts = `${ptSans.variable} ${ptSerif.variable} font-sans`;
 
-const Layout: React.FC<LayoutProps> = ({ children }) => {
+const Layout: FC<LayoutProps> = ({ children }) => {
   // Add fonts to body for portals that do not attach to #app
   useEffect(() => {
     document.body.classList.add(...fonts.split(" "));

--- a/apps/website/src/components/layout/footer/Footer.tsx
+++ b/apps/website/src/components/layout/footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type FC } from "react";
+import { useMemo } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
@@ -8,7 +8,7 @@ import Socials from "./Socials";
 const footerLinkClasses =
   "underline decoration-gray-600 underline-offset-2 transition-colors hover:text-gray-300";
 
-export const Footer: FC = () => {
+export const Footer = () => {
   const router = useRouter();
   const isAdmin = useMemo(
     () => router.pathname === "/admin" || router.pathname.startsWith("/admin/"),

--- a/apps/website/src/components/layout/footer/Footer.tsx
+++ b/apps/website/src/components/layout/footer/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo, type FC } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
@@ -8,7 +8,7 @@ import Socials from "./Socials";
 const footerLinkClasses =
   "underline decoration-gray-600 underline-offset-2 transition-colors hover:text-gray-300";
 
-export const Footer: React.FC = () => {
+export const Footer: FC = () => {
   const router = useRouter();
   const isAdmin = useMemo(
     () => router.pathname === "/admin" || router.pathname.startsWith("/admin/"),

--- a/apps/website/src/components/layout/footer/Socials.tsx
+++ b/apps/website/src/components/layout/footer/Socials.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type FC } from "react";
 
 import Link from "next/link";
 import Image from "next/image";
@@ -22,7 +22,7 @@ import { NotificationsButton } from "@/components/notifications/NotificationsBut
 const buttonClasses =
   "block rounded-2xl bg-alveus-tan p-3 text-alveus-green transition-colors hover:bg-alveus-green-800 hover:text-alveus-tan";
 
-const Socials: React.FC = () => {
+const Socials: FC = () => {
   const reducedMotion = usePrefersReducedMotion();
 
   return (

--- a/apps/website/src/components/layout/footer/Socials.tsx
+++ b/apps/website/src/components/layout/footer/Socials.tsx
@@ -1,5 +1,3 @@
-import { type FC } from "react";
-
 import Link from "next/link";
 import Image from "next/image";
 
@@ -22,7 +20,7 @@ import { NotificationsButton } from "@/components/notifications/NotificationsBut
 const buttonClasses =
   "block rounded-2xl bg-alveus-tan p-3 text-alveus-green transition-colors hover:bg-alveus-green-800 hover:text-alveus-tan";
 
-const Socials: FC = () => {
+const Socials = () => {
   const reducedMotion = usePrefersReducedMotion();
 
   return (

--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -7,7 +7,6 @@ import {
   forwardRef,
   Fragment,
   type ReactElement,
-  type FC,
 } from "react";
 
 import {
@@ -52,7 +51,7 @@ const DropdownMenuItems: typeof Menu.Items = ({ ...props }) => (
 );
 DropdownMenuItems.displayName = "DropdownMenuItems";
 
-const DropdownMenuItem: FC<{ children: ReactElement }> = forwardRef(
+const DropdownMenuItem = forwardRef<HTMLLIElement, { children: ReactElement }>(
   ({ children, ...props }, ref) => (
     <li {...props}>
       {Children.map(children, (child) => cloneElement(child, { ref }))}

--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -1,7 +1,14 @@
 import Link from "next/link";
 import { Menu, Transition } from "@headlessui/react";
 import { signIn, signOut, useSession } from "next-auth/react";
-import React, { Children, cloneElement, forwardRef, Fragment } from "react";
+import {
+  Children,
+  cloneElement,
+  forwardRef,
+  Fragment,
+  type ReactElement,
+  type FC,
+} from "react";
 
 import {
   mainNavStructure,
@@ -45,7 +52,7 @@ const DropdownMenuItems: typeof Menu.Items = ({ ...props }) => (
 );
 DropdownMenuItems.displayName = "DropdownMenuItems";
 
-const DropdownMenuItem: React.FC<{ children: React.ReactElement }> = forwardRef(
+const DropdownMenuItem: FC<{ children: ReactElement }> = forwardRef(
   ({ children, ...props }, ref) => (
     <li {...props}>
       {Children.map(children, (child) => cloneElement(child, { ref }))}

--- a/apps/website/src/components/layout/navbar/MobileMenu.tsx
+++ b/apps/website/src/components/layout/navbar/MobileMenu.tsx
@@ -1,5 +1,5 @@
 import { Disclosure } from "@headlessui/react";
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 import { signIn, signOut, useSession } from "next-auth/react";
 import { mainNavStructure } from "@/config/main-nav-structure";
 import { checkRolesGivePermission, permissions } from "@/config/permissions";

--- a/apps/website/src/components/layout/navbar/NavLink.tsx
+++ b/apps/website/src/components/layout/navbar/NavLink.tsx
@@ -3,7 +3,6 @@ import {
   type AnchorHTMLAttributes,
   type RefAttributes,
   type ReactNode,
-  type FC,
 } from "react";
 import type { LinkProps } from "next/link";
 import Link from "next/link";
@@ -28,7 +27,7 @@ export const navLinkClassesMainActive = "lg:border-white";
 export const navLinkClassesSub = `${navLinkClasses} py-2 hover:bg-alveus-tan/20 rounded`;
 export const navLinkClassesSubActive = "bg-alveus-tan/10";
 
-export const NavLink: FC<NavLinkProps> = forwardRef(
+export const NavLink = forwardRef<HTMLAnchorElement, NavLinkProps>(
   (
     { href, variant = "main", isExternal = false, className, ...props },
     ref,
@@ -63,7 +62,7 @@ export const NavLink: FC<NavLinkProps> = forwardRef(
 );
 NavLink.displayName = "NavLink";
 
-export const NavLinkSub: FC<NavLinkProps> = forwardRef((props, ref) => (
-  <NavLink variant="sub" {...props} ref={ref} />
-));
+export const NavLinkSub = forwardRef<HTMLAnchorElement, NavLinkProps>(
+  (props, ref) => <NavLink variant="sub" {...props} ref={ref} />,
+);
 NavLinkSub.displayName = "NavLinkSub";

--- a/apps/website/src/components/layout/navbar/NavLink.tsx
+++ b/apps/website/src/components/layout/navbar/NavLink.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef } from "react";
+import {
+  forwardRef,
+  type AnchorHTMLAttributes,
+  type RefAttributes,
+  type ReactNode,
+  type FC,
+} from "react";
 import type { LinkProps } from "next/link";
 import Link from "next/link";
 
@@ -7,14 +13,14 @@ import { classes } from "@/utils/classes";
 import { useIsActivePath } from "@/components/shared/hooks/useIsActivePath";
 
 type NavLinkProps = Omit<
-  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  AnchorHTMLAttributes<HTMLAnchorElement>,
   keyof LinkProps
 > &
   LinkProps & {
-    children?: React.ReactNode;
+    children?: ReactNode;
     variant?: "main" | "sub";
     isExternal?: boolean;
-  } & React.RefAttributes<HTMLAnchorElement>;
+  } & RefAttributes<HTMLAnchorElement>;
 
 export const navLinkClasses = `block px-5 h-full transition-colors`;
 export const navLinkClassesMain = `${navLinkClasses} py-3 border-b-2 border-transparent hover:lg:border-white `;
@@ -22,7 +28,7 @@ export const navLinkClassesMainActive = "lg:border-white";
 export const navLinkClassesSub = `${navLinkClasses} py-2 hover:bg-alveus-tan/20 rounded`;
 export const navLinkClassesSubActive = "bg-alveus-tan/10";
 
-export const NavLink: React.FC<NavLinkProps> = forwardRef(
+export const NavLink: FC<NavLinkProps> = forwardRef(
   (
     { href, variant = "main", isExternal = false, className, ...props },
     ref,
@@ -57,7 +63,7 @@ export const NavLink: React.FC<NavLinkProps> = forwardRef(
 );
 NavLink.displayName = "NavLink";
 
-export const NavLinkSub: React.FC<NavLinkProps> = forwardRef((props, ref) => (
+export const NavLinkSub: FC<NavLinkProps> = forwardRef((props, ref) => (
   <NavLink variant="sub" {...props} ref={ref} />
 ));
 NavLinkSub.displayName = "NavLinkSub";

--- a/apps/website/src/components/layout/navbar/Navbar.tsx
+++ b/apps/website/src/components/layout/navbar/Navbar.tsx
@@ -1,4 +1,3 @@
-import { type FC } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Disclosure } from "@headlessui/react";
@@ -10,7 +9,7 @@ import { NotificationsButton } from "@/components/notifications/NotificationsBut
 import IconX from "@/icons/IconX";
 import IconMenu from "@/icons/IconMenu";
 
-export const Navbar: FC = () => {
+export const Navbar = () => {
   return (
     <Disclosure
       as="header"

--- a/apps/website/src/components/layout/navbar/Navbar.tsx
+++ b/apps/website/src/components/layout/navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type FC } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Disclosure } from "@headlessui/react";
@@ -10,7 +10,7 @@ import { NotificationsButton } from "@/components/notifications/NotificationsBut
 import IconX from "@/icons/IconX";
 import IconMenu from "@/icons/IconMenu";
 
-export const Navbar: React.FC = () => {
+export const Navbar: FC = () => {
   return (
     <Disclosure
       as="header"

--- a/apps/website/src/components/layout/navbar/ProfileInfo.tsx
+++ b/apps/website/src/components/layout/navbar/ProfileInfo.tsx
@@ -1,7 +1,7 @@
 import { useSession } from "next-auth/react";
-import React from "react";
+import { type FC } from "react";
 
-export const ProfileInfoImage: React.FC = () => {
+export const ProfileInfoImage: FC = () => {
   const { data: sessionData } = useSession();
   const user = sessionData?.user;
 
@@ -21,7 +21,7 @@ export const ProfileInfoImage: React.FC = () => {
   return <></>;
 };
 
-export const ProfileInfo: React.FC<{ full?: boolean }> = ({ full = false }) => {
+export const ProfileInfo: FC<{ full?: boolean }> = ({ full = false }) => {
   const { data: sessionData } = useSession();
   const user = sessionData?.user;
 

--- a/apps/website/src/components/layout/navbar/ProfileInfo.tsx
+++ b/apps/website/src/components/layout/navbar/ProfileInfo.tsx
@@ -1,7 +1,6 @@
 import { useSession } from "next-auth/react";
-import { type FC } from "react";
 
-export const ProfileInfoImage: FC = () => {
+export const ProfileInfoImage = () => {
   const { data: sessionData } = useSession();
   const user = sessionData?.user;
 
@@ -21,7 +20,7 @@ export const ProfileInfoImage: FC = () => {
   return <></>;
 };
 
-export const ProfileInfo: FC<{ full?: boolean }> = ({ full = false }) => {
+export const ProfileInfo = ({ full = false }) => {
   const { data: sessionData } = useSession();
   const user = sessionData?.user;
 

--- a/apps/website/src/components/notifications/NotificationCategoryCheckbox.tsx
+++ b/apps/website/src/components/notifications/NotificationCategoryCheckbox.tsx
@@ -1,10 +1,10 @@
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, FC } from "react";
 
 import { classes } from "@/utils/classes";
 
 import { navLinkClassesSub } from "@/components/layout/navbar/NavLink";
 
-export const NotificationCategoryCheckbox: React.FC<{
+export const NotificationCategoryCheckbox: FC<{
   tag: string;
   label: string;
   endpoint: string;

--- a/apps/website/src/components/notifications/NotificationCategoryCheckbox.tsx
+++ b/apps/website/src/components/notifications/NotificationCategoryCheckbox.tsx
@@ -1,10 +1,18 @@
-import type { ChangeEvent, FC } from "react";
+import type { ChangeEvent } from "react";
 
 import { classes } from "@/utils/classes";
 
 import { navLinkClassesSub } from "@/components/layout/navbar/NavLink";
 
-export const NotificationCategoryCheckbox: FC<{
+export const NotificationCategoryCheckbox = ({
+  tag,
+  label,
+  endpoint,
+  isRegistered,
+  enabled,
+  tags,
+  handleChange,
+}: {
   tag: string;
   label: string;
   endpoint: string;
@@ -12,7 +20,7 @@ export const NotificationCategoryCheckbox: FC<{
   enabled: boolean;
   tags: Record<string, string>;
   handleChange: (event: ChangeEvent<HTMLInputElement>) => void;
-}> = ({ tag, label, endpoint, isRegistered, enabled, tags, handleChange }) => {
+}) => {
   return (
     <label
       htmlFor={`tag-${tag}`}

--- a/apps/website/src/components/notifications/NotificationErrorMessage.tsx
+++ b/apps/website/src/components/notifications/NotificationErrorMessage.tsx
@@ -1,10 +1,12 @@
+import { type ReactNode } from "react";
+
 import { classes } from "@/utils/classes";
 
 export const NotificationErrorMessage = ({
   children,
   className,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
 }) => (
   <div

--- a/apps/website/src/components/notifications/NotificationPermission.tsx
+++ b/apps/website/src/components/notifications/NotificationPermission.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type FC } from "react";
+import { useCallback } from "react";
 
 import {
   isNotificationsSupported,
@@ -12,10 +12,13 @@ import { typeSafeObjectKeys } from "@/utils/helpers";
 
 import { NotificationErrorMessage } from "@/components/notifications/NotificationErrorMessage";
 
-export const NotificationPermission: FC<{
+export const NotificationPermission = ({
+  notificationPermission,
+  updateNotificationPermission,
+}: {
   notificationPermission: NotificationPermission | false;
   updateNotificationPermission: (perm: NotificationPermission) => void;
-}> = ({ notificationPermission, updateNotificationPermission }) => {
+}) => {
   const swr = usePushServiceWorker();
   const handleSubscribeClick = useCallback(() => {
     if (isNotificationsSupported && Notification.permission === "denied") {

--- a/apps/website/src/components/notifications/NotificationPermission.tsx
+++ b/apps/website/src/components/notifications/NotificationPermission.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, type FC } from "react";
 
 import {
   isNotificationsSupported,
@@ -12,7 +12,7 @@ import { typeSafeObjectKeys } from "@/utils/helpers";
 
 import { NotificationErrorMessage } from "@/components/notifications/NotificationErrorMessage";
 
-export const NotificationPermission: React.FC<{
+export const NotificationPermission: FC<{
   notificationPermission: NotificationPermission | false;
   updateNotificationPermission: (perm: NotificationPermission) => void;
 }> = ({ notificationPermission, updateNotificationPermission }) => {

--- a/apps/website/src/components/notifications/NotificationSettings.tsx
+++ b/apps/website/src/components/notifications/NotificationSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 
 import {

--- a/apps/website/src/components/notifications/NotificationsButton.tsx
+++ b/apps/website/src/components/notifications/NotificationsButton.tsx
@@ -1,5 +1,5 @@
 import { Popover, Transition } from "@headlessui/react";
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 import Link from "next/link";
 
 import { classes } from "@/utils/classes";

--- a/apps/website/src/components/shared/AddEventButton.tsx
+++ b/apps/website/src/components/shared/AddEventButton.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 import { Popover } from "@headlessui/react";
 
 import { env } from "@/env/index.mjs";

--- a/apps/website/src/components/shared/Button.tsx
+++ b/apps/website/src/components/shared/Button.tsx
@@ -1,17 +1,16 @@
-import React from "react";
+import { type ReactNode, type ButtonHTMLAttributes } from "react";
 import type { LinkProps } from "next/link";
 import Link from "next/link";
 
 type ButtonStyleProps = {
   className?: string;
-  children: React.ReactNode | string;
+  children: ReactNode | string;
   size?: "default" | "small";
   width?: "full" | "auto";
   confirmationMessage?: string;
 };
 
-type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
-  ButtonStyleProps;
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & ButtonStyleProps;
 type LinkButtonProps = LinkProps & ButtonStyleProps;
 
 const baseClasses =

--- a/apps/website/src/components/shared/LoginWithTwitchButton.tsx
+++ b/apps/website/src/components/shared/LoginWithTwitchButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { signIn } from "next-auth/react";
 import IconTwitch from "../../icons/IconTwitch";
 import { Button } from "./Button";

--- a/apps/website/src/components/shared/PopoverButton.tsx
+++ b/apps/website/src/components/shared/PopoverButton.tsx
@@ -1,5 +1,4 @@
-import type { MouseEventHandler } from "react";
-import { Fragment } from "react";
+import { Fragment, type MouseEventHandler, type ReactNode } from "react";
 import { Popover } from "@headlessui/react";
 import { Button, defaultButtonClasses } from "@/components/shared/Button";
 
@@ -8,8 +7,8 @@ export function PopoverButton({
   label,
   onClick,
 }: {
-  children: React.ReactNode;
-  label: React.ReactNode;
+  children: ReactNode;
+  label: ReactNode;
   onClick?: MouseEventHandler;
 }) {
   return (

--- a/apps/website/src/components/shared/VideoPlatformIcon.tsx
+++ b/apps/website/src/components/shared/VideoPlatformIcon.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import IconStreamable from "@/icons/IconStreamable";
 import IconImgur from "@/icons/IconImgur";
 import IconVideoCamera from "@/icons/IconVideoCamera";

--- a/apps/website/src/components/shared/data/socials.tsx
+++ b/apps/website/src/components/shared/data/socials.tsx
@@ -1,3 +1,5 @@
+import { type ComponentType } from "react";
+
 import IconInstagram from "@/icons/IconInstagram";
 import IconTikTok from "@/icons/IconTikTok";
 import IconTwitter from "@/icons/IconTwitter";
@@ -7,7 +9,7 @@ import IconYouTube from "@/icons/IconYouTube";
 type SocialLink = {
   link: string;
   title: string;
-  icon: React.ComponentType;
+  icon: ComponentType;
 };
 
 const socials = {

--- a/apps/website/src/components/shared/data/updateChannels.tsx
+++ b/apps/website/src/components/shared/data/updateChannels.tsx
@@ -1,9 +1,11 @@
+import { type ComponentType } from "react";
+
 import IconDiscord from "@/icons/IconDiscord";
 
 type UpdateChannelLink = {
   link: string;
   title: string;
-  icon: React.ComponentType;
+  icon: ComponentType;
 };
 
 const updateChannels = {

--- a/apps/website/src/components/shared/form/CheckboxField.tsx
+++ b/apps/website/src/components/shared/form/CheckboxField.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, type ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 import { useCheckbox, type AriaCheckboxProps } from "react-aria";
 import { useToggleState } from "react-stately";
 

--- a/apps/website/src/components/shared/form/FieldGroup.tsx
+++ b/apps/website/src/components/shared/form/FieldGroup.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import { type ReactNode } from "react";
 
 type FieldGroupProps = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 export function FieldGroup({ children }: FieldGroupProps) {

--- a/apps/website/src/components/shared/form/Fieldset.tsx
+++ b/apps/website/src/components/shared/form/Fieldset.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type ReactNode } from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -6,7 +6,7 @@ type FieldsetProps = {
   className?: string;
   legend: string;
   legendClassName?: string;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 export function Fieldset({

--- a/apps/website/src/components/shared/form/ImageUploadAttachment.tsx
+++ b/apps/website/src/components/shared/form/ImageUploadAttachment.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import React from "react";
 
 import { classes } from "@/utils/classes";
 

--- a/apps/website/src/components/shared/form/LocalDateTimeField.tsx
+++ b/apps/website/src/components/shared/form/LocalDateTimeField.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   type ChangeEvent,
   type InputHTMLAttributes,
   type DetailedHTMLProps,
@@ -23,8 +23,8 @@ type DateTimeFieldProps = DetailedHTMLProps<
     label: string;
     className?: string;
     inputClassName?: string;
-    prefix?: React.ReactNode;
-    suffix?: React.ReactNode;
+    prefix?: ReactNode;
+    suffix?: ReactNode;
     showResetButton?: boolean;
   };
 

--- a/apps/website/src/components/shared/form/RichTextField.tsx
+++ b/apps/website/src/components/shared/form/RichTextField.tsx
@@ -1,4 +1,4 @@
-import React, { type LegacyRef, useRef, useState } from "react";
+import { type LegacyRef, useRef, useState } from "react";
 import type { AriaTextFieldOptions } from "react-aria";
 import { useTextField } from "react-aria";
 import dynamic from "next/dynamic";

--- a/apps/website/src/components/shared/form/SelectBoxField.tsx
+++ b/apps/website/src/components/shared/form/SelectBoxField.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode, type SelectHTMLAttributes } from "react";
+import { type ReactNode, type SelectHTMLAttributes } from "react";
 import { useField, type AriaFieldProps } from "react-aria";
 
 import { classes } from "@/utils/classes";

--- a/apps/website/src/components/shared/form/TextAreaField.tsx
+++ b/apps/website/src/components/shared/form/TextAreaField.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from "react";
-import React, { useRef } from "react";
+import { useRef, type ReactNode } from "react";
 import type { AriaTextFieldOptions } from "react-aria";
 import { useTextField } from "react-aria";
 import { default as TextareaAutosize } from "react-textarea-autosize";

--- a/apps/website/src/components/shared/form/TextField.tsx
+++ b/apps/website/src/components/shared/form/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 import type { AriaTextFieldOptions } from "react-aria";
 import { useTextField } from "react-aria";
 
@@ -11,8 +11,8 @@ export type TextFieldProps = AriaTextFieldOptions<"input"> & {
   className?: string;
   inputClassName?: string;
   list?: string;
-  prefix?: React.ReactNode;
-  suffix?: React.ReactNode;
+  prefix?: ReactNode;
+  suffix?: ReactNode;
   showResetButton?: boolean;
 };
 

--- a/apps/website/src/components/shared/form/UploadAttachmentsField.tsx
+++ b/apps/website/src/components/shared/form/UploadAttachmentsField.tsx
@@ -1,4 +1,13 @@
-import React, { useCallback, useId, useReducer, useRef, useState } from "react";
+import {
+  useCallback,
+  useId,
+  useReducer,
+  useRef,
+  useState,
+  type Dispatch,
+  type ChangeEvent,
+  type Key,
+} from "react";
 import { fileToBase64 } from "@/utils/files";
 import IconUploadFiles from "@/icons/IconUploadFiles";
 import { Button, defaultButtonClasses } from "../Button";
@@ -47,14 +56,14 @@ type FailedUploadFileReference = {
 } & UploadFileReference;
 
 export type FileUploadRenderProps = {
-  key: React.Key;
+  key: Key;
   fileReference: FileReference;
   removeFileReference: (id: string) => void;
 };
 
 type FileUploadingPropsType = {
   files: FileReference[];
-  dispatch: React.Dispatch<FileAction>;
+  dispatch: Dispatch<FileAction>;
   upload: (
     file: File,
   ) => Promise<{ viewUrl: string; fileStorageObjectId: string } | false>;
@@ -209,7 +218,7 @@ export const UploadAttachmentsField = ({
   };
 
   const onInputChange = async (
-    e: React.ChangeEvent<HTMLInputElement>,
+    e: ChangeEvent<HTMLInputElement>,
   ): Promise<void> => {
     await addFiles(e.target.files);
     if (inputRef.current) inputRef.current.value = "";

--- a/apps/website/src/components/shared/form/VideoLinksField.tsx
+++ b/apps/website/src/components/shared/form/VideoLinksField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import { parseVideoUrl } from "@/utils/video-urls";
 import IconTrash from "@/icons/IconTrash";
 import IconPlus from "@/icons/IconPlus";

--- a/apps/website/src/components/shared/hooks/useFileDragAndDrop.ts
+++ b/apps/website/src/components/shared/hooks/useFileDragAndDrop.ts
@@ -1,16 +1,16 @@
-import { useState } from "react";
+import { useState, type DragEvent } from "react";
 
 export function useFileDragAndDrop(
   addFiles: (filesToAdd: FileList | null) => Promise<void>,
 ) {
   const [isDragging, setIsDragging] = useState<boolean>(false);
 
-  const handleDrag = (e: React.DragEvent<HTMLElement>) => {
+  const handleDrag = (e: DragEvent<HTMLElement>) => {
     e.preventDefault();
     e.stopPropagation();
   };
 
-  const handleDragIn = (e: React.DragEvent<HTMLElement>) => {
+  const handleDragIn = (e: DragEvent<HTMLElement>) => {
     e.preventDefault();
     e.stopPropagation();
     if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
@@ -18,13 +18,13 @@ export function useFileDragAndDrop(
     }
   };
 
-  const handleDragOut = (e: React.DragEvent<HTMLElement>) => {
+  const handleDragOut = (e: DragEvent<HTMLElement>) => {
     e.preventDefault();
     e.stopPropagation();
     setIsDragging(false);
   };
 
-  const handleDrop = async (e: React.DragEvent<HTMLElement>) => {
+  const handleDrop = async (e: DragEvent<HTMLElement>) => {
     e.preventDefault();
     e.stopPropagation();
     setIsDragging(false);
@@ -33,7 +33,7 @@ export function useFileDragAndDrop(
     }
   };
 
-  const handleDragStart = (e: React.DragEvent<HTMLElement>) => {
+  const handleDragStart = (e: DragEvent<HTMLElement>) => {
     e.preventDefault();
     e.stopPropagation();
     e.dataTransfer.clearData();

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   forwardRef,
   Fragment,
   isValidElement,

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/router";
 
 import type { ShowAndTellSubmitInput } from "@/server/db/show-and-tell";
@@ -92,7 +92,7 @@ export function ShowAndTellEntryForm({
     { allowedFileTypes },
   );
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
     const data: ShowAndTellSubmitInput = {

--- a/apps/website/src/components/show-and-tell/ShowAndTellNavigation.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellNavigation.tsx
@@ -1,26 +1,31 @@
 import type { LinkProps } from "next/link";
 import Link from "next/link";
-import React from "react";
+import {
+  type AnchorHTMLAttributes,
+  type RefAttributes,
+  type ReactNode,
+  type FC,
+} from "react";
 
 import { classes } from "@/utils/classes";
 
 import { useIsActivePath } from "@/components/shared/hooks/useIsActivePath";
 
 type NavLinkProps = Omit<
-  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  AnchorHTMLAttributes<HTMLAnchorElement>,
   keyof LinkProps
 > &
   LinkProps & {
-    children?: React.ReactNode;
+    children?: ReactNode;
     exact?: boolean;
-  } & React.RefAttributes<HTMLAnchorElement>;
+  } & RefAttributes<HTMLAnchorElement>;
 
 const navLinkClassesActive = "bg-alveus-tan text-alveus-green";
 const navLinkClassesHover = "hover:bg-alveus-tan hover:text-alveus-green";
 const navLinkClasses =
   "rounded-full text-center border-2 border-alveus-tan text-base px-2 py-1 md:px-4 md:py-2 md:text-lg transition-colors transition-colors";
 
-const NavLink: React.FC<NavLinkProps> = ({
+const NavLink: FC<NavLinkProps> = ({
   href,
   exact = false,
   className,

--- a/apps/website/src/components/show-and-tell/ShowAndTellNavigation.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellNavigation.tsx
@@ -4,7 +4,6 @@ import {
   type AnchorHTMLAttributes,
   type RefAttributes,
   type ReactNode,
-  type FC,
 } from "react";
 
 import { classes } from "@/utils/classes";
@@ -25,12 +24,12 @@ const navLinkClassesHover = "hover:bg-alveus-tan hover:text-alveus-green";
 const navLinkClasses =
   "rounded-full text-center border-2 border-alveus-tan text-base px-2 py-1 md:px-4 md:py-2 md:text-lg transition-colors transition-colors";
 
-const NavLink: FC<NavLinkProps> = ({
+const NavLink = ({
   href,
   exact = false,
   className,
   ...props
-}) => {
+}: NavLinkProps) => {
   const isActive = useIsActivePath(href, exact);
 
   return (

--- a/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
@@ -1,5 +1,5 @@
 import type { MouseEventHandler, MutableRefObject } from "react";
-import React, { useCallback, useEffect, useId, useMemo, useRef } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef } from "react";
 import PhotoSwipeLightbox from "photoswipe/lightbox";
 import Image from "next/image";
 

--- a/apps/website/src/components/show-and-tell/gallery/VideoItem.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/VideoItem.tsx
@@ -1,5 +1,5 @@
 import type { LinkAttachment } from "@prisma/client";
-import React from "react";
+import { type AnchorHTMLAttributes } from "react";
 
 import { parseVideoUrl, videoPlatformConfigs } from "@/utils/video-urls";
 import { createImageUrl } from "@/utils/image";
@@ -13,7 +13,7 @@ type VideoThumbnailProps = {
   showPreview?: boolean;
   openInLightbox?: boolean;
   linkAttributes?: Record<string, unknown> &
-    React.AnchorHTMLAttributes<HTMLAnchorElement>;
+    AnchorHTMLAttributes<HTMLAnchorElement>;
 };
 
 export function VideoItem({

--- a/apps/website/src/components/tech/Network.tsx
+++ b/apps/website/src/components/tech/Network.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, type FC } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   Handle,
   Position,
@@ -65,13 +65,13 @@ const nodeTypes: {
   },
 };
 
-const NetworkNode: FC<NodeProps<Data>> = ({
+const NetworkNode = ({
   id,
   data,
   targetPosition = Position.Top,
   sourcePosition = Position.Bottom,
   isConnectable,
-}) => {
+}: NodeProps<Data>) => {
   // Get the source and target edges
   const edges = useEdges();
   let targetEdge, sourceEdge;
@@ -178,7 +178,7 @@ const edgeTypes: {
   },
 };
 
-const NetworkEdge: FC<EdgeProps> = ({
+const NetworkEdge = ({
   source,
   sourceX,
   sourceY,
@@ -187,7 +187,7 @@ const NetworkEdge: FC<EdgeProps> = ({
   targetX,
   targetY,
   targetPosition,
-}) => {
+}: EdgeProps) => {
   // Get the source and target nodes
   const nodes = useNodes<Data>();
   let sourceNode, targetNode;
@@ -288,9 +288,12 @@ const NetworkEdge: FC<EdgeProps> = ({
   );
 };
 
-const NetworkList: FC<{ items: NetworkItem[]; className?: string }> = ({
+const NetworkList = ({
   items,
   className,
+}: {
+  items: NetworkItem[];
+  className?: string;
 }) => (
   <ul className={className}>
     {items.map((item) => (

--- a/apps/website/src/components/tech/Network.tsx
+++ b/apps/website/src/components/tech/Network.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState, type FC } from "react";
 import {
   Handle,
   Position,
@@ -65,7 +65,7 @@ const nodeTypes: {
   },
 };
 
-const NetworkNode: React.FC<NodeProps<Data>> = ({
+const NetworkNode: FC<NodeProps<Data>> = ({
   id,
   data,
   targetPosition = Position.Top,
@@ -178,7 +178,7 @@ const edgeTypes: {
   },
 };
 
-const NetworkEdge: React.FC<EdgeProps> = ({
+const NetworkEdge: FC<EdgeProps> = ({
   source,
   sourceX,
   sourceY,
@@ -288,7 +288,7 @@ const NetworkEdge: React.FC<EdgeProps> = ({
   );
 };
 
-const NetworkList: React.FC<{ items: NetworkItem[]; className?: string }> = ({
+const NetworkList: FC<{ items: NetworkItem[]; className?: string }> = ({
   items,
   className,
 }) => (

--- a/apps/website/src/components/tech/Tree.tsx
+++ b/apps/website/src/components/tech/Tree.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import type { Node as DagreNode } from "dagre";
 import { graphlib, layout } from "dagre";
 import {

--- a/apps/website/src/hooks/consent.tsx
+++ b/apps/website/src/hooks/consent.tsx
@@ -7,7 +7,6 @@ import {
   useMemo,
   forwardRef,
   useRef,
-  type FC,
   type ReactNode,
   type Ref,
 } from "react";
@@ -96,12 +95,15 @@ declare global {
 
 const Context = createContext<ConsentContext | undefined>(undefined);
 
-const ConsentButton: FC<{
-  onClick: () => void;
-  children: ReactNode;
-  disabled?: boolean;
-  ref?: Ref<HTMLButtonElement>;
-}> = forwardRef(({ onClick, children, disabled }, ref) => (
+const ConsentButton = forwardRef<
+  HTMLButtonElement,
+  {
+    onClick: () => void;
+    children: ReactNode;
+    disabled?: boolean;
+    ref?: Ref<HTMLButtonElement>;
+  }
+>(({ onClick, children, disabled }, ref) => (
   <button
     type="button"
     className={[
@@ -119,7 +121,7 @@ const ConsentButton: FC<{
 ));
 ConsentButton.displayName = "ConsentButton";
 
-const ConsentDialog: FC<{ context: ConsentContext }> = ({ context }) => {
+const ConsentDialog = ({ context }: { context: ConsentContext }) => {
   const { consent, update, reset, loaded, interacted } = context;
   const router = useRouter();
 
@@ -314,7 +316,7 @@ const ConsentDialog: FC<{ context: ConsentContext }> = ({ context }) => {
   );
 };
 
-export const ConsentProvider: FC<{ children: ReactNode }> = ({ children }) => {
+export const ConsentProvider = ({ children }: { children: ReactNode }) => {
   const [loaded, setLoaded] = useState(false);
   const [interacted, setInteracted] = useState(false);
   const [consent, setConsent] = useState<Consent>(defaultConsent);

--- a/apps/website/src/hooks/consent.tsx
+++ b/apps/website/src/hooks/consent.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useCallback,
   useEffect,
   useState,
@@ -7,6 +7,9 @@ import React, {
   useMemo,
   forwardRef,
   useRef,
+  type FC,
+  type ReactNode,
+  type Ref,
 } from "react";
 import { useRouter } from "next/router";
 import { Dialog } from "@headlessui/react";
@@ -93,11 +96,11 @@ declare global {
 
 const Context = createContext<ConsentContext | undefined>(undefined);
 
-const ConsentButton: React.FC<{
+const ConsentButton: FC<{
   onClick: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
   disabled?: boolean;
-  ref?: React.Ref<HTMLButtonElement>;
+  ref?: Ref<HTMLButtonElement>;
 }> = forwardRef(({ onClick, children, disabled }, ref) => (
   <button
     type="button"
@@ -116,7 +119,7 @@ const ConsentButton: React.FC<{
 ));
 ConsentButton.displayName = "ConsentButton";
 
-const ConsentDialog: React.FC<{ context: ConsentContext }> = ({ context }) => {
+const ConsentDialog: FC<{ context: ConsentContext }> = ({ context }) => {
   const { consent, update, reset, loaded, interacted } = context;
   const router = useRouter();
 
@@ -311,9 +314,7 @@ const ConsentDialog: React.FC<{ context: ConsentContext }> = ({ context }) => {
   );
 };
 
-export const ConsentProvider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
+export const ConsentProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [loaded, setLoaded] = useState(false);
   const [interacted, setInteracted] = useState(false);
   const [consent, setConsent] = useState<Consent>(defaultConsent);

--- a/apps/website/src/icons/BaseIcon.tsx
+++ b/apps/website/src/icons/BaseIcon.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import { type SVGProps, type ReactNode } from "react";
 
-export type IconProps = React.SVGProps<SVGSVGElement> & {
+export type IconProps = SVGProps<SVGSVGElement> & {
   size?: number | string;
   className?: string;
   alt?: string;
@@ -8,7 +8,7 @@ export type IconProps = React.SVGProps<SVGSVGElement> & {
 
 export type BaseIconProps = IconProps & {
   viewBox: string;
-  children: React.ReactNode | React.ReactNode[];
+  children: ReactNode | ReactNode[];
 };
 
 export function BaseIcon({

--- a/apps/website/src/pages/404.tsx
+++ b/apps/website/src/pages/404.tsx
@@ -1,5 +1,4 @@
 import { type NextPage } from "next";
-import React from "react";
 
 import Heading from "@/components/content/Heading";
 import Meta from "@/components/content/Meta";

--- a/apps/website/src/pages/about/advisory-board.tsx
+++ b/apps/website/src/pages/about/advisory-board.tsx
@@ -1,5 +1,4 @@
 import { type NextPage } from "next";
-import React from "react";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";

--- a/apps/website/src/pages/about/alveus.tsx
+++ b/apps/website/src/pages/about/alveus.tsx
@@ -1,6 +1,6 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import React from "react";
+import { type ReactNode } from "react";
 import type { PartialDateString } from "@alveusgg/data/src/types";
 
 import { formatPartialDateString } from "@/utils/datetime";
@@ -78,7 +78,7 @@ const stats: Record<string, Stat> = {
   },
 } as const;
 
-type HistoryCTA = { key: string; cta: React.ReactNode };
+type HistoryCTA = { key: string; cta: ReactNode };
 type HistoryItem = {
   key: string;
   date: PartialDateString;

--- a/apps/website/src/pages/about/annual-reports/2021.tsx
+++ b/apps/website/src/pages/about/annual-reports/2021.tsx
@@ -1,7 +1,6 @@
 import { type NextPage } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import React from "react";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";

--- a/apps/website/src/pages/about/annual-reports/index.tsx
+++ b/apps/website/src/pages/about/annual-reports/index.tsx
@@ -1,6 +1,5 @@
 import { type NextPage } from "next";
 import Link from "next/link";
-import React from "react";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";

--- a/apps/website/src/pages/about/board-of-directors.tsx
+++ b/apps/website/src/pages/about/board-of-directors.tsx
@@ -1,5 +1,4 @@
 import { type NextPage } from "next";
-import React from "react";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";

--- a/apps/website/src/pages/about/maya.tsx
+++ b/apps/website/src/pages/about/maya.tsx
@@ -1,6 +1,5 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import React from "react";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";

--- a/apps/website/src/pages/about/staff.tsx
+++ b/apps/website/src/pages/about/staff.tsx
@@ -1,6 +1,5 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import React from "react";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";

--- a/apps/website/src/pages/about/tech.tsx
+++ b/apps/website/src/pages/about/tech.tsx
@@ -1,6 +1,6 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import React from "react";
+import { type FC } from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -280,12 +280,7 @@ type ListProps = {
   dark?: boolean;
 };
 
-const List: React.FC<ListProps> = ({
-  items,
-  className,
-  itemClassName,
-  dark,
-}) => (
+const List: FC<ListProps> = ({ items, className, itemClassName, dark }) => (
   <ul className={className}>
     {Object.entries(items).map(([key, item], idx) => (
       <li

--- a/apps/website/src/pages/about/tech.tsx
+++ b/apps/website/src/pages/about/tech.tsx
@@ -1,6 +1,5 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import { type FC } from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -280,7 +279,7 @@ type ListProps = {
   dark?: boolean;
 };
 
-const List: FC<ListProps> = ({ items, className, itemClassName, dark }) => (
+const List = ({ items, className, itemClassName, dark }: ListProps) => (
   <ul className={className}>
     {Object.entries(items).map(([key, item], idx) => (
       <li

--- a/apps/website/src/pages/admin/activity-feed.tsx
+++ b/apps/website/src/pages/admin/activity-feed.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 import type { InferGetStaticPropsType, NextPage, NextPageContext } from "next";
 
 import { trpc } from "@/utils/trpc";

--- a/apps/website/src/pages/admin/dashboard.tsx
+++ b/apps/website/src/pages/admin/dashboard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { InferGetStaticPropsType, NextPageContext, NextPage } from "next";
 
 import { getAdminSSP } from "@/server/utils/admin";

--- a/apps/website/src/pages/admin/forms/[formId]/edit.tsx
+++ b/apps/website/src/pages/admin/forms/[formId]/edit.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type {
   InferGetStaticPropsType,
   NextPage,

--- a/apps/website/src/pages/admin/forms/create.tsx
+++ b/apps/website/src/pages/admin/forms/create.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { InferGetStaticPropsType, NextPageContext, NextPage } from "next";
 
 import { getAdminSSP } from "@/server/utils/admin";

--- a/apps/website/src/pages/admin/forms/index.tsx
+++ b/apps/website/src/pages/admin/forms/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { InferGetStaticPropsType, NextPageContext, NextPage } from "next";
 
 import { getAdminSSP } from "@/server/utils/admin";

--- a/apps/website/src/pages/admin/notifications.tsx
+++ b/apps/website/src/pages/admin/notifications.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { InferGetStaticPropsType, NextPageContext, NextPage } from "next";
 
 import { getAdminSSP } from "@/server/utils/admin";

--- a/apps/website/src/pages/admin/show-and-tell/index.tsx
+++ b/apps/website/src/pages/admin/show-and-tell/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { InferGetStaticPropsType, NextPage, NextPageContext } from "next";
 
 import { getAdminSSP } from "@/server/utils/admin";

--- a/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
+++ b/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { NextPage, NextPageContext, InferGetStaticPropsType } from "next";
 import { useRouter } from "next/router";
 

--- a/apps/website/src/pages/admin/show-and-tell/review/[entryId]/preview.tsx
+++ b/apps/website/src/pages/admin/show-and-tell/review/[entryId]/preview.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { NextPage, NextPageContext, InferGetStaticPropsType } from "next";
 import { useRouter } from "next/router";
 

--- a/apps/website/src/pages/admin/twitch/[channelId]/edit.tsx
+++ b/apps/website/src/pages/admin/twitch/[channelId]/edit.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type {
   InferGetStaticPropsType,
   NextPage,

--- a/apps/website/src/pages/admin/twitch/create.tsx
+++ b/apps/website/src/pages/admin/twitch/create.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { InferGetStaticPropsType, NextPageContext, NextPage } from "next";
 
 import { permissions } from "@/config/permissions";

--- a/apps/website/src/pages/admin/twitch/index.tsx
+++ b/apps/website/src/pages/admin/twitch/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { InferGetStaticPropsType, NextPageContext, NextPage } from "next";
 
 import { permissions } from "@/config/permissions";

--- a/apps/website/src/pages/admin/users.tsx
+++ b/apps/website/src/pages/admin/users.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useId, useState } from "react";
+import { useCallback, useId, useState } from "react";
 import type { InferGetStaticPropsType, NextPage, NextPageContext } from "next";
 
 import { trpc } from "@/utils/trpc";

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -1,7 +1,7 @@
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Image from "next/image";
 import PhotoSwipeLightbox from "photoswipe/lightbox";
-import React, { useEffect, useId, useMemo, Fragment } from "react";
+import { useEffect, useId, useMemo, Fragment } from "react";
 
 import ambassadors, {
   type Ambassador,

--- a/apps/website/src/pages/ambassadors/index.tsx
+++ b/apps/website/src/pages/ambassadors/index.tsx
@@ -6,7 +6,6 @@ import {
   useEffect,
   useMemo,
   useState,
-  type FC,
   type ComponentProps,
 } from "react";
 
@@ -125,10 +124,13 @@ const isSortByOption = (option: string): option is SortByOption =>
 export const ambassadorImageHover =
   "transition group-hover:scale-102 group-hover:shadow-lg group-hover:brightness-105 group-hover:contrast-115 group-hover:saturate-110";
 
-const AmbassadorItem: FC<{
+const AmbassadorItem = ({
+  ambassador,
+  level = 2,
+}: {
   ambassador: AmbassadorKey;
   level?: ComponentProps<typeof Heading>["level"];
-}> = ({ ambassador, level = 2 }) => {
+}) => {
   const data = useMemo(() => ambassadors[ambassador], [ambassador]);
   const images = useMemo(() => getAmbassadorImages(ambassador), [ambassador]);
 
@@ -157,11 +159,15 @@ const AmbassadorItem: FC<{
   );
 };
 
-const AmbassadorItems: FC<{
+const AmbassadorItems = ({
+  ambassadors,
+  className,
+  level,
+}: {
   ambassadors: AmbassadorKey[];
   className?: string;
   level?: ComponentProps<typeof Heading>["level"];
-}> = ({ ambassadors, className, level }) => (
+}) => (
   <div
     className={classes(
       "grid gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4",
@@ -174,13 +180,19 @@ const AmbassadorItems: FC<{
   </div>
 );
 
-const AmbassadorGroup: FC<{
+const AmbassadorGroup = ({
+  type,
+  group,
+  name,
+  ambassadors,
+  active = false,
+}: {
   type: string;
   group: string;
   name: string;
   ambassadors: AmbassadorKey[];
   active?: boolean;
-}> = ({ type, group, name, ambassadors, active = false }) => {
+}) => {
   // If this group is the "active" one in the URL, scroll it into view
   const scroll = useCallback(
     (node: HTMLDivElement | null) => {

--- a/apps/website/src/pages/ambassadors/index.tsx
+++ b/apps/website/src/pages/ambassadors/index.tsx
@@ -1,7 +1,14 @@
 import { type NextPage } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FC,
+  type ComponentProps,
+} from "react";
 
 import ambassadors, {
   type AmbassadorKey,
@@ -118,9 +125,9 @@ const isSortByOption = (option: string): option is SortByOption =>
 export const ambassadorImageHover =
   "transition group-hover:scale-102 group-hover:shadow-lg group-hover:brightness-105 group-hover:contrast-115 group-hover:saturate-110";
 
-const AmbassadorItem: React.FC<{
+const AmbassadorItem: FC<{
   ambassador: AmbassadorKey;
-  level?: React.ComponentProps<typeof Heading>["level"];
+  level?: ComponentProps<typeof Heading>["level"];
 }> = ({ ambassador, level = 2 }) => {
   const data = useMemo(() => ambassadors[ambassador], [ambassador]);
   const images = useMemo(() => getAmbassadorImages(ambassador), [ambassador]);
@@ -150,10 +157,10 @@ const AmbassadorItem: React.FC<{
   );
 };
 
-const AmbassadorItems: React.FC<{
+const AmbassadorItems: FC<{
   ambassadors: AmbassadorKey[];
   className?: string;
-  level?: React.ComponentProps<typeof Heading>["level"];
+  level?: ComponentProps<typeof Heading>["level"];
 }> = ({ ambassadors, className, level }) => (
   <div
     className={classes(
@@ -167,7 +174,7 @@ const AmbassadorItems: React.FC<{
   </div>
 );
 
-const AmbassadorGroup: React.FC<{
+const AmbassadorGroup: FC<{
   type: string;
   group: string;
   name: string;

--- a/apps/website/src/pages/animal-quest/[episodeName].tsx
+++ b/apps/website/src/pages/animal-quest/[episodeName].tsx
@@ -1,6 +1,6 @@
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Image from "next/image";
-import React, { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 
 import animalQuest, {
   hosts,

--- a/apps/website/src/pages/animal-quest/index.tsx
+++ b/apps/website/src/pages/animal-quest/index.tsx
@@ -1,6 +1,6 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import React, { Fragment } from "react";
+import { Fragment, type FC } from "react";
 
 import animalQuest, {
   type AnimalQuestWithEpisode,
@@ -39,7 +39,7 @@ type AnimalQuestSectionProps = {
   items: AnimalQuestWithEpisode[];
 };
 
-const AnimalQuestSection: React.FC<AnimalQuestSectionProps> = ({ items }) => {
+const AnimalQuestSection: FC<AnimalQuestSectionProps> = ({ items }) => {
   return (
     <div className="flex flex-wrap">
       {items.map((episode) => (

--- a/apps/website/src/pages/animal-quest/index.tsx
+++ b/apps/website/src/pages/animal-quest/index.tsx
@@ -1,6 +1,6 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import { Fragment, type FC } from "react";
+import { Fragment } from "react";
 
 import animalQuest, {
   type AnimalQuestWithEpisode,
@@ -39,7 +39,7 @@ type AnimalQuestSectionProps = {
   items: AnimalQuestWithEpisode[];
 };
 
-const AnimalQuestSection: FC<AnimalQuestSectionProps> = ({ items }) => {
+const AnimalQuestSection = ({ items }: AnimalQuestSectionProps) => {
   return (
     <div className="flex flex-wrap">
       {items.map((episode) => (

--- a/apps/website/src/pages/auth/signin.tsx
+++ b/apps/website/src/pages/auth/signin.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type {
   InferGetServerSidePropsType,
   NextPage,

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -1,6 +1,6 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import React from "react";
+import { type FC } from "react";
 
 import { formatDateTime } from "@/utils/datetime";
 import { camelToKebab } from "@/utils/string-case";
@@ -172,9 +172,7 @@ type CollaborationsSectionProps = {
   items: Collaborations;
 };
 
-const CollaborationsSection: React.FC<CollaborationsSectionProps> = ({
-  items,
-}) => {
+const CollaborationsSection: FC<CollaborationsSectionProps> = ({ items }) => {
   return (
     <Lightbox id="collaborations" className="flex flex-wrap">
       {({ Trigger }) => (

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -1,6 +1,5 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import { type FC } from "react";
 
 import { formatDateTime } from "@/utils/datetime";
 import { camelToKebab } from "@/utils/string-case";
@@ -172,7 +171,7 @@ type CollaborationsSectionProps = {
   items: Collaborations;
 };
 
-const CollaborationsSection: FC<CollaborationsSectionProps> = ({ items }) => {
+const CollaborationsSection = ({ items }: CollaborationsSectionProps) => {
   return (
     <Lightbox id="collaborations" className="flex flex-wrap">
       {({ Trigger }) => (

--- a/apps/website/src/pages/contact-us.tsx
+++ b/apps/website/src/pages/contact-us.tsx
@@ -1,5 +1,4 @@
 import { type NextPage } from "next";
-import React from "react";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";

--- a/apps/website/src/pages/donate.tsx
+++ b/apps/website/src/pages/donate.tsx
@@ -1,6 +1,6 @@
 import { type NextPage } from "next";
 import Link from "next/link";
-import React from "react";
+import { type ComponentType, type FC } from "react";
 
 import { useConsent } from "@/hooks/consent";
 
@@ -17,7 +17,7 @@ import IconBitcoin from "@/icons/IconBitcoin";
 import { type IconProps } from "@/icons/BaseIcon";
 
 type DonateLink = {
-  icon: React.ComponentType<IconProps>;
+  icon: ComponentType<IconProps>;
   title: string;
   link: string;
   external: boolean;
@@ -60,7 +60,7 @@ const givingBlock: DonateLink = {
     "Donate cryptocurrency, stocks or via card to Alveus using The Giving Block.",
 };
 
-const DonateItem: React.FC<{ link: DonateLink }> = ({ link }) => (
+const DonateItem: FC<{ link: DonateLink }> = ({ link }) => (
   <Link
     href={link.link}
     {...(link.external ? { target: "_blank", rel: "noreferrer" } : {})}

--- a/apps/website/src/pages/donate.tsx
+++ b/apps/website/src/pages/donate.tsx
@@ -1,6 +1,6 @@
 import { type NextPage } from "next";
 import Link from "next/link";
-import { type ComponentType, type FC } from "react";
+import { type ComponentType } from "react";
 
 import { useConsent } from "@/hooks/consent";
 
@@ -60,7 +60,7 @@ const givingBlock: DonateLink = {
     "Donate cryptocurrency, stocks or via card to Alveus using The Giving Block.",
 };
 
-const DonateItem: FC<{ link: DonateLink }> = ({ link }) => (
+const DonateItem = ({ link }: { link: DonateLink }) => (
   <Link
     href={link.link}
     {...(link.external ? { target: "_blank", rel: "noreferrer" } : {})}

--- a/apps/website/src/pages/events.tsx
+++ b/apps/website/src/pages/events.tsx
@@ -1,6 +1,6 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import React from "react";
+import { type ReactNode } from "react";
 
 import { formatDateTime } from "@/utils/datetime";
 import { camelToKebab } from "@/utils/string-case";
@@ -28,7 +28,7 @@ type Event = {
   date: Date;
   video: Video;
   stats: Record<string, { title: string; stat: string }>;
-  info: React.ReactNode;
+  info: ReactNode;
 };
 
 const events = {

--- a/apps/website/src/pages/forms/[formId]/index.tsx
+++ b/apps/website/src/pages/forms/[formId]/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type {
   NextPage,
   InferGetServerSidePropsType,

--- a/apps/website/src/pages/forms/[formId]/rules.tsx
+++ b/apps/website/src/pages/forms/[formId]/rules.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type {
   GetServerSideProps,
   InferGetServerSidePropsType,

--- a/apps/website/src/pages/forms/index.tsx
+++ b/apps/website/src/pages/forms/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { NextPage, GetStaticProps, InferGetStaticPropsType } from "next";
 import Link from "next/link";
 

--- a/apps/website/src/pages/found-animal.tsx
+++ b/apps/website/src/pages/found-animal.tsx
@@ -1,5 +1,5 @@
 import { type NextPage } from "next";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import Image from "next/image";
 import Section from "@/components/content/Section";

--- a/apps/website/src/pages/notifications/[notificationId].tsx
+++ b/apps/website/src/pages/notifications/[notificationId].tsx
@@ -4,7 +4,7 @@ import type {
   NextPage,
 } from "next";
 
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 
 import { useRouter } from "next/router";
 import Section from "@/components/content/Section";

--- a/apps/website/src/pages/po-box.tsx
+++ b/apps/website/src/pages/po-box.tsx
@@ -1,6 +1,5 @@
 import { type NextPage } from "next";
 import Link from "next/link";
-import React from "react";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";

--- a/apps/website/src/pages/privacy-policy.tsx
+++ b/apps/website/src/pages/privacy-policy.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { type NextPage } from "next";
 
 import privacyPolicy from "@/data/privacy-policy.md";

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -1,10 +1,11 @@
-import type { KeyboardEventHandler } from "react";
-import React, {
+import {
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
+  type WheelEvent,
+  type KeyboardEventHandler,
 } from "react";
 import type { InferGetStaticPropsType, NextPage } from "next";
 import Image from "next/image";
@@ -183,7 +184,7 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
   const scrollDebounce = 250; // Milliseconds to wait before snapping
   const scrollThreshold = 0.1; // multiplier of the viewport height
   const onScroll = useCallback(
-    (e: React.WheelEvent<HTMLDivElement>) => {
+    (e: WheelEvent<HTMLDivElement>) => {
       // Ignore the event if we're not in presentation view,
       // or if we're not currently on an entry,
       // or if the user isn't scrolling

--- a/apps/website/src/pages/show-and-tell/my-posts/[postId]/index.tsx
+++ b/apps/website/src/pages/show-and-tell/my-posts/[postId]/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
 import Meta from "@/components/content/Meta";

--- a/apps/website/src/pages/show-and-tell/my-posts/[postId]/preview.tsx
+++ b/apps/website/src/pages/show-and-tell/my-posts/[postId]/preview.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
 

--- a/apps/website/src/pages/show-and-tell/my-posts/index.tsx
+++ b/apps/website/src/pages/show-and-tell/my-posts/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { NextPage } from "next";
 import { useSession } from "next-auth/react";
 import Image from "next/image";

--- a/apps/website/src/pages/show-and-tell/posts/[postId]/index.tsx
+++ b/apps/website/src/pages/show-and-tell/posts/[postId]/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type {
   GetStaticPropsContext,
   InferGetStaticPropsType,

--- a/apps/website/src/pages/show-and-tell/submit-post.tsx
+++ b/apps/website/src/pages/show-and-tell/submit-post.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import type { NextPage } from "next";
 import { useSession } from "next-auth/react";
 import Section from "@/components/content/Section";


### PR DESCRIPTION
## Describe your changes

We shouldn't need to be importing React into every JSX context as Next.js uses the modern react-jsx transform (it would've also handled importing React for us anyway prior to this afaik).

The use of React.FC is also discouraged, with the preferred approach just being to let the typing be implied from the functional components themselves, so this removes all usage of the FC type.

## Notes for testing your change

Everything builds, all React imports and FC usages cleaned up.