### PR TITLE
Tweak example env file to be more intuitive

### DIFF
--- a/apps/website/.env.example
+++ b/apps/website/.env.example
@@ -15,7 +15,7 @@ DATABASE_URL='mysql://user:pass@us-east.connect.psdb.cloud/alveusgg?sslaccept=st
 SHADOW_DATABASE_URL='mysql://user:pass@us-east.connect.psdb.cloud/alveusgg/shadow?sslaccept=strict'
 
 # Next Auth
-# You can generate the secret via 'openssl rand -base64 32' on Linux
+#   You can generate the secret via 'openssl rand -base64 32' on Linux
 # More info: https://next-auth.js.org/configuration/options#secret
 NEXTAUTH_SECRET=
 NEXTAUTH_URL=http://localhost:3000
@@ -25,9 +25,9 @@ TWITCH_CLIENT_ID=
 TWITCH_CLIENT_SECRET=
 
 # Twitch Event Sub (Webhook)
-TWITCH_EVENTSUB_CALLBACK=http://localhost:3000/api/webhooks/twitch/eventsub
-# You can generate the secret via 'openssl rand -base64 32' on Linux
+#   You can generate the secret via 'openssl rand -base64 32' on Linux
 TWITCH_EVENTSUB_SECRET=
+TWITCH_EVENTSUB_CALLBACK=http://localhost:3000/api/webhooks/twitch/eventsub
 
 # Discord Bot
 DISCORD_BOT_NAME="Alveus Test"
@@ -41,11 +41,11 @@ DISCORD_CHANNEL_WEBHOOK_URLS_ANNOUNCEMENT=https://discord.com/api/webhooks/ccc/x
 #DISCORD_CHANNEL_WEBHOOK_TO_EVERYONE_ANNOUNCEMENT=true
 
 # Action API secret
-# You can generate the secret via 'openssl rand -base64 32' on Linux
+#   You can generate the secret via 'openssl rand -base64 32' on Linux
 ACTION_API_SECRET=
 
 # Web Push VAPID Key
-# Generate via 'npx web-push generate-vapid-keys'
+#   You can generate the keys via 'npx web-push generate-vapid-keys'
 NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY=
 WEB_PUSH_VAPID_PRIVATE_KEY=
 WEB_PUSH_VAPID_SUBJECT=mailto:admin@alveus.gg

--- a/apps/website/.env.example
+++ b/apps/website/.env.example
@@ -46,9 +46,9 @@ ACTION_API_SECRET=
 
 # Web Push VAPID Key
 # Generate via 'npx web-push generate-vapid-keys'
-WEB_PUSH_VAPID_SUBJECT=mailto:admin@alveus.gg
-WEB_PUSH_VAPID_PRIVATE_KEY=
 NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY=
+WEB_PUSH_VAPID_PRIVATE_KEY=
+WEB_PUSH_VAPID_SUBJECT=mailto:admin@alveus.gg
 
 # File Storage (S3-compatible)
 FILE_STORAGE_ENDPOINT=https://nyc3.digitaloceanspaces.com


### PR DESCRIPTION
## Describe your changes

Recently got tripped up by the fact that `npx web-push generate-vapid-keys` returns the public key first, whereas the env example had the private key first.

Also, just cleaned up the comments and ordering a bit for consistency.

## Notes for testing your change

Ensure I didn't actually remove anything from the env, just shuffled things around.