### PR TITLE
Bump security policy expiry to 2025

### DIFF
--- a/apps/website/public/.well-known/security.txt
+++ b/apps/website/public/.well-known/security.txt
@@ -1,4 +1,4 @@
 Contact: mailto:opensource@alveussanctuary.org
 Policy: https://github.com/alveusgg/alveusgg/blob/main/SECURITY.md
-Expires: 2024-01-31T04:00:00.000Z
+Expires: 2025-01-31T04:00:00.000Z
 Preferred-Languages: en


### PR DESCRIPTION
## Describe your changes

Per https://www.rfc-editor.org/rfc/rfc9116#section-2.5.5 expires should be a year or so into the future.

## Notes for testing your change

Date is updated.