### PR TITLE
Fix homepage performance in Firefox (remove blur placeholder)

### DIFF
--- a/apps/website/src/components/content/Slideshow.tsx
+++ b/apps/website/src/components/content/Slideshow.tsx
@@ -137,7 +137,6 @@ const Slideshow = ({
             quality="50"
             loader={qualityLoader}
             priority={idx === 0}
-            placeholder="blur"
             className="h-full w-full object-cover"
             style={{
               animationDelay: `${idx * animation.duration.offset}ms`,


### PR DESCRIPTION
## Describe your changes

In Firefox specifically, the homepage seems to cause a large lag spike on initial load, preventing the page from painting until it is loaded. In Chrome, this works perfectly with no issues.

After some trial-and-error removal of suspect parts of how the homepage slideshow, it would appear the source of the lag in Firefox was the base64 svg/png placeholder background images being set on the images prior to them loading fully. Removing these seems to completely resolve the lag, though does leave the page with no image until the first slide loads (which seems to be relatively fast anecdotally).

## Notes for testing your change

When compared to production, no lag is seen in Firefox when loading the homepage.
