### PR TITLE
Restrict TheGivingBlock embed width to full

### DIFF
--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -9,13 +9,13 @@ const TheGivingBlockEmbed = () => {
   }, []);
 
   return (
-    <>
+    <div className="inline-block [&>*]:max-w-full">
       <div id="tgb-widget-script"></div>
       <Script
         src="https://widget.thegivingblock.com/widget/script.js"
         async={true}
       ></Script>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Describe your changes

Resolves #389

## Notes for testing your change

On small viewports, the giving block embed is restricted to the width of the page and does not overflow the page.