### PR TITLE
Wait for images to load before animating slideshow

### DIFF
--- a/apps/website/src/components/content/Slideshow.tsx
+++ b/apps/website/src/components/content/Slideshow.tsx
@@ -10,6 +10,7 @@ import {
 
 import { camelToKebab } from "@/utils/string-case";
 import { createImageUrl, type ImageLoaderProps } from "@/utils/image";
+import { classes } from "@/utils/classes";
 
 type SlideshowProps = {
   images: {
@@ -109,16 +110,13 @@ const Slideshow = ({
     return createImageUrl({ ...props, quality });
   }, []);
 
-  // Wait until the first two images have loaded before starting the animation
+  // Stagger the images loading in, and animate once the first two are loaded
   const [loaded, setLoaded] = useState(new Set());
   const handleLoad = useCallback(
     (idx: number) => setLoaded((current) => new Set(current).add(idx)),
     [],
   );
-  const ready = useMemo(
-    () => loaded.has(0) && (loaded.has(1) || images.length === 1),
-    [loaded, images.length],
-  );
+  const ready = loaded.has(0) && loaded.has(1);
 
   return (
     <div className="relative z-0 h-full w-full">
@@ -157,7 +155,10 @@ const Slideshow = ({
             priority={idx === 0}
             onLoadingComplete={() => handleLoad(idx)}
             placeholder="blur"
-            className="h-full w-full object-cover"
+            className={classes(
+              "h-full w-full object-cover",
+              idx !== 0 && !loaded.has(idx - 1) && "hidden",
+            )}
             style={{
               animationDelay: `${idx * animation.duration.offset}ms`,
               animationPlayState: ready ? "running" : "paused",

--- a/apps/website/src/components/content/Slideshow.tsx
+++ b/apps/website/src/components/content/Slideshow.tsx
@@ -127,8 +127,8 @@ const Slideshow = ({
           __html: [
             `@keyframes slideshow-${id}-container { ${animation.keyframes.container} }`,
             `@keyframes slideshow-${id}-image { ${animation.keyframes.image} }`,
-            `.slideshow-${id}-container { animation: ${animation.duration.total}ms slideshow-${id}-container infinite; will-change: opacity, z-index; }`,
-            `.slideshow-${id}-container img { animation: ${animation.duration.total}ms slideshow-${id}-image infinite; transform: scale(${scale.from}); will-change: transform; }`,
+            `.slideshow-${id}-container { animation: ${animation.duration.total}ms slideshow-${id}-container infinite; }`,
+            `.slideshow-${id}-container img { animation: ${animation.duration.total}ms slideshow-${id}-image infinite; transform: scale(${scale.from}); }`,
             `@media (prefers-reduced-motion) { .slideshow-${id}-container img { animation-play-state: paused !important; } }`,
           ].join("\n"),
         }}

--- a/apps/website/src/components/content/Slideshow.tsx
+++ b/apps/website/src/components/content/Slideshow.tsx
@@ -110,12 +110,15 @@ const Slideshow = ({
   }, []);
 
   // Wait until the first two images have loaded before starting the animation
-  const [loaded, setLoaded] = useState(-1);
+  const [loaded, setLoaded] = useState(new Set());
   const handleLoad = useCallback(
-    (idx: number) => setLoaded((current) => Math.max(current, idx)),
+    (idx: number) => setLoaded((current) => new Set(current).add(idx)),
     [],
   );
-  const ready = loaded >= 1;
+  const ready = useMemo(
+    () => loaded.has(0) && (loaded.has(1) || images.length === 1),
+    [loaded, images.length],
+  );
 
   return (
     <div className="relative z-0 h-full w-full">


### PR DESCRIPTION
## Describe your changes

While the slideshow seemed to behave great in Chrome, in Firefox I had noticed it sometimes really struggles if the images aren't cached, trying to render and animate the images at the same time.

This PR updates the logic in the slideshow, making use of the [`onLoadingComplete`](https://nextjs.org/docs/pages/api-reference/components/image#onloadingcomplete) prop from `next/image`, to require that the first two images of the slideshow have loaded fully before we start the animation that will transition between them. Hopefully, before we get to the third image and so on they've had time to naturally load.

This also removes the `will-change` declarations for the animations, as it appears this was also causing issues with Firefox due to it trying to allocate too much memory for all the images. Instead, we'll just let the browser figure out what to optimize.

## Notes for testing your change

In both Chrome and Firefox, the homepage slideshow continues to visually look correct, and doesn't appear to stress the browser out.