### PR TITLE
useGrouped: use router.replace

### DIFF
--- a/apps/website/src/hooks/grouped.tsx
+++ b/apps/website/src/hooks/grouped.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/router";
 
 type ObjectKey<T> = Extract<keyof T, string>;
 
@@ -87,6 +88,8 @@ const useGrouped = <T, O extends Options<T>, I extends ObjectKey<O>>({
   // Ensures we don't immediately overwrite the URL anchor with the initial option
   const [checked, setChecked] = useState(false);
 
+  const router = useRouter();
+
   // When the option or group changes, update the URL anchor
   // If the option is the initial and there is no group, remove the anchor
   useEffect(() => {
@@ -95,7 +98,8 @@ const useGrouped = <T, O extends Options<T>, I extends ObjectKey<O>>({
     const url = new URL(window.location.href);
     url.hash =
       group || option !== initial ? `${option}${group ? `:${group}` : ""}` : "";
-    window.history.replaceState({}, "", url.toString());
+
+    router.replace(url.toString(), undefined, { scroll: false });
   }, [checked, option, group, initial]);
 
   // When the URL anchor changes, update the option and group
@@ -113,6 +117,7 @@ const useGrouped = <T, O extends Options<T>, I extends ObjectKey<O>>({
     // Mark that we've done an initial check
     setChecked(true);
   }, [options, update]);
+
   useEffect(() => {
     anchor();
     window.addEventListener("hashchange", anchor);


### PR DESCRIPTION
## Describe your changes

Use `router.replace` instead of `window.history.replaceState`, to preserve the functionality of back/forward on pages using `useGrouped`. Not sure *exactly* what was going on here but I think `replaceState` is clobbering some state on the history entry that Next relies on for navigation. 

## Notes for testing your change

Open the homepage, navigate to the ambassadors page, open one of the ambassadors' subpages. You should then be able go back twice to the homepage, then forward twice to the ambassador's subpage. Sorting options and group anchors should function as intended and scroll state should be preserved when returning to the ambassadors page via back/forward. 
