### PR TITLE
Enforce prettier in GitHub Actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,47 @@
-name: Test
+name: Checks
 on: [pull_request]
+
 jobs:
-  test:
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node.js (.nvmrc)
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        id: pnpm-install
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run prettier
+        run: pnpm run prettier --check
+
+  tests:
     runs-on: ubuntu-latest
 
     strategy:

--- a/apps/website/src/data/network.ts
+++ b/apps/website/src/data/network.ts
@@ -256,7 +256,7 @@ const data: NetworkItem[] = [
                     model: "Ubiquiti UAP-AC-M-Pro",
                     url: "https://store.ui.com/us/en/pro/category/wiif-outdoor/products/unifi-ac-mesh-pro-ap",
                     connection: { type: "ethernet", location: "wall" },
-                  }
+                  },
                 ],
               },
             ],

--- a/apps/website/src/env/index.mjs
+++ b/apps/website/src/env/index.mjs
@@ -51,7 +51,7 @@ export const env = createEnv({
       // Since NextAuth.js automatically uses the VERCEL_URL if present.
       (str) => process.env.VERCEL_URL || str,
       // VERCEL_URL doesn't include `https` so it cant be validated as a URL
-      process.env.VERCEL_URL ? z.string() : z.string().url()
+      process.env.VERCEL_URL ? z.string() : z.string().url(),
     ),
     TWITCH_CLIENT_ID: z.string(),
     TWITCH_CLIENT_SECRET: z.string(),

--- a/apps/website/src/pages/about/maya.tsx
+++ b/apps/website/src/pages/about/maya.tsx
@@ -119,17 +119,18 @@ const AboutMayaPage: NextPage = () => {
             <p className="text-lg">
               Maya Higa is one of the top female streamers on Twitch and a
               rising star on YouTube. Her passions include wildlife conservation
-              and education, and she integrates these into her content regularly,
-              creating some of the most unique content on Twitch. Maya is a
-              licensed falconer and wildlife conservationist. Her livestreams
-              feature falconry, wildlife rehab, conservation education, and
-              charity fundraising. She created a conservation podcast in 2019
-              which has since aired more than 60 episodes on her channel and
-              raised more than $92,000 for wildlife protection organizations
-              around the globe. Maya founded Alveus Sanctuary, a non-profit
-              exotic animal sanctuary and virtual education center in central
-              Texas and raised more than $500,000 during her first fundraising
-              stream thanks to her amazing community and fellow streamers.
+              and education, and she integrates these into her content
+              regularly, creating some of the most unique content on Twitch.
+              Maya is a licensed falconer and wildlife conservationist. Her
+              livestreams feature falconry, wildlife rehab, conservation
+              education, and charity fundraising. She created a conservation
+              podcast in 2019 which has since aired more than 60 episodes on her
+              channel and raised more than $92,000 for wildlife protection
+              organizations around the globe. Maya founded Alveus Sanctuary, a
+              non-profit exotic animal sanctuary and virtual education center in
+              central Texas and raised more than $500,000 during her first
+              fundraising stream thanks to her amazing community and fellow
+              streamers.
             </p>
           </div>
         </Section>

--- a/apps/website/src/pages/events.tsx
+++ b/apps/website/src/pages/events.tsx
@@ -244,10 +244,10 @@ const events = {
           Two teams were formed from the creators, and they competed in many
           activities around the property throughout the event. A game of apple
           bobbing started the evening off, followed by hale bale throwing to see
-          which team had better technique. A little while later, we had a game of
-          badminton on the grass, followed by trivia and then the dunk tank. We
-          rounded off the evening with some mud wrestling. Thank you to all the
-          creators that joined us, and everyone who watched and donated!
+          which team had better technique. A little while later, we had a game
+          of badminton on the grass, followed by trivia and then the dunk tank.
+          We rounded off the evening with some mud wrestling. Thank you to all
+          the creators that joined us, and everyone who watched and donated!
         </p>
       </>
     ),
@@ -276,7 +276,7 @@ const events = {
     },
     info: (
       <p>
-        The event that started it all! A 20-hour-long mega-stream with a bunch 
+        The event that started it all! A 20-hour-long mega-stream with a bunch
         of donation goals along the way, aiming to raise as much money as
         possible to kick-start Alveus. Each donor that donated $100 or more got
         their name engraved on a golden leaf that form part of six donor trees

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "lint-staged": "lint-staged --relative"
+    "lint-staged": "lint-staged --relative",
+    "prettier": "prettier . --write"
   }
 }


### PR DESCRIPTION
## Describe your changes

When talking with @Echoskope about preparing #434, it was noticed that the file had a missing `,` that prettier should've enforced. I then realised we don't actually enforce prettier anywhere in CI, only in commit hooks locally if you have them enabled.

This PR adds a GitHub Actions check for PRs to ensure they're following prettier conventions, and fixes a few outstanding violations.

## Notes for testing your change

`pnpm run prettier` and `pnpm run prettier --check` work as expected locally. GitHub Actions check works in PR.
