### PR TITLE
Remove December 1st messaging for top-hat promo

### DIFF
--- a/apps/website/src/data/promo.ts
+++ b/apps/website/src/data/promo.ts
@@ -8,10 +8,10 @@ interface Promo {
 }
 
 const promo: Promo | null = {
-  title: "Holiday Sweaters & 2024 Calendars",
-  subtitle: "Available from December 1st",
+  title: "Holiday Sweaters, 2024 Calendars, and more",
+  subtitle: "Available Now",
   content:
-    "Grab yourself an embroidered Holiday sweater and a 2024 calendar featuring a selection of our ambassadors, shipping worldwide and in time for Christmas.",
+    "Grab yourself an embroidered Holiday sweater, a 2024 calendar featuring a selection of our ambassadors, or discover more Alveus apparel in the store.",
   link: "/apparel",
   external: true,
   excluded: [],


### PR DESCRIPTION
## Describe your changes

As we're into the new year now, the Dec 1st messaging doesn't really make sense.

## Notes for testing your change

Updated wording seems fine.