### PR TITLE
Replace offer help w/ PO Box on homepage

### DIFF
--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -22,8 +22,8 @@ import PlushieCarousel from "@/components/content/PlushieCarousel";
 import Consent from "@/components/Consent";
 
 import IconAmazon from "@/icons/IconAmazon";
+import IconBox from "@/icons/IconBox";
 import IconPayPal from "@/icons/IconPayPal";
-import IconEnvelope from "@/icons/IconEnvelope";
 
 import mayaImage from "@/assets/maya.png";
 
@@ -100,20 +100,20 @@ const featuredAmbassadors = typeSafeObjectEntries(ambassadors)
 const help = {
   donate: {
     icon: IconPayPal,
-    title: "Donate via PayPal",
-    link: "/paypal",
-    external: true,
+    title: "Donate to Alveus directly",
+    link: "/donate",
+    external: false,
   },
   amazon: {
     icon: IconAmazon,
-    title: "Amazon Wishlist",
+    title: "Gift via our Amazon Wishlist",
     link: "/wishlist",
     external: true,
   },
   contact: {
-    icon: IconEnvelope,
-    title: "Offer Help",
-    link: "/contact-us",
+    icon: IconBox,
+    title: "Send items to our PO Box",
+    link: "/po-box",
     external: false,
   },
 };


### PR DESCRIPTION
## Describe your changes

Offer Help linked to the Contact Us page which historically had an email to reach out to if you had skills to offer. We removed that email in #351, but didn't update the homepage at the time. This updates the How to Help section to link to the PO Box instead of the Contact Us page, and updates the donate link to be to the donate page so the user has all the options, instead of directly to PayPal.

## Notes for testing your change

Links work, text makes sense.