### PR TITLE
Swap StreamElements for Fossabot on commands page, fix overflow + inconsistent anchors

### DIFF
--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -104,7 +104,7 @@ const AboutTechPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-28 -right-8 z-10 hidden h-auto w-1/2 max-w-[10rem] rotate-45 -scale-x-100 select-none lg:block 2xl:max-w-[12rem]"
+          className="pointer-events-none absolute -bottom-32 right-0 z-10 hidden h-auto w-1/2 max-w-[10rem] -scale-x-100 select-none lg:block"
         />
 
         <Section>

--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -203,7 +203,7 @@ const AboutTechPage: NextPage = () => {
                   <Heading
                     level={3}
                     className="text-2xl"
-                    id={`commands-${sentenceToKebab(category)}`}
+                    id={`commands:${sentenceToKebab(category)}`}
                     link
                   >
                     {category}
@@ -289,7 +289,7 @@ const AboutTechPage: NextPage = () => {
                     <Heading
                       level={3}
                       className="text-2xl"
-                      id={`presets-${camelToKebab(camera)}`}
+                      id={`presets:${camelToKebab(camera)}`}
                       link
                     >
                       {title}

--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -240,25 +240,25 @@ const AboutTechPage: NextPage = () => {
       </div>
 
       <Section dark>
-        <Heading level={2} className="mb-2 mt-0" id="streamelements" link>
-          StreamElements
+        <Heading level={2} className="mb-2 mt-0" id="fossabot" link>
+          Fossabot
         </Heading>
 
         <div className="flex flex-row flex-wrap items-center gap-x-16 gap-y-4 lg:flex-nowrap">
           <p className="text-lg">
-            Alongside the custom chat bot for all the commands above,
-            StreamElements is also used in the Twitch (and YouTube) chat to
-            provide a set of commands that anyone can access, providing easy
-            access to a bunch of common information and links.
+            Alongside the custom chat bot for all the commands above, Fossabot
+            is also used in the Twitch chat to provide a set of commands that
+            anyone can access, providing easy access to a bunch of common
+            information and links.
           </p>
 
           <Link
-            href="https://streamelements.com/alveussanctuary/commands"
+            href="https://fossabot.com/alveussanctuary/commands"
             className="text-md mx-auto inline-block flex-shrink-0 rounded-full border-2 border-white px-4 py-2 transition-colors hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
             custom
             external
           >
-            Explore StreamElements Commands
+            Explore Fossabot Commands
           </Link>
         </div>
       </Section>


### PR DESCRIPTION
## Describe your changes

Resolves #519, fixes an overflow on the page caused by one of the leaves, and updates the heading anchors to be more consistent with our other pages (e.g. /ambassadors#classification:birds)

## Notes for testing your change

No overflow, Fossabot link works.