### PR TITLE
Do not escape fuzzy links for discord

### DIFF
--- a/apps/website/__tests__/discord.test.ts
+++ b/apps/website/__tests__/discord.test.ts
@@ -10,20 +10,31 @@ test("wrapping fully qualified urls", async () => {
   expect(res).toEqual(expected);
 });
 
-test("wrapping partial urls", async () => {
-  const example = "twitch.tv/alveussanctuary";
-  const expected = "<twitch.tv/alveussanctuary>";
+test("wrapping multiple qualified urls", async () => {
+  const example =
+    "http://twitch.tv/alveussanctuary, https://www.twitter.com/AlveusSanctuary, https://youtube.com/@AlveusSanctuary";
+  const expected =
+    "<http://twitch.tv/alveussanctuary>, <https://www.twitter.com/AlveusSanctuary>, <https://youtube.com/@AlveusSanctuary>";
 
   const res = escapeLinksForDiscord(example);
 
   expect(res).toEqual(expected);
 });
 
-test("wrapping multiple partial urls", async () => {
+test("not wrapping partial urls", async () => {
+  const example = "twitch.tv/alveussanctuary";
+  const expected = "twitch.tv/alveussanctuary";
+
+  const res = escapeLinksForDiscord(example);
+
+  expect(res).toEqual(expected);
+});
+
+test("not wrapping multiple partial urls", async () => {
   const example =
     "twitch.tv/alveussanctuary, twitter.com/AlveusSanctuary, youtube.com/@AlveusSanctuary";
   const expected =
-    "<twitch.tv/alveussanctuary>, <twitter.com/AlveusSanctuary>, <youtube.com/@AlveusSanctuary>";
+    "twitch.tv/alveussanctuary, twitter.com/AlveusSanctuary, youtube.com/@AlveusSanctuary";
 
   const res = escapeLinksForDiscord(example);
 
@@ -32,9 +43,9 @@ test("wrapping multiple partial urls", async () => {
 
 test("full message example", async () => {
   const example =
-    "We're live at twitch.tv/alveussanctuary! Georgie is a big cutie!";
+    "We're live at https://twitch.tv/alveussanctuary! Georgie is a big cutie!";
   const expected =
-    "We're live at <twitch.tv/alveussanctuary>! Georgie is a big cutie!";
+    "We're live at <https://twitch.tv/alveussanctuary>! Georgie is a big cutie!";
 
   const res = escapeLinksForDiscord(example);
 

--- a/apps/website/src/utils/escape-links-for-discord.ts
+++ b/apps/website/src/utils/escape-links-for-discord.ts
@@ -2,7 +2,11 @@
 import LinkifyIt from "linkify-it";
 
 export function escapeLinksForDiscord(text: string) {
-  const linkify = new LinkifyIt();
+  const linkify = new LinkifyIt({
+    fuzzyLink: false,
+    fuzzyEmail: false,
+    fuzzyIP: false,
+  });
 
   const matches = linkify.match(text);
 


### PR DESCRIPTION
## Describe your changes

Do not escape incomplete (fuzzy) links for discord anymore.

## Notes for testing your change

Check link are escaped correctly but incomplete are not unnecessarily escaped.

Resolves #384