### PR TITLE
Use aria-describedby for report images

### DIFF
--- a/apps/website/src/pages/about/annual-reports/2021.tsx
+++ b/apps/website/src/pages/about/annual-reports/2021.tsx
@@ -43,168 +43,174 @@ const AboutAnnualReport2021Page: NextPage = () => {
         />
 
         <div className="sr-only" id="report">
-          <Heading level={2} className="mt-8">
-            Viewer Demographics
-          </Heading>
+          <div>
+            <Heading level={2} className="mt-8">
+              Viewer Demographics
+            </Heading>
 
-          <p>
-            Alveus has the unique ability to reach viewers across the world
-            virtually. While educating primarily U.S. viewers, our reach is
-            gradually expanding worldwide.
-          </p>
+            <p>
+              Alveus has the unique ability to reach viewers across the world
+              virtually. While educating primarily U.S. viewers, our reach is
+              gradually expanding worldwide.
+            </p>
 
-          <p>
-            Twitch&apos;s user demographic is 41% ages 16-24 and 32% ages 25-34.
-            With Twitch being our main platform, we have the opportunity to
-            reach an audience of budding consumers. This next generation will
-            determine the future for our planet.
-          </p>
+            <p>
+              Twitch&apos;s user demographic is 41% ages 16-24 and 32% ages
+              25-34. With Twitch being our main platform, we have the
+              opportunity to reach an audience of budding consumers. This next
+              generation will determine the future for our planet.
+            </p>
 
-          {/* TODO: These values are based on the pixel width of the graph -- would be great to get the original numbers */}
-          {/* <div className="flex flex-wrap justify-between gap-8">
+            {/* TODO: These values are based on the pixel width of the graph -- would be great to get the original numbers */}
+            {/* <div className="flex flex-wrap justify-between gap-8">
+              <dl>
+                <dt className="mt-2 font-bold">United States</dt>
+                <dd>695,550</dd>
+
+                <dt className="mt-2 font-bold">Canada</dt>
+                <dd>110,650</dd>
+
+                <dt className="mt-2 font-bold">United Kingdom</dt>
+                <dd>110,650</dd>
+
+                <dt className="mt-2 font-bold">Germany</dt>
+                <dd>94,850</dd>
+
+                <dt className="mt-2 font-bold">Sweden</dt>
+                <dd>47,400</dd>
+
+                <dt className="mt-2 font-bold">Norway</dt>
+                <dd>31,600</dd>
+
+                <dt className="mt-2 font-bold">Brazil</dt>
+                <dd>15,800</dd>
+
+                <dt className="mt-2 font-bold">India</dt>
+                <dd>15,800</dd>
+
+                <dt className="mt-2 font-bold">France</dt>
+                <dd>15,800</dd>
+
+                <dt className="mt-2 font-bold">Portugal</dt>
+                <dd>15,800</dd>
+              </dl>
+
+              <dl>
+                <dt className="mt-2 font-bold">Male</dt>
+                <dd>64.2%</dd>
+
+                <dt className="mt-2 font-bold">Female</dt>
+                <dd>37.6%</dd>
+              </dl>
+            </div> */}
+
+            <p>
+              Alveus has been steadily growing platforms across all social
+              media. With larger followings, we are able to educate a wider and
+              more diverse online audience.
+            </p>
+
+            <table className="w-full table-auto">
+              <thead>
+                <tr>
+                  <th className="text-start">Platform</th>
+                  <th className="text-start">2021</th>
+                  <th className="text-start">2022</th>
+                </tr>
+              </thead>
+
+              <tbody>
+                <tr>
+                  <td>Twitch</td>
+                  <td>19,575</td>
+                  <td>68,600</td>
+                </tr>
+                <tr>
+                  <td>Instagram</td>
+                  <td>33,742</td>
+                  <td>47,000</td>
+                </tr>
+                <tr>
+                  <td>YouTube</td>
+                  <td>0</td>
+                  <td>25,400</td>
+                </tr>
+                <tr>
+                  <td>TikTok</td>
+                  <td>27,800</td>
+                  <td>41,800</td>
+                </tr>
+                <tr>
+                  <td>X (Twitter)</td>
+                  <td>55,219</td>
+                  <td>67,700</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div>
+            <Heading level={2} className="mt-8">
+              Financial Report
+            </Heading>
+
+            <p>
+              In 2021, Alveus raised a total of $763,380 USD due to generous
+              support in the form of donations. Alveus had a total of
+              $144,411.80 in expenses in 2021. An additional $297,197.17 was
+              dedicated to enclosures and infrastructure.
+            </p>
+
+            <p>
+              Note: 2022 financials have not yet been released at this time. A
+              2022 report will be created and released in 2023.
+            </p>
+
+            <p>
+              In 2021, the majority (67.30%) of funds were dedicated to
+              development of the facility. This included fencing, enclosure
+              builds, interior renovations of buildings, and more. Operating
+              expenses included the salary of one staff member (Ella Rocks,
+              Animal Care Coordinator) in addition to general animal care costs.
+            </p>
+
             <dl>
-              <dt className="mt-2 font-bold">United States</dt>
-              <dd>695,550</dd>
+              <dt className="mt-2 font-bold">Construction</dt>
+              <dd>67.30%</dd>
 
-              <dt className="mt-2 font-bold">Canada</dt>
-              <dd>110,650</dd>
+              <dt className="mt-2 font-bold">Operating</dt>
+              <dd>17.79%</dd>
 
-              <dt className="mt-2 font-bold">United Kingdom</dt>
-              <dd>110,650</dd>
+              <dt className="mt-2 font-bold">Fundraising</dt>
+              <dd>8.46%</dd>
 
-              <dt className="mt-2 font-bold">Germany</dt>
-              <dd>94,850</dd>
-
-              <dt className="mt-2 font-bold">Sweden</dt>
-              <dd>47,400</dd>
-
-              <dt className="mt-2 font-bold">Norway</dt>
-              <dd>31,600</dd>
-
-              <dt className="mt-2 font-bold">Brazil</dt>
-              <dd>15,800</dd>
-
-              <dt className="mt-2 font-bold">India</dt>
-              <dd>15,800</dd>
-
-              <dt className="mt-2 font-bold">France</dt>
-              <dd>15,800</dd>
-
-              <dt className="mt-2 font-bold">Portugal</dt>
-              <dd>15,800</dd>
+              <dt className="mt-2 font-bold">Management</dt>
+              <dd>6.45%</dd>
             </dl>
+          </div>
 
-            <dl>
-              <dt className="mt-2 font-bold">Male</dt>
-              <dd>64.2%</dd>
+          <div>
+            <Heading level={2} className="mt-8">
+              Continuing Our Mission
+            </Heading>
 
-              <dt className="mt-2 font-bold">Female</dt>
-              <dd>37.6%</dd>
-            </dl>
-          </div> */}
+            <p>
+              The mission of Alveus is to inspire online audiences to engage in
+              conservation efforts. We do this by nurturing a connection between
+              viewers and our animal ambassadors so that they learn to care
+              about their species.
+            </p>
 
