### PR TITLE
Fix prettier error loading esm plugin

### DIFF
--- a/apps/website/prettier.config.cjs
+++ b/apps/website/prettier.config.cjs
@@ -1,5 +1,0 @@
-// @ts-check
-/** @type {import("prettier").Config} */
-module.exports = {
-  plugins: [require.resolve("prettier-plugin-tailwindcss")],
-};

--- a/apps/website/prettier.config.mjs
+++ b/apps/website/prettier.config.mjs
@@ -1,0 +1,7 @@
+// @ts-check
+/** @type {import("prettier").Config} */
+const config = {
+  plugins: ["prettier-plugin-tailwindcss"],
+};
+
+export default config;


### PR DESCRIPTION
## Describe your changes

Changed the prettier config to ESM to fix loading the tailwind prettier plugin.

## Notes for testing your change

Run `pnpm install` then change a source file in the website directory, commit the change and see that the commit push runs without errors.
