### PR TITLE
Fall carnival event: cut down promo, keep tickets for now

### DIFF
--- a/apps/website/src/components/events/fall-carnival-2023/IntroSection.tsx
+++ b/apps/website/src/components/events/fall-carnival-2023/IntroSection.tsx
@@ -8,7 +8,6 @@ import { classes } from "@/utils/classes";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";
-import Link from "@/components/content/Link";
 
 type IntroSectionProps = {
   showTicket?: boolean;
@@ -45,17 +44,8 @@ export function IntroSection({
       )}
 
       <div>
-        <div className="mb-2 inline-block rounded-lg bg-white/90 px-2 py-0.5 text-xs uppercase text-carnival">
-          Upcoming event
-        </div>
-
-        <Heading>You are invited to the Alveus Fall Carnival 2023!</Heading>
-        <p className="text-lg">
-          November 4th 2023 at 11am CT live on{" "}
-          <Link href="https://twitch.tv/maya" dark external>
-            twitch.tv/maya
-          </Link>
-        </p>
+        <Heading>Alveus Fall Carnival 2023</Heading>
+        <p className="text-lg">November 4th 2023 at 11am CT</p>
 
         {showLinkToClaimTicket && (
           <div className="mt-6 md:mt-8 lg:mt-14">

--- a/apps/website/src/components/layout/Layout.tsx
+++ b/apps/website/src/components/layout/Layout.tsx
@@ -1,10 +1,6 @@
 import { useEffect, type ReactNode } from "react";
 import { PT_Sans, PT_Serif } from "next/font/google";
 import Head from "next/head";
-import Link from "next/link";
-import { useRouter } from "next/router";
-
-import IconArrowRight from "@/icons/IconArrowRight";
 
 import Meta from "@/components/content/Meta";
 import { Navbar } from "./navbar/Navbar";
@@ -34,10 +30,10 @@ const Layout = ({ children }: LayoutProps) => {
     document.body.classList.add(...fonts.split(" "));
   }, []);
 
-  const { pathname } = useRouter();
-  const showTopHat =
-    !pathname.startsWith("/events/fall-carnival-2023") &&
-    !pathname.startsWith("/admin");
+  //const { pathname } = useRouter();
+  //const showTopHat =
+  //  !pathname.startsWith("/events/fall-carnival-2023") &&
+  //  !pathname.startsWith("/admin");
 
   return (
     <>
@@ -87,7 +83,7 @@ const Layout = ({ children }: LayoutProps) => {
           Jump to main navigation
         </a>
 
-        {showTopHat && (
+        {/* showTopHat && (
           <Link
             href="/events/fall-carnival-2023"
             className="relative z-10 block border-b border-b-carnival-800 bg-carnival px-4 pb-1 pt-1.5 text-sm text-white hover:underline"
@@ -97,7 +93,7 @@ const Layout = ({ children }: LayoutProps) => {
               <IconArrowRight className="h-4 w-4" />
             </div>
           </Link>
-        )}
+        ) */}
 
         <Navbar />
         <main tabIndex={-1} id="main" className="flex flex-grow flex-col">

--- a/apps/website/src/pages/events/fall-carnival-2023/index.tsx
+++ b/apps/website/src/pages/events/fall-carnival-2023/index.tsx
@@ -85,7 +85,7 @@ const FallCarnival2023EventPage: NextPage = () => {
     <>
       <Meta
         title="Alveus Fall Carnival 2023"
-        description="You are invited to the Alveus Fall Carnival 2023 - Customize your ticket!"
+        description="Alveus Fall Carnival 2023 - Customize your ticket!"
         image={ogImage.src}
       />
 

--- a/apps/website/src/pages/events/fall-carnival-2023/tickets/[userName].tsx
+++ b/apps/website/src/pages/events/fall-carnival-2023/tickets/[userName].tsx
@@ -67,7 +67,7 @@ const TicketPage: NextPage = () => {
     <>
       <Meta
         title="Alveus Fall Carnival 2023"
-        description="You are invited to the Alveus Fall Carnival 2023 - Customize your ticket!"
+        description="Alveus Fall Carnival 2023 - Customize your ticket!"
       >
         {/* preload the ticket */}
         <link

--- a/apps/website/src/pages/updates.tsx
+++ b/apps/website/src/pages/updates.tsx
@@ -12,7 +12,6 @@ import { RecentNotifications } from "@/components/notifications/RecentNotificati
 import updateChannels from "@/components/shared/data/updateChannels";
 
 import bellPeepo from "@/assets/bell-peepo.webp";
-import { IntroSection } from "@/components/events/fall-carnival-2023/IntroSection";
 
 const notificationTags = ["stream"];
 
@@ -67,8 +66,6 @@ const UpdatesPage: NextPage = () => {
           />
         </div>
       </Section>
-
-      <IntroSection showTicket showLinkToClaimTicket />
 
       {/* Grow the last section to cover the page */}
       <Section className="flex-grow">


### PR DESCRIPTION
## Describe your changes

<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->


Just reduce the promo for the event on the page since its done. Also remove "invitation" wording.

## Notes for testing your change

See the pages look fine.