### PR TITLE
Bypass consent for crawlers on AQ pages

### DIFF
--- a/apps/website/src/components/Consent.tsx
+++ b/apps/website/src/components/Consent.tsx
@@ -1,4 +1,9 @@
-import { useCallback, type MouseEventHandler, type ReactNode } from "react";
+import {
+  useCallback,
+  type MouseEventHandler,
+  type ReactNode,
+  useMemo,
+} from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -14,12 +19,32 @@ import Link from "@/components/content/Link";
 type ConsentProps = {
   item: string;
   consent: ConsentKey;
+  indexable?: boolean;
   className?: string;
   children: ReactNode;
 };
 
-const Consent = ({ item, consent: key, className, children }: ConsentProps) => {
+const Consent = ({
+  item,
+  consent: key,
+  indexable,
+  className,
+  children,
+}: ConsentProps) => {
+  // Get the current user consent state
+  // If this is "indexable", we'll ignore consent for known crawlers
   const { consent, update, loaded } = useConsent();
+  const crawling = useMemo(
+    () =>
+      indexable &&
+      typeof navigator !== "undefined" &&
+      ["googlebot", "bingbot", "linkedinbot"].some((bot) =>
+        navigator.userAgent.toLowerCase().includes(bot),
+      ),
+    [indexable],
+  );
+
+  // When the user clicks the consent button, update the state
   const clicked = useCallback<MouseEventHandler<HTMLButtonElement>>(
     (e) => {
       e.preventDefault();
@@ -36,7 +61,7 @@ const Consent = ({ item, consent: key, className, children }: ConsentProps) => {
       )}
     >
       {loaded &&
-        (consent[key] ? (
+        (crawling || consent[key] ? (
           <>
             <p className="absolute -z-10 m-auto text-2xl" aria-hidden="true">
               Loading {item}...

--- a/apps/website/src/pages/animal-quest/[episodeName].tsx
+++ b/apps/website/src/pages/animal-quest/[episodeName].tsx
@@ -422,6 +422,7 @@ const AnimalQuestEpisodePage: NextPage<AnimalQuestEpisodePageProps> = ({
             item="episode video"
             consent="twitch"
             className="aspect-video h-auto w-full rounded-2xl bg-alveus-green text-alveus-tan"
+            indexable
           >
             {twitchEmbed && (
               <iframe


### PR DESCRIPTION
## Describe your changes

This is a bit of an experiment, with the aim hopefully for Google to index the AQ episode pages as video pages.

Google currently sees them as _potential_ video pages, but only due to the OG meta tags, not due to the video content actually on the page (it can't see that as it is behind content).

![image](https://github.com/alveusgg/alveusgg/assets/12371363/c534500b-3a88-4974-a84f-9546d720e733)

As such, this PR adds a new flag to the consent component, so that we can opt specific usages of it into bypassing the consent screen when we want it to be indexed by known crawlers.

## Notes for testing your change

Using a tool to fake your user-agent as Googlebot (https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers), with consent set to deny all, the Twitch embed on the AQ episode pages should still load.
