### PR TITLE
Add YouTube to homepage watch live button as dropdown

### DIFF
--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -300,7 +300,17 @@ const config = {
     {
       source: "/live",
       destination: "https://twitch.tv/alveussanctuary",
-      permanent: false,
+      permanent: true,
+    },
+    {
+      source: "/live/twitch",
+      destination: "https://twitch.tv/alveussanctuary",
+      permanent: true,
+    },
+    {
+      source: "/live/youtube",
+      destination: "https://www.youtube.com/AlveusSanctuary/live",
+      permanent: true,
     },
   ],
   headers: async () => [

--- a/apps/website/src/components/content/WatchLive.tsx
+++ b/apps/website/src/components/content/WatchLive.tsx
@@ -22,17 +22,20 @@ const dropdownLinks = [
 ];
 
 const WatchLive = () => (
-  <Link
-    className="group/link inline-block rounded-full border-2 border-white px-4 py-2 text-lg transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
-    href={defaultLink.href}
-    target="_blank"
-    rel="noreferrer"
-  >
-    Watch Live on{" "}
+  <div className="group/link inline-flex rounded-full border-2 border-white text-lg transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green">
+    <Link
+      className="whitespace-pre-wrap py-2 pl-4"
+      href={defaultLink.href}
+      target="_blank"
+      rel="noreferrer"
+    >
+      Watch Live on{" "}
+    </Link>
+
     <Menu as="span" className="relative">
       {({ open }) => (
         <>
-          <Menu.Button className="group/button inline-flex items-center gap-0.5">
+          <Menu.Button className="group/button inline-flex items-center gap-0.5 py-2 pr-4">
             <span className="relative">
               {defaultLink.platform}
 
@@ -89,7 +92,7 @@ const WatchLive = () => (
         </>
       )}
     </Menu>
-  </Link>
+  </div>
 );
 
 export default WatchLive;

--- a/apps/website/src/components/content/WatchLive.tsx
+++ b/apps/website/src/components/content/WatchLive.tsx
@@ -1,0 +1,85 @@
+import { Fragment } from "react";
+import Link from "next/link";
+import { Menu, Transition } from "@headlessui/react";
+
+import IconChevronDown from "@/icons/IconChevronDown";
+import { classes } from "@/utils/classes";
+
+const defaultLink = {
+  href: "/live",
+  platform: "Twitch",
+};
+
+const dropdownLinks = [
+  {
+    href: "/live/twitch",
+    platform: "Twitch",
+  },
+  {
+    href: "/live/youtube",
+    platform: "YouTube",
+  },
+];
+
+const WatchLive = () => (
+  <Link
+    className="group inline-block rounded-full border-2 border-white px-4 py-2 text-lg transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
+    href={defaultLink.href}
+    target="_blank"
+    rel="noreferrer"
+  >
+    Watch Live on{" "}
+    <Menu as="span" className="relative">
+      {({ open }) => (
+        <>
+          <Menu.Button className="inline-flex items-center gap-0.5">
+            {defaultLink.platform}
+            <IconChevronDown
+              size={16}
+              className={classes(
+                "transition-transform",
+                open ? "translate-y-1" : "translate-y-0.5",
+              )}
+            />
+          </Menu.Button>
+
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-100"
+            enterFrom="transform opacity-0 scale-95"
+            enterTo="transform opacity-100 scale-100"
+            leave="transition ease-in duration-75"
+            leaveFrom="transform opacity-100 scale-100"
+            leaveTo="transform opacity-0 scale-95"
+          >
+            <Menu.Items
+              as="ul"
+              className="group absolute left-0 top-full z-30 -ml-4 mt-1 flex flex-col rounded  bg-alveus-tan text-alveus-green shadow-lg outline outline-1 outline-black/20"
+            >
+              {dropdownLinks.map((link) => (
+                <Menu.Item key={link.href} as="li">
+                  {({ active }) => (
+                    <a
+                      href={link.href}
+                      target="_blank"
+                      rel="noreferrer"
+                      className={classes(
+                        "block rounded px-4 py-1 transition-colors hover:bg-alveus-green  hover:text-alveus-tan",
+                        active &&
+                          "outline-blue-500 group-focus-visible:outline",
+                      )}
+                    >
+                      {link.platform}
+                    </a>
+                  )}
+                </Menu.Item>
+              ))}
+            </Menu.Items>
+          </Transition>
+        </>
+      )}
+    </Menu>
+  </Link>
+);
+
+export default WatchLive;

--- a/apps/website/src/components/content/WatchLive.tsx
+++ b/apps/website/src/components/content/WatchLive.tsx
@@ -23,7 +23,7 @@ const dropdownLinks = [
 
 const WatchLive = () => (
   <Link
-    className="group inline-block rounded-full border-2 border-white px-4 py-2 text-lg transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
+    className="group/link inline-block rounded-full border-2 border-white px-4 py-2 text-lg transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
     href={defaultLink.href}
     target="_blank"
     rel="noreferrer"
@@ -32,8 +32,18 @@ const WatchLive = () => (
     <Menu as="span" className="relative">
       {({ open }) => (
         <>
-          <Menu.Button className="inline-flex items-center gap-0.5">
-            {defaultLink.platform}
+          <Menu.Button className="group/button inline-flex items-center gap-0.5">
+            <span className="relative">
+              {defaultLink.platform}
+
+              <span
+                className={classes(
+                  "absolute inset-x-0 bottom-0 block h-0.5 bg-white transition-all group-hover/link:bg-alveus-green",
+                  open ? "max-w-full" : "max-w-0 group-hover/button:max-w-full",
+                )}
+              />
+            </span>
+
             <IconChevronDown
               size={16}
               className={classes(
@@ -54,7 +64,7 @@ const WatchLive = () => (
           >
             <Menu.Items
               as="ul"
-              className="group absolute left-0 top-full z-30 -ml-4 mt-1 flex flex-col rounded  bg-alveus-tan text-alveus-green shadow-lg outline outline-1 outline-black/20"
+              className="group/items absolute left-0 top-full z-30 -ml-4 mt-1 flex flex-col rounded  bg-alveus-tan text-alveus-green shadow-lg outline outline-1 outline-black/20"
             >
               {dropdownLinks.map((link) => (
                 <Menu.Item key={link.href} as="li">
@@ -66,7 +76,7 @@ const WatchLive = () => (
                       className={classes(
                         "block rounded px-4 py-1 transition-colors hover:bg-alveus-green  hover:text-alveus-tan",
                         active &&
-                          "outline-blue-500 group-focus-visible:outline",
+                          "outline-blue-500 group-focus-visible/items:outline",
                       )}
                     >
                       {link.platform}

--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -185,9 +185,10 @@ export function DesktopMenu() {
                         {link.title}
                         <IconChevronDown
                           size={16}
-                          className={`${
-                            open ? "translate-y-1" : "translate-y-0.5"
-                          } transition-transform`}
+                          className={classes(
+                            "transition-transform",
+                            open ? "translate-y-1" : "translate-y-0.5",
+                          )}
                         />
                       </Menu.Button>
 

--- a/apps/website/src/config/main-nav-structure.ts
+++ b/apps/website/src/config/main-nav-structure.ts
@@ -31,7 +31,7 @@ export const mainNavStructure: NavStructure = {
     title: "Explore",
     dropdown: {
       live: {
-        title: "Live",
+        title: "Live Cams",
         link: "/live",
         isExternal: true,
       },

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -2,19 +2,18 @@ import type { NextPage } from "next";
 import Link from "next/link";
 import Image from "next/image";
 import { useEffect, useState } from "react";
-import { Menu } from "@headlessui/react";
 
 import ambassadors from "@alveusgg/data/src/ambassadors/core";
 import { getAmbassadorImages } from "@alveusgg/data/src/ambassadors/images";
 
 import { typeSafeObjectEntries } from "@/utils/helpers";
 import { camelToKebab } from "@/utils/string-case";
-import { classes } from "@/utils/classes";
 import usePrefersReducedMotion from "@/hooks/motion";
 
 import { ambassadorImageHover } from "@/pages/ambassadors";
 
 import Heading from "@/components/content/Heading";
+import WatchLive from "@/components/content/WatchLive";
 import Slideshow from "@/components/content/Slideshow";
 import Section from "@/components/content/Section";
 import Carousel from "@/components/content/Carousel";
@@ -22,7 +21,6 @@ import { Lightbox } from "@/components/content/YouTube";
 import PlushieCarousel from "@/components/content/PlushieCarousel";
 import Consent from "@/components/Consent";
 
-import IconChevronDown from "@/icons/IconChevronDown";
 import IconAmazon from "@/icons/IconAmazon";
 import IconPayPal from "@/icons/IconPayPal";
 import IconEnvelope from "@/icons/IconEnvelope";
@@ -179,68 +177,7 @@ const Home: NextPage = () => {
               >
                 Meet the Ambassadors
               </Link>
-              <Link
-                className="group inline-block rounded-full border-2 border-white px-4 py-2 text-lg transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
-                href="/live"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Watch Live on{" "}
-                <Menu as="span" className="relative">
-                  {({ open }) => (
-                    <>
-                      <Menu.Button className="inline-flex items-center gap-0.5">
-                        Twitch
-                        <IconChevronDown
-                          size={16}
-                          className={classes(
-                            "transition-transform",
-                            open ? "translate-y-1" : "translate-y-0.5",
-                          )}
-                        />
-                      </Menu.Button>
-
-                      <Menu.Items
-                        as="ul"
-                        className="group absolute left-0 top-full z-30 -ml-3 mt-1 flex flex-col rounded  bg-alveus-tan text-alveus-green shadow-lg outline outline-1 outline-black/20"
-                      >
-                        <Menu.Item as="li">
-                          {({ active }) => (
-                            <a
-                              href="/live/twitch"
-                              target="_blank"
-                              rel="noreferrer"
-                              className={classes(
-                                "block rounded px-3 py-1 transition-colors hover:bg-alveus-green  hover:text-alveus-tan",
-                                active &&
-                                  "outline-blue-500 group-focus-visible:outline",
-                              )}
-                            >
-                              Twitch
-                            </a>
-                          )}
-                        </Menu.Item>
-                        <Menu.Item as="li">
-                          {({ active }) => (
-                            <a
-                              href="/live/youtube"
-                              target="_blank"
-                              rel="noreferrer"
-                              className={classes(
-                                "block rounded px-3 py-1 transition-colors hover:bg-alveus-green  hover:text-alveus-tan",
-                                active &&
-                                  "outline-blue-500 group-focus-visible:outline",
-                              )}
-                            >
-                              YouTube
-                            </a>
-                          )}
-                        </Menu.Item>
-                      </Menu.Items>
-                    </>
-                  )}
-                </Menu>
-              </Link>
+              <WatchLive />
             </div>
           </div>
 

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -2,12 +2,14 @@ import type { NextPage } from "next";
 import Link from "next/link";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import { Menu } from "@headlessui/react";
 
 import ambassadors from "@alveusgg/data/src/ambassadors/core";
 import { getAmbassadorImages } from "@alveusgg/data/src/ambassadors/images";
 
 import { typeSafeObjectEntries } from "@/utils/helpers";
 import { camelToKebab } from "@/utils/string-case";
+import { classes } from "@/utils/classes";
 import usePrefersReducedMotion from "@/hooks/motion";
 
 import { ambassadorImageHover } from "@/pages/ambassadors";
@@ -20,6 +22,7 @@ import { Lightbox } from "@/components/content/YouTube";
 import PlushieCarousel from "@/components/content/PlushieCarousel";
 import Consent from "@/components/Consent";
 
+import IconChevronDown from "@/icons/IconChevronDown";
 import IconAmazon from "@/icons/IconAmazon";
 import IconPayPal from "@/icons/IconPayPal";
 import IconEnvelope from "@/icons/IconEnvelope";
@@ -177,12 +180,66 @@ const Home: NextPage = () => {
                 Meet the Ambassadors
               </Link>
               <Link
-                className="inline-block rounded-full border-2 border-white px-4 py-2 text-lg transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
+                className="group inline-block rounded-full border-2 border-white px-4 py-2 text-lg transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
                 href="/live"
                 target="_blank"
                 rel="noreferrer"
               >
-                Watch Live
+                Watch Live on{" "}
+                <Menu as="span" className="relative">
+                  {({ open }) => (
+                    <>
+                      <Menu.Button className="inline-flex items-center gap-0.5">
+                        Twitch
+                        <IconChevronDown
+                          size={16}
+                          className={classes(
+                            "transition-transform",
+                            open ? "translate-y-1" : "translate-y-0.5",
+                          )}
+                        />
+                      </Menu.Button>
+
+                      <Menu.Items
+                        as="ul"
+                        className="group absolute left-0 top-full z-30 -ml-3 mt-1 flex flex-col rounded  bg-alveus-tan text-alveus-green shadow-lg outline outline-1 outline-black/20"
+                      >
+                        <Menu.Item as="li">
+                          {({ active }) => (
+                            <a
+                              href="/live/twitch"
+                              target="_blank"
+                              rel="noreferrer"
+                              className={classes(
+                                "block rounded px-3 py-1 transition-colors hover:bg-alveus-green  hover:text-alveus-tan",
+                                active &&
+                                  "outline-blue-500 group-focus-visible:outline",
+                              )}
+                            >
+                              Twitch
+                            </a>
+                          )}
+                        </Menu.Item>
+                        <Menu.Item as="li">
+                          {({ active }) => (
+                            <a
+                              href="/live/youtube"
+                              target="_blank"
+                              rel="noreferrer"
+                              className={classes(
+                                "block rounded px-3 py-1 transition-colors hover:bg-alveus-green  hover:text-alveus-tan",
+                                active &&
+                                  "outline-blue-500 group-focus-visible:outline",
+                              )}
+                            >
+                              YouTube
+                            </a>
+                          )}
+                        </Menu.Item>
+                      </Menu.Items>
+                    </>
+                  )}
+                </Menu>
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## Describe your changes

Resolves #497

Closes #503

Adds a new shortlink for the YT livestream (`/live/youtube`), and a matching link for Twitch (`/live/twitch`).

Adds a new dropdown the homepage `Watch Live` button, allowing the user to pick YouTube instead of Twitch if they wish. The button is still a link to Twitch by default, and still only requires a single click if the user does not click on `Twitch` specifically.

## Notes for testing your change

Shortlinks both work as expected. Watch Live button is intuitive to interact with, and still allows for single-click navigation.
