### PR TITLE
Remove merch promo from tophat

### DIFF
--- a/apps/website/src/data/promo.ts
+++ b/apps/website/src/data/promo.ts
@@ -7,14 +7,6 @@ interface Promo {
   excluded: string[];
 }
 
-const promo: Promo | null = {
-  title: "Holiday Sweaters, 2024 Calendars, and more",
-  subtitle: "Available Now",
-  content:
-    "Grab yourself an embroidered Holiday sweater, a 2024 calendar featuring a selection of our ambassadors, or discover more Alveus apparel in the store.",
-  link: "/apparel",
-  external: true,
-  excluded: [],
-};
+const promo: Promo | null = null;
 
 export default promo;


### PR DESCRIPTION
## Describe your changes

We're well into the New Year now, so promoting holiday sweaters and calendars seems a bit dated.

## Notes for testing your change

Tophat promo removed.