-          <p>
-            Alveus has been steadily growing platforms across all social media.
-            With larger followings, we are able to educate a wider and more
-            diverse online audience.
-          </p>
+            <p>
+              With your continued support, we are able to remain a powerful
+              force for conservation while providing enriched and comfortable
+              lives for our animal ambassadors.
+            </p>
 
-          <table className="w-full table-auto">
-            <thead>
-              <tr>
-                <th className="text-start">Platform</th>
-                <th className="text-start">2021</th>
-                <th className="text-start">2022</th>
-              </tr>
-            </thead>
-
-            <tbody>
-              <tr>
-                <td>Twitch</td>
-                <td>19,575</td>
-                <td>68,600</td>
-              </tr>
-              <tr>
-                <td>Instagram</td>
-                <td>33,742</td>
-                <td>47,000</td>
-              </tr>
-              <tr>
-                <td>YouTube</td>
-                <td>0</td>
-                <td>25,400</td>
-              </tr>
-              <tr>
-                <td>TikTok</td>
-                <td>27,800</td>
-                <td>41,800</td>
-              </tr>
-              <tr>
-                <td>X (Twitter)</td>
-                <td>55,219</td>
-                <td>67,700</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <Heading level={2} className="mt-8">
-            Financial Report
-          </Heading>
-
-          <p>
-            In 2021, Alveus raised a total of $763,380 USD due to generous
-            support in the form of donations. Alveus had a total of $144,411.80
-            in expenses in 2021. An additional $297,197.17 was dedicated to
-            enclosures and infrastructure.
-          </p>
-
-          <p>
-            Note: 2022 financials have not yet been released at this time. A
-            2022 report will be created and released in 2023.
-          </p>
-
-          <p>
-            In 2021, the majority (67.30%) of funds were dedicated to
-            development of the facility. This included fencing, enclosure
-            builds, interior renovations of buildings, and more. Operating
-            expenses included the salary of one staff member (Ella Rocks, Animal
-            Care Coordinator) in addition to general animal care costs.
-          </p>
-
-          <dl>
-            <dt className="mt-2 font-bold">Construction</dt>
-            <dd>67.30%</dd>
-
-            <dt className="mt-2 font-bold">Operating</dt>
-            <dd>17.79%</dd>
-
-            <dt className="mt-2 font-bold">Fundraising</dt>
-            <dd>8.46%</dd>
-
-            <dt className="mt-2 font-bold">Management</dt>
-            <dd>6.45%</dd>
-          </dl>
-
-          <Heading level={2} className="mt-8">
-            Continuing Our Mission
-          </Heading>
-
-          <p>
-            The mission of Alveus is to inspire online audiences to engage in
-            conservation efforts. We do this by nurturing a connection between
-            viewers and our animal ambassadors so that they learn to care about
-            their species.
-          </p>
-
-          <p>
-            With your continued support, we are able to remain a powerful force
-            for conservation while providing enriched and comfortable lives for
-            our animal ambassadors.
-          </p>
-
-          <p>
-            <strong>Thank you.</strong>
-          </p>
+            <p>
+              <strong>Thank you.</strong>
+            </p>
+          </div>
         </div>
       </Section>
     </>

