### PR TITLE
Set HTML background to avoid white on overscroll

### DIFF
--- a/apps/website/src/pages/_document.tsx
+++ b/apps/website/src/pages/_document.tsx
@@ -2,7 +2,10 @@ import { Html, Head, Main, NextScript } from "next/document";
 
 const Document = () => {
   return (
-    <Html lang="en">
+    <Html
+      lang="en"
+      className="bg-gradient-to-b from-alveus-green-900 from-45% to-gray-800 to-55% bg-fixed"
+    >
       <Head />
       <body>
         <Main />


### PR DESCRIPTION
## Describe your changes

Sets a background on the base HTML element of the page, ensuring that any overscroll on pages shows a correctly colored background that matches the page, rather than a white background.

### Before

https://github.com/alveusgg/alveusgg/assets/12371363/6ae9920f-5069-4480-895e-61af178478a9

https://github.com/alveusgg/alveusgg/assets/12371363/343f8bdb-7273-4c3a-99a4-5c5aa0bb88f9

### After

https://github.com/alveusgg/alveusgg/assets/12371363/aba96acb-79b7-4349-b93b-03d92c3f699e

https://github.com/alveusgg/alveusgg/assets/12371363/f1ae7b79-fc70-47f5-b9e9-426fb43e0be3

## Notes for testing your change

In browsers that offer "bouncy" scroll that will overscroll the page slightly, when pulling down at the top of the page (such that the nav moves down the page), the overscroll is now the same color as the nav background (on most pages) rather than being white. Similarly, at the bottom of the page if you attempt to keep scrolling (such that the footer moves up the page), the overscroll is now the same color as the footer background rather than being white.
