### PR TITLE
Fix Show and Tell scroll position, disable fetching on focus

### DIFF
--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -78,6 +78,7 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
         pages: [{ items: initialEntries, nextCursor: nextCursor }],
       },
       getNextPageParam: (lastPage) => lastPage.nextCursor,
+      refetchOnWindowFocus: false,
     },
   );
 


### PR DESCRIPTION
## Describe your changes

<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->

resolves #379

## Notes for testing your change

- Find a post as your fix position
- Switch tab/window to lose focus 
- Wait for a post to be approved
- Switch back to tab and fix position will be the same
