### PR TITLE
feat: limit container width to xl

### DIFF
--- a/apps/website/src/styles/globals.css
+++ b/apps/website/src/styles/globals.css
@@ -19,6 +19,11 @@
 }
 
 @layer components {
+  .container {
+    @apply 2xl:max-w-screen-xl;
+  }
+
+
   details > summary {
     list-style: none;
   }


### PR DESCRIPTION
## Describe your changes

Limits all containers to XL width (1280px). Resolves #394

## Notes for testing your change

Click through the pages and see if it improves the readability while still looking good
