### PR TITLE
Update data (Winnie's dairy animal quest)

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -28,7 +28,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@alveusgg/data": "github:alveusgg/data#0.25.1",
+    "@alveusgg/data": "github:alveusgg/data#0.26.0",
     "@aws-sdk/client-s3": "^3.414.0",
     "@aws-sdk/s3-request-presigner": "^3.414.0",
     "@fontsource/pt-sans": "^5.0.8",

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -14,7 +14,7 @@ import {
   type AmbassadorImages,
 } from "@alveusgg/data/src/ambassadors/images";
 import {
-  getAmbassadorEpisode,
+  getAmbassadorEpisodes,
   type AnimalQuestWithRelation,
 } from "@alveusgg/data/src/animal-quest";
 import enclosures, { type Enclosure } from "@alveusgg/data/src/enclosures";
@@ -46,7 +46,7 @@ type AmbassadorPageProps = {
   enclosure: Enclosure;
   images: AmbassadorImages;
   merchImage?: AmbassadorImage;
-  animalQuest?: AnimalQuestWithRelation;
+  animalQuest?: AnimalQuestWithRelation[];
 };
 
 export const getStaticPaths: GetStaticPaths = () => {
@@ -76,7 +76,7 @@ export const getStaticProps: GetStaticProps<AmbassadorPageProps> = async (
       enclosure: enclosures[ambassador.enclosure],
       images: getAmbassadorImages(ambassadorKey),
       merchImage: getAmbassadorMerchImage(ambassadorKey),
-      animalQuest: getAmbassadorEpisode(ambassadorKey), // featured + related
+      animalQuest: getAmbassadorEpisodes(ambassadorKey),
     },
   };
 };
@@ -263,44 +263,48 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
               ))}
             </dl>
 
-            {animalQuest && (
-              <Link
-                href={`/animal-quest/${sentenceToKebab(animalQuest.edition)}`}
-                className="group relative z-0 my-6 flex flex-wrap items-center justify-between gap-8 rounded-2xl bg-alveus-tan px-6 py-4 shadow-xl transition hover:scale-102 hover:shadow-2xl sm:flex-nowrap md:flex-wrap xl:flex-nowrap"
-                custom
-              >
-                <Image
-                  src={animalQuestImage}
-                  alt=""
-                  width={688}
-                  className="absolute inset-0 -z-10 h-full w-full rounded-2xl bg-alveus-tan object-cover opacity-10"
-                />
+            {animalQuest &&
+              animalQuest.map((aq) => (
+                <Link
+                  key={aq.episode}
+                  href={`/animal-quest/${sentenceToKebab(aq.edition)}`}
+                  className="group relative z-0 my-6 flex flex-wrap items-center justify-between gap-8 rounded-2xl bg-alveus-tan px-6 py-4 shadow-xl transition hover:scale-102 hover:shadow-2xl sm:flex-nowrap md:flex-wrap xl:flex-nowrap"
+                  custom
+                >
+                  <Image
+                    src={animalQuestImage}
+                    alt=""
+                    width={688}
+                    className="absolute inset-0 -z-10 h-full w-full rounded-2xl bg-alveus-tan object-cover opacity-10"
+                  />
 
-                <div>
-                  <Heading
-                    level={2}
-                    className="transition-colors group-hover:text-alveus-green-800"
-                  >
-                    Learn more{" "}
-                    {animalQuest.relation === "featured" &&
-                      `about ${ambassador.name} `}
-                    on{" "}
-                    <span className="min-[320px]:whitespace-nowrap">
-                      Animal Quest
-                    </span>
-                  </Heading>
-                  <p className="text-xl text-alveus-green-800">
-                    Animal Quest Ep. {animalQuest.episode}:{" "}
-                    {animalQuest.edition}
-                  </p>
-                </div>
+                  <div>
+                    <Heading
+                      level={2}
+                      className="transition-colors group-hover:text-alveus-green-800"
+                    >
+                      Animal Quest #{aq.episode}:{" "}
+                      <span className="min-[320px]:whitespace-nowrap">
+                        {aq.edition}
+                      </span>
+                    </Heading>
+                    <p className="text-xl text-alveus-green-800">
+                      Learn more{" "}
+                      {aq.relation === "featured" &&
+                        `about ${ambassador.name} `}
+                      on{" "}
+                      <span className="min-[320px]:whitespace-nowrap">
+                        Animal Quest
+                      </span>
+                    </p>
+                  </div>
 
-                <IconYouTube
-                  size={48}
-                  className="shrink-0 transition-colors group-hover:text-alveus-green-600"
-                />
-              </Link>
-            )}
+                  <IconYouTube
+                    size={48}
+                    className="shrink-0 transition-colors group-hover:text-alveus-green-600"
+                  />
+                </Link>
+              ))}
 
             <div className="pswp-gallery my-6" id={photoswipe}>
               <Carousel

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
   apps/website:
     dependencies:
       '@alveusgg/data':
-        specifier: github:alveusgg/data#0.25.1
-        version: github.com/alveusgg/data/02dbb3ddc7451a30ff5d30c6bd7fba4ab9e3e60b
+        specifier: github:alveusgg/data#0.26.0
+        version: github.com/alveusgg/data/229db29774aa5a9dc5c2e5c7b08cec7c13c7fb5d
       '@aws-sdk/client-s3':
         specifier: ^3.414.0
         version: 3.414.0
@@ -10103,8 +10103,8 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/alveusgg/data/02dbb3ddc7451a30ff5d30c6bd7fba4ab9e3e60b:
-    resolution: {tarball: https://codeload.github.com/alveusgg/data/tar.gz/02dbb3ddc7451a30ff5d30c6bd7fba4ab9e3e60b}
+  github.com/alveusgg/data/229db29774aa5a9dc5c2e5c7b08cec7c13c7fb5d:
+    resolution: {tarball: https://codeload.github.com/alveusgg/data/tar.gz/229db29774aa5a9dc5c2e5c7b08cec7c13c7fb5d}
     name: '@alveusgg/data'
-    version: 0.25.1
+    version: 0.26.0
     dev: false


### PR DESCRIPTION
## Describe your changes

cc https://github.com/alveusgg/data/pull/49

This data change replaces `getAmbassadorEpisode` with `getAmbassadorEpisodes`, so the ambassador pages needed to be updated to handle multiple episodes. Other than making that a loop now, I also swapped the headline/text, so the focus is on the episode name, which looks far more logical when multiple are shown (such as on Winnie's page).

## Notes for testing your change

Ambassador pages with a single AQ episode look fine and render correctly.

Ambassador pages with multiple AQ episodes look fine and render correctly.
