### PR TITLE
Link component should always underline

### DIFF
--- a/apps/website/src/components/admin/forms/Forms.tsx
+++ b/apps/website/src/components/admin/forms/Forms.tsx
@@ -1,10 +1,14 @@
 import type { inferRouterOutputs } from "@trpc/server";
-import Link from "next/link";
 import { useCallback, useState } from "react";
 import { Menu } from "@headlessui/react";
 
 import type { AppRouter } from "@/server/trpc/router/_app";
 import { trpc } from "@/utils/trpc";
+
+import IconPencil from "@/icons/IconPencil";
+import IconTrash from "@/icons/IconTrash";
+import IconEllipsis from "@/icons/IconEllipsis";
+import IconDownload from "@/icons/IconDownload";
 
 import {
   Button,
@@ -13,13 +17,12 @@ import {
   secondaryButtonClasses,
 } from "@/components/shared/Button";
 import { ModalDialog } from "@/components/shared/ModalDialog";
+
+import DateTime from "@/components/content/DateTime";
+import Link from "@/components/content/Link";
+
 import { Headline } from "@/components/admin/Headline";
 import { Panel } from "@/components/admin/Panel";
-import DateTime from "@/components/content/DateTime";
-import IconPencil from "@/icons/IconPencil";
-import IconTrash from "@/icons/IconTrash";
-import IconEllipsis from "@/icons/IconEllipsis";
-import IconDownload from "@/icons/IconDownload";
 
 type RouterOutput = inferRouterOutputs<AppRouter>;
 type FormWithCount = RouterOutput["adminForms"]["getForms"][number];
@@ -92,11 +95,7 @@ function Form({ form, onError, onUpdate }: FormProps) {
           <div className="flex flex-col gap-0.5">
             <div className="text-xl">{form.label}</div>
             <div className="flex flex-col gap-1">
-              <Link
-                className="underline"
-                href={`/forms/${form.slug || form.id}`}
-                target="_blank"
-              >
+              <Link href={`/forms/${form.slug || form.id}`} external>
                 Public Link: {form.slug || form.id}
               </Link>
               <button

--- a/apps/website/src/components/content/Link.tsx
+++ b/apps/website/src/components/content/Link.tsx
@@ -24,7 +24,7 @@ const Link = ({
   const computedClassName = useMemo(
     () =>
       classes(
-        !custom && "transition-colors hover:underline",
+        !custom && "transition-colors underline",
         !custom &&
           (dark
             ? "text-red-200 hover:text-blue-200"

--- a/apps/website/src/components/forms/ConsentFieldset.tsx
+++ b/apps/website/src/components/forms/ConsentFieldset.tsx
@@ -1,8 +1,9 @@
 import { PLACEHOLDER_ASK_MARKETING_EMAILS_LABEL } from "@/utils/forms";
 
-import Link from "../content/Link";
-import { Fieldset } from "../shared/form/Fieldset";
-import { CheckboxField } from "../shared/form/CheckboxField";
+import { Fieldset } from "@/components/shared/form/Fieldset";
+import { CheckboxField } from "@/components/shared/form/CheckboxField";
+
+import Link from "@/components/content/Link";
 
 export function ConsentFieldset({
   withShippingAddress = false,
@@ -13,7 +14,7 @@ export function ConsentFieldset({
     <Fieldset legend="Data processing">
       <CheckboxField isRequired={true} name="acceptPrivacy" value="yes">
         I have read and accept the{" "}
-        <Link className="underline" href="/privacy-policy" external>
+        <Link href="/privacy-policy" external>
           Privacy Policy
         </Link>
         .{" "}

--- a/apps/website/src/components/forms/EntryRulesFieldset.tsx
+++ b/apps/website/src/components/forms/EntryRulesFieldset.tsx
@@ -1,8 +1,9 @@
 import type { Form } from "@prisma/client";
-import Link from "next/link";
 
-import { Fieldset } from "../shared/form/Fieldset";
-import { CheckboxField } from "../shared/form/CheckboxField";
+import { Fieldset } from "@/components/shared/form/Fieldset";
+import { CheckboxField } from "@/components/shared/form/CheckboxField";
+
+import Link from "@/components/content/Link";
 
 type EntryRulesFieldsetProps = {
   form: Form;
@@ -13,11 +14,7 @@ export function EntryRulesFieldset({ form }: EntryRulesFieldsetProps) {
     <Fieldset legend="Rules">
       <CheckboxField isRequired={true} name="acceptRules" value="yes">
         I agree to the{" "}
-        <Link
-          className="underline"
-          href={`/forms/${form.slug || form.id}/rules`}
-          target="_blank"
-        >
+        <Link href={`/forms/${form.slug || form.id}/rules`} external>
           Official Rules
         </Link>
       </CheckboxField>

--- a/apps/website/src/components/tech/Network.tsx
+++ b/apps/website/src/components/tech/Network.tsx
@@ -20,6 +20,9 @@ import { classes } from "@/utils/classes";
 import { convertToSlug } from "@/utils/slugs";
 
 import IconExternal from "@/icons/IconExternal";
+
+import Link from "@/components/content/Link";
+
 import Tree, { type TreeNode } from "@/components/tech/Tree";
 
 type Data = {
@@ -340,14 +343,9 @@ const NetworkList = ({
         <p>
           Model:{" "}
           {item.url ? (
-            <a
-              href={item.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline"
-            >
+            <Link href={item.url} external>
               {item.model}
-            </a>
+            </Link>
           ) : (
             item.model
           )}

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -108,7 +108,7 @@ const GiveAnHourPage: NextPage = () => {
           <p className="text-md mt-8">
             Given an hour? Share your activities with the community and inspire
             others, via the{" "}
-            <Link href="/show-and-tell/submit-post" dark className="underline">
+            <Link href="/show-and-tell/submit-post" dark>
               Show and Tell
             </Link>{" "}
             page.
@@ -266,12 +266,7 @@ const GiveAnHourPage: NextPage = () => {
           </p>
 
           <p className="mt-4 text-lg">
-            <Link
-              href={giveAnHourPoster.src}
-              external
-              dark
-              className="underline"
-            >
+            <Link href={giveAnHourPoster.src} external dark>
               Download this guide as a poster
             </Link>{" "}
             to share with your community and inspire others to take action.
@@ -299,10 +294,7 @@ const GiveAnHourPage: NextPage = () => {
           <p className="text-lg">
             Share the hours you&apos;ve given and what you&apos;ve been doing
             with the Alveus community and inspire others, via the{" "}
-            <Link href="/show-and-tell/submit-post" className="underline">
-              Show and Tell
-            </Link>{" "}
-            page.
+            <Link href="/show-and-tell/submit-post">Show and Tell</Link> page.
           </p>
 
           <p className="mt-8 text-lg">

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -348,7 +348,7 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
 
           <p className="text-lg">
             Been up to something yourself? Share your own activities via the{" "}
-            <Link href="/show-and-tell/submit-post" dark className="underline">
+            <Link href="/show-and-tell/submit-post" dark>
               submission page
             </Link>
             .
@@ -357,7 +357,7 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
           <p className="mt-8">
             As a community, we&apos;re tracking the hours we spend giving back
             to the planet, as part of the WWF&apos;s{" "}
-            <Link href="/show-and-tell/give-an-hour" dark className="underline">
+            <Link href="/show-and-tell/give-an-hour" dark>
               Give an Hour
             </Link>{" "}
             initiative.

--- a/apps/website/src/pages/show-and-tell/posts/[postId]/index.tsx
+++ b/apps/website/src/pages/show-and-tell/posts/[postId]/index.tsx
@@ -68,17 +68,12 @@ const ShowAndTellEntryPage: NextPage<
 
           <p className="text-lg">
             Been up to something yourself? Share your own activities via the{" "}
-            <Link href="/show-and-tell/submit-post" className="underline">
-              submission page
-            </Link>
-            .
+            <Link href="/show-and-tell/submit-post">submission page</Link>.
           </p>
 
           <p className="mt-8 text-lg">
             <IconArrowRight className="inline-block h-5 w-5 rotate-180" />{" "}
-            <Link href="/show-and-tell" className="underline">
-              Back to all posts
-            </Link>
+            <Link href="/show-and-tell">Back to all posts</Link>
           </p>
         </div>
 


### PR DESCRIPTION
## Describe your changes

A lot of our usage of `Link` already set `underline`, and where we don't do it Lighthouse informs us that we should for accessibility. As such, updating `Link` to set `underline` always, not just on hover, and cleaning up usages relating to that.

## Notes for testing your change

`Link` used where expected, text always underlined.