--- a/apps/website/src/pages/about/annual-reports/2021.tsx
+++ b/apps/website/src/pages/about/annual-reports/2021.tsx
@@ -37,11 +37,12 @@ const AboutAnnualReport2021Page: NextPage = () => {
         <Image
           src={report2021Image}
           quality={100}
-          alt=""
           className="mx-auto h-auto w-full max-w-3xl"
+          alt="Report graphic"
+          aria-describedby="report"
         />
 
-        <div className="sr-only">
+        <div className="sr-only" id="report">
           <Heading level={2} className="mt-8">
             Viewer Demographics
           </Heading>

--- a/apps/website/src/pages/about/annual-reports/2022.tsx
+++ b/apps/website/src/pages/about/annual-reports/2022.tsx
@@ -43,345 +43,353 @@ const AboutAnnualReport2022Page: NextPage = () => {
         />
 
         <div className="sr-only" id="report">
-          <Heading level={2} className="mt-8">
-            Followers
-          </Heading>
+          <div>
+            <Heading level={2} className="mt-8">
+              Followers
+            </Heading>
 
-          <table className="w-full table-auto">
-            <thead>
-              <tr>
-                <th className="text-start">Platform</th>
-                <th className="text-start">Start 2022</th>
-                <th className="text-start">End 2022</th>
-              </tr>
-            </thead>
+            <table className="w-full table-auto">
+              <thead>
+                <tr>
+                  <th className="text-start">Platform</th>
+                  <th className="text-start">Start 2022</th>
+                  <th className="text-start">End 2022</th>
+                </tr>
+              </thead>
 
-            <tbody>
-              <tr>
-                <td>Twitch</td>
-                <td>19,575</td>
-                <td>68,600</td>
-              </tr>
-              <tr>
-                <td>Instagram</td>
-                <td>33,742</td>
-                <td>47,000</td>
-              </tr>
-              <tr>
-                <td>YouTube</td>
-                <td>0</td>
-                <td>25,400</td>
-              </tr>
-              <tr>
-                <td>TikTok</td>
-                <td>27,800</td>
-                <td>41,800</td>
-              </tr>
-              <tr>
-                <td>X (Twitter)</td>
-                <td>55,219</td>
-                <td>67,700</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <Heading level={2} className="mt-8">
-            Twitch Demographics
-          </Heading>
-
-          <div className="flex flex-wrap justify-between gap-8">
-            <dl>
-              <dt className="mt-2 font-bold">Male</dt>
-              <dd>78.36%</dd>
-
-              <dt className="mt-2 font-bold">Female</dt>
-              <dd>19.64%</dd>
-
-              <dt className="mt-2 font-bold">Other</dt>
-              <dd>2%</dd>
-            </dl>
-
-            <dl>
-              <dt className="mt-2 font-bold">18-24</dt>
-              <dd>35.85%</dd>
-
-              <dt className="mt-2 font-bold">25-34</dt>
-              <dd>32.14%</dd>
-
-              <dt className="mt-2 font-bold">35-44</dt>
-              <dd>15.33%</dd>
-
-              <dt className="mt-2 font-bold">45-54</dt>
-              <dd>8.62%</dd>
-
-              <dt className="mt-2 font-bold">55-64</dt>
-              <dd>4.97%</dd>
-            </dl>
-
-            <dl>
-              <dt className="mt-2 font-bold">USA</dt>
-              <dd>20.48%</dd>
-
-              <dt className="mt-2 font-bold">Germany</dt>
-              <dd>6.54%</dd>
-
-              <dt className="mt-2 font-bold">South Korea</dt>
-              <dd>5.09%</dd>
-
-              <dt className="mt-2 font-bold">Russia</dt>
-              <dd>4.7%</dd>
-
-              <dt className="mt-2 font-bold">France</dt>
-              <dd>4.27%</dd>
-
-              <dt className="mt-2 font-bold">Others</dt>
-              <dd>58.95%</dd>
-            </dl>
+              <tbody>
+                <tr>
+                  <td>Twitch</td>
+                  <td>19,575</td>
+                  <td>68,600</td>
+                </tr>
+                <tr>
+                  <td>Instagram</td>
+                  <td>33,742</td>
+                  <td>47,000</td>
+                </tr>
+                <tr>
+                  <td>YouTube</td>
+                  <td>0</td>
+                  <td>25,400</td>
+                </tr>
+                <tr>
+                  <td>TikTok</td>
+                  <td>27,800</td>
+                  <td>41,800</td>
+                </tr>
+                <tr>
+                  <td>X (Twitter)</td>
+                  <td>55,219</td>
+                  <td>67,700</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
 
-          <div className="flex flex-wrap justify-between gap-8">
-            <Heading level={3} className="text-xl">
-              50.3 million minutes watched
+          <div>
+            <Heading level={2} className="mt-8">
+              Twitch Demographics
             </Heading>
-            <Heading level={3} className="text-xl">
-              2.65 million live views
-            </Heading>
-            <Heading level={3} className="text-xl">
-              18,689 peak viewership
-            </Heading>
+
+            <div className="flex flex-wrap justify-between gap-8">
+              <dl>
+                <dt className="mt-2 font-bold">Male</dt>
+                <dd>78.36%</dd>
+
+                <dt className="mt-2 font-bold">Female</dt>
+                <dd>19.64%</dd>
+
+                <dt className="mt-2 font-bold">Other</dt>
+                <dd>2%</dd>
+              </dl>
+
+              <dl>
+                <dt className="mt-2 font-bold">18-24</dt>
+                <dd>35.85%</dd>
+
+                <dt className="mt-2 font-bold">25-34</dt>
+                <dd>32.14%</dd>
+
+                <dt className="mt-2 font-bold">35-44</dt>
+                <dd>15.33%</dd>
+
+                <dt className="mt-2 font-bold">45-54</dt>
+                <dd>8.62%</dd>
+
+                <dt className="mt-2 font-bold">55-64</dt>
+                <dd>4.97%</dd>
+              </dl>
+
+              <dl>
+                <dt className="mt-2 font-bold">USA</dt>
+                <dd>20.48%</dd>
+
+                <dt className="mt-2 font-bold">Germany</dt>
+                <dd>6.54%</dd>
+
+                <dt className="mt-2 font-bold">South Korea</dt>
+                <dd>5.09%</dd>
+
+                <dt className="mt-2 font-bold">Russia</dt>
+                <dd>4.7%</dd>
+
+                <dt className="mt-2 font-bold">France</dt>
+                <dd>4.27%</dd>
+
+                <dt className="mt-2 font-bold">Others</dt>
+                <dd>58.95%</dd>
+              </dl>
+            </div>
+
+            <div className="flex flex-wrap justify-between gap-8">
+              <Heading level={3} className="text-xl">
+                50.3 million minutes watched
+              </Heading>
+              <Heading level={3} className="text-xl">
+                2.65 million live views
+              </Heading>
+              <Heading level={3} className="text-xl">
+                18,689 peak viewership
+              </Heading>
+            </div>
           </div>
 
-          <Heading level={2} className="mt-8">
-            Financial Report
-          </Heading>
+          <div>
+            <Heading level={2} className="mt-8">
+              Financial Report
+            </Heading>
 
-          <table className="w-full table-auto">
-            <tbody>
-              <tr>
-                <td>
-                  <strong>Total Income</strong>
-                </td>
-                <td>
-                  <strong>300,066.79</strong>
-                </td>
-              </tr>
-              <tr>
-                <td>Donations and Grants</td>
-                <td>266,585.66</td>
-              </tr>
-              <tr>
-                <td>Merch</td>
-                <td>33,481.13</td>
-              </tr>
-            </tbody>
+            <table className="w-full table-auto">
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>Total Income</strong>
+                  </td>
+                  <td>
+                    <strong>300,066.79</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Donations and Grants</td>
+                  <td>266,585.66</td>
+                </tr>
+                <tr>
+                  <td>Merch</td>
+                  <td>33,481.13</td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td colSpan={2}>
-                  <hr />
-                </td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td colSpan={2}>
+                    <hr />
+                  </td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td>
-                  <strong>Total Expenses</strong>
-                </td>
-                <td>
-                  <strong>285,838.93</strong>
-                </td>
-              </tr>
-              <tr>
-                <td>Operational Expenses</td>
-                <td>32,679.86</td>
-              </tr>
-              <tr>
-                <td>Advertising Expense</td>
-                <td>154.61</td>
-              </tr>
-              <tr>
-                <td>Fundraising Expense</td>
-                <td>4,218.80</td>
-              </tr>
-              <tr>
-                <td>Salary Expense</td>
-                <td>121,240.94</td>
-              </tr>
-              <tr>
-                <td>Insurance Expense</td>
-                <td>16,429.08</td>
-              </tr>
-              <tr>
-                <td>Repairs and Maintenance Expense</td>
-                <td>38,792.41</td>
-              </tr>
-              <tr>
-                <td>Meals &amp; Entertainment</td>
-                <td>1,344.43</td>
-              </tr>
-              <tr>
-                <td>Office Supplies &amp; Software Expense</td>
-                <td>5,551.98</td>
-              </tr>
-              <tr>
-                <td>Other Income &amp; Expenses</td>
-                <td>3,318.66</td>
-              </tr>
-              <tr>
-                <td>Tax Expense</td>
-                <td>147</td>
-              </tr>
-              <tr>
-                <td>Depreciation</td>
-                <td>10,297.08</td>
-              </tr>
-              <tr>
-                <td>Utilities Expense</td>
-                <td>9,516.09</td>
-              </tr>
-              <tr>
-                <td>Travel Expense</td>
-                <td>3,229.19</td>
-              </tr>
-              <tr>
-                <td>Contractor Expense</td>
-                <td>15,512.46</td>
-              </tr>
-              <tr>
-                <td>Streaming Expense</td>
-                <td>17,024.54</td>
-              </tr>
-              <tr>
-                <td>Legal &amp; Professional Fees</td>
-                <td>6,381.80</td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>Total Expenses</strong>
+                  </td>
+                  <td>
+                    <strong>285,838.93</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Operational Expenses</td>
+                  <td>32,679.86</td>
+                </tr>
+                <tr>
+                  <td>Advertising Expense</td>
+                  <td>154.61</td>
+                </tr>
+                <tr>
+                  <td>Fundraising Expense</td>
+                  <td>4,218.80</td>
+                </tr>
+                <tr>
+                  <td>Salary Expense</td>
+                  <td>121,240.94</td>
+                </tr>
+                <tr>
+                  <td>Insurance Expense</td>
+                  <td>16,429.08</td>
+                </tr>
+                <tr>
+                  <td>Repairs and Maintenance Expense</td>
+                  <td>38,792.41</td>
+                </tr>
+                <tr>
+                  <td>Meals &amp; Entertainment</td>
+                  <td>1,344.43</td>
+                </tr>
+                <tr>
+                  <td>Office Supplies &amp; Software Expense</td>
+                  <td>5,551.98</td>
+                </tr>
+                <tr>
+                  <td>Other Income &amp; Expenses</td>
+                  <td>3,318.66</td>
+                </tr>
+                <tr>
+                  <td>Tax Expense</td>
+                  <td>147</td>
+                </tr>
+                <tr>
+                  <td>Depreciation</td>
+                  <td>10,297.08</td>
+                </tr>
+                <tr>
+                  <td>Utilities Expense</td>
+                  <td>9,516.09</td>
+                </tr>
+                <tr>
+                  <td>Travel Expense</td>
+                  <td>3,229.19</td>
+                </tr>
+                <tr>
+                  <td>Contractor Expense</td>
+                  <td>15,512.46</td>
+                </tr>
+                <tr>
+                  <td>Streaming Expense</td>
+                  <td>17,024.54</td>
+                </tr>
+                <tr>
+                  <td>Legal &amp; Professional Fees</td>
+                  <td>6,381.80</td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td colSpan={2}>
-                  <hr />
-                </td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td colSpan={2}>
+                    <hr />
+                  </td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td>
-                  <strong>Net Income</strong>
-                </td>
-                <td>
-                  <strong>14,227.86</strong>
-                </td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>Net Income</strong>
+                  </td>
+                  <td>
+                    <strong>14,227.86</strong>
+                  </td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td colSpan={2}>
-                  <hr />
-                </td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td colSpan={2}>
+                    <hr />
+                  </td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td>
-                  <strong>Total Assets</strong>
-                </td>
-                <td>
-                  <strong>621,387.23</strong>
-                </td>
-              </tr>
-              <tr>
-                <td>Total Current Assets - Cash</td>
-                <td>117,763.40</td>
-              </tr>
-              <tr>
-                <td>Total Fixed Assets</td>
-                <td>503,623.83</td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>Total Assets</strong>
+                  </td>
+                  <td>
+                    <strong>621,387.23</strong>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Total Current Assets - Cash</td>
+                  <td>117,763.40</td>
+                </tr>
+                <tr>
+                  <td>Total Fixed Assets</td>
+                  <td>503,623.83</td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td colSpan={2}>
-                  <hr />
-                </td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td colSpan={2}>
+                    <hr />
+                  </td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td>
-                  <strong>Total Liabilities</strong>
-                </td>
-                <td>
-                  <strong>677.99</strong>
-                </td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>Total Liabilities</strong>
+                  </td>
+                  <td>
+                    <strong>677.99</strong>
+                  </td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td colSpan={2}>
-                  <hr />
-                </td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td colSpan={2}>
+                    <hr />
+                  </td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td>
-                  <strong>Total Equity - Retained Earnings</strong>
-                </td>
-                <td>
-                  <strong>620,709.24</strong>
-                </td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>Total Equity - Retained Earnings</strong>
+                  </td>
+                  <td>
+                    <strong>620,709.24</strong>
+                  </td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td colSpan={2}>
-                  <hr />
-                </td>
-              </tr>
-            </tbody>
+              <tbody>
+                <tr>
+                  <td colSpan={2}>
+                    <hr />
+                  </td>
+                </tr>
+              </tbody>
 
-            <tbody>
-              <tr>
-                <td>
-                  <strong>Total Liabilities &amp; Equity</strong>
-                </td>
-                <td>
-                  <strong>621,387.23</strong>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>Total Liabilities &amp; Equity</strong>
+                  </td>
+                  <td>
+                    <strong>621,387.23</strong>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
 
-          <Heading level={2} className="mt-8">
-            Continuing Our Mission
-          </Heading>
+          <div>
+            <Heading level={2} className="mt-8">
+              Continuing Our Mission
+            </Heading>
 
-          <p>
-            The mission of Alveus is to inspire online audiences to engage in
-            conservation efforts. We do this by nurturing a connection between
-            viewers and our animal ambassadors so that they learn to care about
-            their species.
-          </p>
+            <p>
+              The mission of Alveus is to inspire online audiences to engage in
+              conservation efforts. We do this by nurturing a connection between
+              viewers and our animal ambassadors so that they learn to care
+              about their species.
+            </p>
 
-          <p>
-            With your continued support, we are able to remain a powerful force
-            for conservation while providing enriched and comfortable lives for
-            our animal ambassadors.
-          </p>
+            <p>
+              With your continued support, we are able to remain a powerful
+              force for conservation while providing enriched and comfortable
+              lives for our animal ambassadors.
+            </p>
 
-          <p>
-            <strong>Thank you.</strong>
-          </p>
+            <p>
+              <strong>Thank you.</strong>
+            </p>
+          </div>
         </div>
       </Section>
     </>

--- a/apps/website/src/pages/about/annual-reports/2022.tsx
+++ b/apps/website/src/pages/about/annual-reports/2022.tsx
@@ -37,11 +37,12 @@ const AboutAnnualReport2022Page: NextPage = () => {
         <Image
           src={report2022Image}
           quality={100}
-          alt=""
           className="mx-auto h-auto w-full max-w-3xl"
+          alt="Report graphic"
+          aria-describedby="report"
         />
 
-        <div className="sr-only">
+        <div className="sr-only" id="report">
           <Heading level={2} className="mt-8">
             Followers
           </Heading>


### PR DESCRIPTION
## Describe your changes

Further improves the accessibility of the reports by using `aria-describedby` to tell a11y tools that the report images are described by the text versions of the report. `described` is used rather than `labeled` as we are providing a long description rather than a short label.

## Notes for testing your change

See if a11y tools detect the description -- in Firefox's developer tools accessibility tab, the image now has `relations > described by`.
