### PR TITLE
Prefer meta noindex over robots.txt disallow

### DIFF
--- a/apps/website/next-sitemap.config.cjs
+++ b/apps/website/next-sitemap.config.cjs
@@ -14,8 +14,6 @@ module.exports = {
     "/auth/*",
     "/admin",
     "/admin/*",
-    "/wip",
-    "/wip/*",
     "/forms",
     "/forms/*",
     "/show-and-tell/*",
@@ -32,7 +30,7 @@ module.exports = {
         disallow:
           process.env.NEXT_PUBLIC_NOINDEX === "true"
             ? ["/"]
-            : ["/api/", "/bingo/play/", "/auth/", "/admin/", "/wip/"],
+            : ["/api/", "/bingo/play/", "/auth/", "/admin/"],
       },
     ],
   },

--- a/apps/website/next-sitemap.config.cjs
+++ b/apps/website/next-sitemap.config.cjs
@@ -39,7 +39,6 @@ module.exports = {
                 "/admin/",
                 "/wip/",
                 "/forms/",
-                "/privacy-policy",
               ],
       },
     ],

--- a/apps/website/next-sitemap.config.cjs
+++ b/apps/website/next-sitemap.config.cjs
@@ -32,14 +32,7 @@ module.exports = {
         disallow:
           process.env.NEXT_PUBLIC_NOINDEX === "true"
             ? ["/"]
-            : [
-                "/api/",
-                "/bingo/play/",
-                "/auth/",
-                "/admin/",
-                "/wip/",
-                "/forms/",
-              ],
+            : ["/api/", "/bingo/play/", "/auth/", "/admin/", "/wip/"],
       },
     ],
   },

--- a/apps/website/src/components/content/Meta.tsx
+++ b/apps/website/src/components/content/Meta.tsx
@@ -9,13 +9,14 @@ type MetaProps = {
   title?: string;
   description?: string;
   image?: string;
+  noindex?: boolean;
   children?: ReactNode;
 };
 
 // Get our base URL, which will either be specifically set, or from Vercel for preview deployments
 const BASE_URL = env.NEXT_PUBLIC_BASE_URL;
 
-const Meta = ({ title, description, image, children }: MetaProps) => {
+const Meta = ({ title, description, image, noindex, children }: MetaProps) => {
   const defaultTitle = "Alveus Sanctuary";
   const defaultDescription =
     "Alveus is a 501(c)(3) nonprofit organization functioning as a wildlife sanctuary & virtual education center following the journeys of our non-releasable ambassadors, aiming to educate and spark an appreciation for them and their wild counterparts.";
@@ -64,7 +65,7 @@ const Meta = ({ title, description, image, children }: MetaProps) => {
         content={computedDescription}
       />
       <meta key="twitter:image" name="twitter:image" content={computedImage} />
-      {env.NEXT_PUBLIC_NOINDEX === "true" && (
+      {(env.NEXT_PUBLIC_NOINDEX === "true" || noindex) && (
         <meta key="robots" name="robots" content="noindex" />
       )}
       {children}

--- a/apps/website/src/pages/forms/[formId]/index.tsx
+++ b/apps/website/src/pages/forms/[formId]/index.tsx
@@ -67,6 +67,7 @@ const FormPage: NextPage<FormPageProps> = ({ form, ...props }) => (
     <Meta
       title={form.label}
       description={`Check out the ${form.label} form at Alveus.`}
+      noindex
     />
 
     {/* Nav background */}

--- a/apps/website/src/pages/forms/[formId]/rules.tsx
+++ b/apps/website/src/pages/forms/[formId]/rules.tsx
@@ -55,6 +55,7 @@ const FormPage: NextPage<FormPageProps> = ({ form, rules }) => {
       <Meta
         title={`Rules | ${form.label} | Forms`}
         description={`Rules for the ${form.label} form at Alveus.`}
+        noindex
       />
 
       {/* Nav background */}

--- a/apps/website/src/pages/forms/index.tsx
+++ b/apps/website/src/pages/forms/index.tsx
@@ -32,7 +32,11 @@ export const getStaticProps: GetStaticProps<{
 const FormsPage: NextPage<FormsPageProps> = ({ forms }) => {
   return (
     <>
-      <Meta title="Forms" description="Check out the latest forms at Alveus." />
+      <Meta
+        title="Forms"
+        description="Check out the latest forms at Alveus."
+        noindex
+      />
 
       {/* Nav background */}
       <div className="-mt-40 hidden h-40 bg-alveus-green-900 lg:block" />

--- a/apps/website/src/pages/privacy-policy.tsx
+++ b/apps/website/src/pages/privacy-policy.tsx
@@ -12,6 +12,7 @@ const PrivacyPolicyPage: NextPage = () => {
       <Meta
         title="Privacy Policy"
         description="At Alveus Sanctuary Inc., one of our main priorities is the privacy of our visitors. This Privacy Policy document contains types of information that is collected and recorded by Alveus Sanctuary Inc. and how we use it."
+        noindex
       />
 
       {/* Nav background */}


### PR DESCRIPTION
## Describe your changes

When a route is disallowed in robots.txt, Google can't access it at all, and is unsure if it should be indexed or not. If instead we allow Google to access it, and explicitly set a noindex meta tag, we ensure that Google knows not to index those pages ever.

## Notes for testing your change

noindex present on privacy policy + all forms pages.