### PR TITLE
Refactor useGrouped to prevent render loops breaking navigation

### DIFF
--- a/apps/website/src/hooks/grouped.tsx
+++ b/apps/website/src/hooks/grouped.tsx
@@ -62,7 +62,10 @@ const useGrouped = <T, O extends Options<T>, I extends ObjectKey<O>>({
   initial,
 }: Props<T, O, I>) => {
   const calcState = useCallback(
-    (newOption: ObjectKey<O>, newGroup: GroupKey<T, O> | null = null) => {
+    (
+      newOption: ObjectKey<O>,
+      newGroup: GroupKey<T, O> | null = null,
+    ): State<T, O> => {
       // The current items will either be an array of items, or an object of groups of items
       const newItems = options[newOption]?.sort(items) || [];
 
@@ -81,7 +84,7 @@ const useGrouped = <T, O extends Options<T>, I extends ObjectKey<O>>({
   );
 
   // Track the active option, group and result
-  const [state, setState] = useState<State<T, O>>(() => calcState(initial));
+  const [state, setState] = useState(() => calcState(initial));
 
   const router = useRouter();
 

--- a/apps/website/src/hooks/grouped.tsx
+++ b/apps/website/src/hooks/grouped.tsx
@@ -104,8 +104,7 @@ const useGrouped = <T, O extends Options<T>, I extends ObjectKey<O>>({
 
   // When the URL anchor changes, update the option and group
   const anchor = useCallback(() => {
-    const url = new URL(window.location.href);
-    const hash = url.hash.slice(1);
+    const hash = window.location.hash.slice(1);
     const [newOption, newGroup] = hash.split(":");
 
     // Only continue if the option is valid

--- a/apps/website/src/hooks/grouped.tsx
+++ b/apps/website/src/hooks/grouped.tsx
@@ -36,7 +36,7 @@ type Result<T, O extends Options<T>> = O[ObjectKey<O>] extends {
   : never;
 
 // For each sort by option, if the option's sort function returns an object, we want to know the keys of that object
-// Again, this is essentially the same as keyof Grouped<T>, but allows for constraining the type if a constant is passed in
+// Again, this is essentially the same as keyof GroupedItems<T>, but allows for constraining the type if a constant is passed in
 type GroupKey<T, O extends Options<T>> = O[ObjectKey<O>] extends {
   sort: (items: T[]) => infer G;
 }

--- a/apps/website/src/hooks/grouped.tsx
+++ b/apps/website/src/hooks/grouped.tsx
@@ -45,12 +45,6 @@ type GroupKey<T, O extends Options<T>> = O[ObjectKey<O>] extends {
     : never
   : never;
 
-type State<T, O extends Options<T>> = {
-  option: ObjectKey<O>;
-  group: GroupKey<T, O> | null;
-  result: Result<T, O>;
-};
-
 const isOptionKey = <T, O extends Options<T>>(
   options: O,
   key: string | undefined,
@@ -62,10 +56,7 @@ const useGrouped = <T, O extends Options<T>, I extends ObjectKey<O>>({
   initial,
 }: Props<T, O, I>) => {
   const calcState = useCallback(
-    (
-      newOption: ObjectKey<O>,
-      newGroup: GroupKey<T, O> | null = null,
-    ): State<T, O> => {
+    (newOption: ObjectKey<O>, newGroup: GroupKey<T, O> | null = null) => {
       // The current items will either be an array of items, or an object of groups of items
       const newItems = options[newOption]?.sort(items) || [];
 


### PR DESCRIPTION
## Describe your changes

Replace the effect updating the URL by updating the URL within the update handler. This way a hash change wont trigger another URL update.

## Notes for testing your change

Check navigation works and url updates appropriately.
