### PR TITLE
Use Grouped component/hook for events + collaborations

### DIFF
--- a/apps/website/src/components/content/Grouped.tsx
+++ b/apps/website/src/components/content/Grouped.tsx
@@ -7,6 +7,8 @@ export interface GroupedProps<T> {
   option: string;
   group: string | null;
   name: string | null;
+  index: number | null;
+  size: number | null;
 }
 
 type Component<T, R extends HTMLElement> = ComponentType<
@@ -17,6 +19,8 @@ const Group = <T, R extends HTMLElement>({
   option,
   group,
   name,
+  index,
+  size,
   items,
   active,
   component: Component,
@@ -24,6 +28,8 @@ const Group = <T, R extends HTMLElement>({
   option: string;
   group: string;
   name: string;
+  index: number;
+  size: number;
   items: T[];
   active: boolean;
   component: Component<T, R>;
@@ -42,6 +48,8 @@ const Group = <T, R extends HTMLElement>({
       items={items}
       option={option}
       group={group}
+      index={index}
+      size={size}
       name={name}
     />
   );
@@ -59,14 +67,23 @@ const Grouped = <T, R extends HTMLElement>({
   component: Component<T, R>;
 }) => {
   return Array.isArray(result) ? (
-    <Component items={result} option={option} group={group} name={null} />
+    <Component
+      items={result}
+      option={option}
+      group={group}
+      name={null}
+      index={null}
+      size={null}
+    />
   ) : (
-    [...result.entries()].map(([key, val]) => (
+    [...result.entries()].map(([key, val], idx) => (
       <Group
         key={key}
         option={option}
         group={key}
         name={val.name}
+        index={idx}
+        size={result.size}
         items={val.items}
         active={key === group}
         component={Component}

--- a/apps/website/src/components/content/YouTube.tsx
+++ b/apps/website/src/components/content/YouTube.tsx
@@ -5,6 +5,7 @@ import {
   useId,
   useMemo,
   useState,
+  forwardRef,
   type ReactNode,
 } from "react";
 import PhotoSwipeLightbox from "photoswipe/lightbox";
@@ -147,182 +148,180 @@ type LightboxProps = {
   onChange?: (value?: string) => void;
 };
 
-export const Lightbox = ({
-  id,
-  className,
-  children,
-  value,
-  onChange,
-}: LightboxProps) => {
-  const { update: updateConsent } = useConsent();
+export const Lightbox = forwardRef<HTMLDivElement, LightboxProps>(
+  ({ id, className, children, value, onChange }, ref) => {
+    const { update: updateConsent } = useConsent();
 
-  // Start up Photoswipe lightbox
-  const defaultId = useId().replace(/\W/g, "").toLowerCase();
-  const photoswipeId = `photoswipe-${id || defaultId}`;
-  const [photoswipe, setPhotoswipe] = useState<PhotoSwipeLightbox>();
+    // Start up Photoswipe lightbox
+    const defaultId = useId().replace(/\W/g, "").toLowerCase();
+    const photoswipeId = `photoswipe-${id || defaultId}`;
+    const [photoswipe, setPhotoswipe] = useState<PhotoSwipeLightbox>();
 
-  useEffect(() => {
-    const opts = {
-      ...getDefaultPhotoswipeLightboxOptions(),
-      gallery: `#${photoswipeId}`,
-      mainClass: `pswp--${photoswipeId}`,
-      children: `a[data-lightbox-${photoswipeId}]`,
-      preloaderDelay: 0,
-    };
-    const lightbox = new PhotoSwipeLightbox(opts);
+    useEffect(() => {
+      const opts = {
+        ...getDefaultPhotoswipeLightboxOptions(),
+        gallery: `#${photoswipeId}`,
+        mainClass: `pswp--${photoswipeId}`,
+        children: `a[data-lightbox-${photoswipeId}]`,
+        preloaderDelay: 0,
+      };
+      const lightbox = new PhotoSwipeLightbox(opts);
 
-    // Expose the video id
-    lightbox.addFilter("itemData", (itemData) => ({
-      ...itemData,
-      trigger: safeJsonParse(
-        itemData.element?.getAttribute(`data-lightbox-${photoswipeId}`) || "",
-      ),
-    }));
+      // Expose the video id
+      lightbox.addFilter("itemData", (itemData) => ({
+        ...itemData,
+        trigger: safeJsonParse(
+          itemData.element?.getAttribute(`data-lightbox-${photoswipeId}`) || "",
+        ),
+      }));
 
-    // Create the lightbox iframe
-    lightbox.on("contentLoad", (e) => {
-      const { content } = e;
-      if (!content.data.trigger?.videoId) return;
+      // Create the lightbox iframe
+      lightbox.on("contentLoad", (e) => {
+        const { content } = e;
+        if (!content.data.trigger?.videoId) return;
 
-      // Prevent the default content load
-      e.preventDefault();
+        // Prevent the default content load
+        e.preventDefault();
 
-      // Ensure the user has consented to YouTube
-      updateConsent({ youtube: true });
+        // Ensure the user has consented to YouTube
+        updateConsent({ youtube: true });
 
-      // Create our content element
-      content.element = document.createElement("div");
-      content.element.className =
-        "pointer-events-none flex flex-col items-center h-full w-full p-0 md:p-4 lg:p-8";
+        // Create our content element
+        content.element = document.createElement("div");
+        content.element.className =
+          "pointer-events-none flex flex-col items-center h-full w-full p-0 md:p-4 lg:p-8";
 
-      // Create our video wrapper
-      const wrapper = document.createElement("div");
-      wrapper.className = `flex items-center justify-center h-full w-full pswp--${photoswipeId}-wrapper`;
-      content.element.appendChild(wrapper);
+        // Create our video wrapper
+        const wrapper = document.createElement("div");
+        wrapper.className = `flex items-center justify-center h-full w-full pswp--${photoswipeId}-wrapper`;
+        content.element.appendChild(wrapper);
 
-      // Create our iframe
-      const iframe = document.createElement("iframe");
-      iframe.src = iframeSrc(content.data.trigger.videoId);
-      Object.entries(iframeAttrs).forEach(([key, value]) => {
-        iframe.setAttribute(camelToKebab(key), value);
+        // Create our iframe
+        const iframe = document.createElement("iframe");
+        iframe.src = iframeSrc(content.data.trigger.videoId);
+        Object.entries(iframeAttrs).forEach(([key, value]) => {
+          iframe.setAttribute(camelToKebab(key), value);
+        });
+        iframe.className = classes("pointer-events-auto", iframe.className);
+
+        // Allow full-screen for the iframe
+        iframe.allowFullscreen = true;
+        iframe.allow = ["fullscreen", iframe.allow].filter(Boolean).join("; ");
+
+        // Register the photoswipe load bindings
+        iframe.addEventListener("load", () => {
+          content.onLoaded();
+        });
+        iframe.addEventListener("error", () => {
+          content.onError();
+        });
+
+        // Append the iframe
+        wrapper.appendChild(iframe);
+
+        // If we have a caption, add it
+        if (content.data.trigger.caption) {
+          const caption = document.createElement("div");
+          caption.className = "text-alveus-tan text-xl my-4 md:mb-0 lg:mt-8";
+          caption.innerHTML = content.data.trigger.caption;
+          content.element.appendChild(caption);
+        }
       });
-      iframe.className = classes("pointer-events-auto", iframe.className);
 
-      // Allow full-screen for the iframe
-      iframe.allowFullscreen = true;
-      iframe.allow = ["fullscreen", iframe.allow].filter(Boolean).join("; ");
-
-      // Register the photoswipe load bindings
-      iframe.addEventListener("load", () => {
-        content.onLoaded();
-      });
-      iframe.addEventListener("error", () => {
-        content.onError();
+      // Expose the current slide to the controlled value
+      lightbox.on("contentActivate", ({ content }) => {
+        if (onChange) onChange(content.data.trigger?.triggerId);
       });
 
-      // Append the iframe
-      wrapper.appendChild(iframe);
+      // When closing, let the controlled value know
+      lightbox.on("close", () => {
+        if (onChange) onChange(undefined);
+      });
 
-      // If we have a caption, add it
-      if (content.data.trigger.caption) {
-        const caption = document.createElement("div");
-        caption.className = "text-alveus-tan text-xl my-4 md:mb-0 lg:mt-8";
-        caption.innerHTML = content.data.trigger.caption;
-        content.element.appendChild(caption);
+      // Initialize the lightbox
+      lightbox.init();
+      setPhotoswipe(lightbox);
+
+      // Do the cleanup in the reverse order
+      return () => {
+        setPhotoswipe(undefined);
+        lightbox.destroy();
+      };
+    }, [photoswipeId, updateConsent, onChange]);
+
+    // If the controlled value changes, make sure the lightbox and it are in sync
+    useEffect(() => {
+      // If we have no lightbox, do nothing
+      if (!photoswipe) return;
+
+      // If we have no value, close the lightbox
+      if (!value) {
+        photoswipe.pswp?.close();
+        return;
       }
-    });
 
-    // Expose the current slide to the controlled value
-    lightbox.on("contentActivate", ({ content }) => {
-      if (onChange) onChange(content.data.trigger?.triggerId);
-    });
+      // If photoswipe is active and the value is the same, do nothing
+      const active = photoswipe.pswp?.currSlide?.data?.trigger?.triggerId as
+        | string
+        | undefined;
+      if (active === value) return;
 
-    // When closing, let the controlled value know
-    lightbox.on("close", () => {
-      if (onChange) onChange(undefined);
-    });
-
-    // Initialize the lightbox
-    lightbox.init();
-    setPhotoswipe(lightbox);
-
-    // Do the cleanup in the reverse order
-    return () => {
-      setPhotoswipe(undefined);
-      lightbox.destroy();
-    };
-  }, [photoswipeId, updateConsent, onChange]);
-
-  // If the controlled value changes, make sure the lightbox and it are in sync
-  useEffect(() => {
-    // If we have no lightbox, do nothing
-    if (!photoswipe) return;
-
-    // If we have no value, close the lightbox
-    if (!value) {
-      photoswipe.pswp?.close();
-      return;
-    }
-
-    // If photoswipe is active and the value is the same, do nothing
-    const active = photoswipe.pswp?.currSlide?.data?.trigger?.triggerId as
-      | string
-      | undefined;
-    if (active === value) return;
-
-    // Get the gallery and children
-    const gallery = resolvePhotoswipeElementProvider(
-      photoswipe.options.gallery,
-    )?.[0];
-    if (!gallery) return;
-    const items = resolvePhotoswipeElementProvider(
-      photoswipe.options.children,
-      gallery,
-    );
-    if (!items) return;
-
-    // Locate the matching trigger and open it
-    // If we can't find it, set the value back to the active slide
-    const match = items.findIndex(
-      (child) =>
-        safeJsonParse(child.getAttribute(`data-lightbox-${photoswipeId}`) || "")
-          ?.triggerId === value,
-    );
-    if (match !== -1)
-      photoswipe.loadAndOpen(
-        match,
-        photoswipe.options.dataSource || { gallery, items },
+      // Get the gallery and children
+      const gallery = resolvePhotoswipeElementProvider(
+        photoswipe.options.gallery,
+      )?.[0];
+      if (!gallery) return;
+      const items = resolvePhotoswipeElementProvider(
+        photoswipe.options.children,
+        gallery,
       );
-    if (match === -1 && onChange) onChange(active);
-  }, [value, photoswipe, photoswipeId, onChange]);
+      if (!items) return;
 
-  // Expose the nested components
-  const ctx: LightboxCtxProps = useMemo(
-    () => ({
-      Trigger: createTrigger(photoswipeId),
-      parseUrl,
-      id: photoswipeId,
-    }),
-    [photoswipeId],
-  );
+      // Locate the matching trigger and open it
+      // If we can't find it, set the value back to the active slide
+      const match = items.findIndex(
+        (child) =>
+          safeJsonParse(
+            child.getAttribute(`data-lightbox-${photoswipeId}`) || "",
+          )?.triggerId === value,
+      );
+      if (match !== -1)
+        photoswipe.loadAndOpen(
+          match,
+          photoswipe.options.dataSource || { gallery, items },
+        );
+      if (match === -1 && onChange) onChange(active);
+    }, [value, photoswipe, photoswipeId, onChange]);
 
-  // Allow children to be functions that receive the context
-  const childrenToRender = useMemo(
-    () =>
-      (Array.isArray(children) ? children : [children]).map((child, index) => {
-        const element = typeof child === "function" ? child(ctx) : child;
-        return cloneElement(element, { key: index });
+    // Expose the nested components
+    const ctx: LightboxCtxProps = useMemo(
+      () => ({
+        Trigger: createTrigger(photoswipeId),
+        parseUrl,
+        id: photoswipeId,
       }),
-    [children, ctx],
-  );
+      [photoswipeId],
+    );
 
-  return (
-    <>
-      <style
-        dangerouslySetInnerHTML={{
-          // Hide the placeholder overlay
-          // Ensure we retain the aspect ratio of the video
-          __html: `
+    // Allow children to be functions that receive the context
+    const childrenToRender = useMemo(
+      () =>
+        (Array.isArray(children) ? children : [children]).map(
+          (child, index) => {
+            const element = typeof child === "function" ? child(ctx) : child;
+            return cloneElement(element, { key: index });
+          },
+        ),
+      [children, ctx],
+    );
+
+    return (
+      <>
+        <style
+          dangerouslySetInnerHTML={{
+            // Hide the placeholder overlay
+            // Ensure we retain the aspect ratio of the video
+            __html: `
 .pswp--${photoswipeId} .pswp__img--placeholder {
   display: none;
 }
@@ -339,11 +338,14 @@ export const Lightbox = ({
   }
 }
 `,
-        }}
-      />
-      <div id={photoswipeId} className={className}>
-        {childrenToRender}
-      </div>
-    </>
-  );
-};
+          }}
+        />
+        <div id={photoswipeId} className={className} ref={ref}>
+          {childrenToRender}
+        </div>
+      </>
+    );
+  },
+);
+
+Lightbox.displayName = "Lightbox";

--- a/apps/website/src/pages/ambassadors/index.tsx
+++ b/apps/website/src/pages/ambassadors/index.tsx
@@ -146,7 +146,12 @@ const AmbassadorItems = forwardRef<
 >(({ items, option, group, name }, ref) => (
   <>
     {name && (
-      <Heading level={2} className="mb-8 mt-12" id={`${option}:${group}`} link>
+      <Heading
+        level={2}
+        className="alveus-green-800 mb-8 mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl"
+        id={`${option}:${group}`}
+        link
+      >
         {name}
       </Heading>
     )}

--- a/apps/website/src/pages/animal-quest/index.tsx
+++ b/apps/website/src/pages/animal-quest/index.tsx
@@ -102,7 +102,12 @@ const AnimalQuestItems = forwardRef<
 >(({ items, option, group, name }, ref) => (
   <>
     {name && (
-      <Heading level={2} className="mt-12" id={`${option}:${group}`} link>
+      <Heading
+        level={2}
+        className="alveus-green-800 mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl"
+        id={`${option}:${group}`}
+        link
+      >
         {name}
       </Heading>
     )}

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -1,16 +1,19 @@
-import { useEffect, useState } from "react";
+import { forwardRef, useEffect, useMemo, useState } from "react";
 import { type NextPage } from "next";
 import Image from "next/image";
 
+import useGrouped, { type GroupedItems, type Options } from "@/hooks/grouped";
+
 import { formatDateTime } from "@/utils/datetime";
-import { camelToKebab, kebabToCamel } from "@/utils/string-case";
 import { classes } from "@/utils/classes";
+import { convertToSlug } from "@/utils/slugs";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";
 import Meta from "@/components/content/Meta";
 import Link from "@/components/content/Link";
 import { Lightbox, Preview } from "@/components/content/YouTube";
+import Grouped, { type GroupedProps } from "@/components/content/Grouped";
 
 import leafRightImage1 from "@/assets/floral/leaf-right-1.png";
 import leafRightImage2 from "@/assets/floral/leaf-right-2.png";
@@ -25,301 +28,339 @@ type Collaboration = {
   vodId?: string;
 };
 
-type Collaborations = Record<string, Collaboration>;
-
-const collaborations = {
-  emilyWang: {
+const collaborations: Collaboration[] = [
+  {
     name: "Emily Wang",
     link: "https://www.twitch.tv/emilyywang",
     date: new Date("2024-02-13"),
     videoId: "CE-mNI_5eEI",
   },
-  jinny: {
+  {
     name: "Jinny",
     link: "https://www.twitch.tv/jinnytty",
     date: new Date("2024-02-08"),
     videoId: "c-EoBOEr1_g",
   },
-  jaidenAnimationsAlpharad: {
+  {
     name: "JaidenAnimations & Alpharad",
     link: null,
     date: new Date("2024-02-02"),
     videoId: "W74Ub2HR1Y4",
     vodId: "U2HqCEr5_e4",
   },
-  cinna: {
+  {
     name: "Cinna",
     link: "https://www.twitch.tv/cinna",
     date: new Date("2024-01-28"),
     videoId: "URSbZwAqLNE",
   },
-  hasan: {
+  {
     name: "Hasan",
     link: "https://www.twitch.tv/hasanabi",
     date: new Date("2024-01-26"),
     videoId: "E_iO1ZKlHyM",
     vodId: "MnPhxGBoY-I",
   },
-  fanfan: {
+  {
     name: "Fanfan",
     link: "https://www.twitch.tv/fanfan",
     date: new Date("2023-11-13"),
     videoId: "OCf7356WlNo",
   },
-  alluux: {
+  {
     name: "Alluux",
     link: "https://www.twitch.tv/alluux",
     date: new Date("2023-11-05"),
     videoId: "x1KMHDgmsR0",
   },
-  filian: {
+  {
     name: "Filian",
     link: "https://www.twitch.tv/filian",
     date: new Date("2023-10-11"),
     videoId: "WaQcdQBrz0I",
   },
-  trihex: {
+  {
     name: "Trihex",
     link: "https://www.twitch.tv/trihex",
     date: new Date("2023-09-21"),
     videoId: "lxks3skYeO4",
     vodId: "H0gaJrLY5X0",
   },
-  esfand: {
+  {
     name: "Esfand",
     link: "https://www.twitch.tv/esfandtv",
     date: new Date("2023-08-26"),
     videoId: "9aXebCBRonA",
     vodId: "o7nyVU62rf8",
   },
-  extraEmily: {
+  {
     name: "ExtraEmily",
     link: "https://www.twitch.tv/extraemily",
     date: new Date("2023-06-22"),
     videoId: "maJTBSkgA4Y",
     vodId: "qbxV8xgA7Vg",
   },
-  zoil: {
+  {
     name: "Zoil",
     link: "https://www.twitch.tv/zoil",
     date: new Date("2023-06-13"),
     videoId: "8M_qtYuSrys",
     vodId: "n4KpVaUmrSE",
   },
-  peachJars: {
+  {
     name: "PeachJars and Jessica Nigri",
     link: "https://www.twitch.tv/peachjars",
     date: new Date("2023-05-21"),
     videoId: "-HuS6wbpqzQ",
     vodId: "KF4HIypXiyc",
   },
-  squeex: {
+  {
     name: "Squeex",
     link: "https://www.twitch.tv/squeex",
     date: new Date("2023-05-19"),
     videoId: "oUJxCDGQDlY",
     vodId: "dCV8b8LcG-0",
   },
-  caroline: {
+  {
     name: "Caroline Kwan",
     link: "https://www.twitch.tv/carolinekwan",
     date: new Date("2023-05-09"),
     videoId: "H5nV79y-Prg",
     vodId: "4MmCFJadSg8",
   },
-  lacari: {
+  {
     name: "Lacari",
     link: "https://www.twitch.tv/lacari",
     date: new Date("2023-05-02"),
     videoId: "IssAfvy_bmo",
     vodId: "mVOypbE5YNs",
   },
-  dailyDose: {
+  {
     name: "Daily Dose",
     link: "https://www.youtube.com/@DailyDoseOfInternet",
     date: new Date("2023-04-25"),
     videoId: "M9BBwvR3i-E",
     vodId: "j8GxD4adNyk",
   },
-  graycen: {
+  {
     name: "Graycen",
     link: "https://www.twitch.tv/graycen",
     date: new Date("2023-04-18"),
     videoId: "M3WBnThqRkg",
   },
-  dareon: {
+  {
     name: "Dareon",
     link: "https://www.twitch.tv/dareon",
     date: new Date("2023-04-11"),
     videoId: "kqKnhu5zBIY",
     vodId: "RCzMJs9uDSI",
   },
-  yungJeff: {
+  {
     name: "YungJeff",
     link: "https://twitter.com/YUNGJEFF",
     date: new Date("2023-04-04"),
     videoId: "BXOEWQZ8C_Y",
   },
-  pointCrow: {
+  {
     name: "PointCrow",
     link: "https://www.twitch.tv/pointcrow",
     date: new Date("2023-03-24"),
     videoId: "FhmkQkbV42U",
     vodId: "Qz1Iniho9-g",
   },
-  russel: {
+  {
     name: "Russel",
     link: "https://www.twitch.tv/russel",
     date: new Date("2023-03-20"),
     videoId: "Xizgus_phn4",
     vodId: "OUaYjkkLeFQ",
   },
-  ludwig: {
+  {
     name: "Ludwig",
     link: "https://www.youtube.com/@ludwig",
     date: new Date("2023-02-25"),
     videoId: "po1jytjDu4E",
     vodId: "vuLMTU8QHAU",
   },
-  alinity: {
+  {
     name: "Alinity",
     link: "https://www.twitch.tv/alinity",
     date: new Date("2023-02-09"),
     videoId: "bak3RqjCzE0",
     vodId: "XHTEs94Cf4s",
   },
-  connorEatsPants: {
+  {
     name: "ConnorEatsPants",
     link: "https://www.twitch.tv/connoreatspants",
     date: new Date("2023-01-25"),
     videoId: "nC8qlK3k96Q",
     vodId: "SMEyEfVlzlM",
   },
-  botezSisters: {
+  {
     name: "The Botez Sisters",
     link: "https://www.twitch.tv/botezlive",
     date: new Date("2022-08-30"),
     videoId: "QgvNy11kU6E",
   },
-  knut: {
+  {
     name: "Knut",
     link: "https://www.twitch.tv/knut",
     date: new Date("2022-08-09"),
     videoId: "lFhFx6kf2E4",
   },
-  moistCr1tikal: {
+  {
     name: "MoistCr1TiKaL",
     link: "https://www.twitch.tv/moistcr1tikal",
     date: new Date("2022-04-30"),
     videoId: "pb7MR59s1Z0",
     vodId: "x-OPvwjGHEU",
   },
-  jackManifold: {
+  {
     name: "Jack Manifold",
     link: "https://www.twitch.tv/jackmanifoldtv",
     date: new Date("2022-04-21"),
     videoId: "jzyxhnODe2g",
   },
-} as const satisfies Collaborations;
+];
 
-const collaborationsByYear: { year: number; collaborations: Collaborations }[] =
-  Object.entries(
-    Object.entries(collaborations).reduce<Record<string, Collaborations>>(
-      (acc, [key, value]) => ({
-        ...acc,
-        [value.date.getUTCFullYear()]: {
-          ...(acc[value.date.getUTCFullYear()] || {}),
-          [key]: value,
+const sortByOptions = {
+  all: {
+    label: "All Collaborations",
+    sort: (collaborations) =>
+      [...collaborations]
+        .sort((a, b) => b.date.getTime() - a.date.getTime())
+        .reduce<GroupedItems<Collaboration>>((map, collaboration) => {
+          const year = collaboration.date.getUTCFullYear().toString();
+
+          map.set(year, {
+            name: year,
+            items: [...(map.get(year)?.items || []), collaboration],
+          });
+          return map;
+        }, new Map()),
+  },
+} as const satisfies Options<Collaboration>;
+
+const CollaborationItems = forwardRef<
+  HTMLDivElement,
+  GroupedProps<Collaboration>
+>(({ items, option, group, name, index }, ref) => {
+  const itemsWithSlugs = useMemo(
+    () =>
+      items.reduce(
+        (acc, item) => {
+          const slug = convertToSlug(item.name);
+          return { ...acc, [slug]: item };
         },
-      }),
-      {},
-    ),
-  )
-    .map(([year, collaborations]) => ({ year: Number(year), collaborations }))
-    .sort((a, b) => b.year - a.year);
+        {} as Record<string, Collaboration>,
+      ),
+    [items],
+  );
 
-type CollaborationsSectionProps = {
-  items: Collaborations;
-  year: number;
-};
-
-const CollaborationsSection = ({ items, year }: CollaborationsSectionProps) => {
   const [open, setOpen] = useState<string>();
   useEffect(() => {
-    const hash = kebabToCamel(window.location.hash.slice(1));
-    if (hash && items[hash]) setOpen(hash);
-  }, [items]);
+    const hash = window.location.hash.slice(1);
+    if (Object.prototype.hasOwnProperty.call(itemsWithSlugs, hash))
+      setOpen(hash);
+  }, [itemsWithSlugs]);
 
   return (
-    <Lightbox
-      id={`collaborations-${year}`}
-      className="flex flex-wrap"
-      value={open}
-      onChange={setOpen}
-    >
-      {({ Trigger }) => (
-        <>
-          {Object.entries(items).map(([key, value]) => (
-            <div
-              key={key}
-              className="mx-auto flex basis-full flex-col items-center justify-start py-8 md:px-8 lg:basis-1/2"
-            >
-              <Heading
-                level={2}
-                className="flex flex-wrap items-end justify-center gap-x-8 gap-y-2 text-center"
-                id={camelToKebab(key)}
-              >
-                {value.link !== null ? (
-                  <Link
-                    href={value.link}
-                    className="hover:text-alveus-green-600 hover:underline"
-                    external
-                    custom
-                  >
-                    {value.name}
-                  </Link>
-                ) : (
-                  value.name
-                )}
-                <small className="text-xl text-alveus-green-600">
-                  <Link href={`#${camelToKebab(key)}`} custom>
-                    {formatDateTime(value.date, { style: "long" })}
-                  </Link>
-                </small>
-              </Heading>
-
-              <Trigger
-                videoId={value.videoId}
-                caption={`${value.name}: ${formatDateTime(value.date, {
-                  style: "long",
-                })}`}
-                triggerId={key}
-                className="w-full max-w-2xl"
-              >
-                <Preview videoId={value.videoId} />
-              </Trigger>
-
-              {value.vodId && (
-                <p className="mt-2">
-                  (
-                  <Link
-                    href={`https://www.youtube.com/watch?v=${value.vodId}&list=PLtQafKoimfLd6dM9CQqiLm79khNgxsoN3`}
-                    external
-                  >
-                    Full stream VoD
-                  </Link>
-                  )
-                </p>
-              )}
-            </div>
-          ))}
-        </>
+    <>
+      {name && (
+        <Heading
+          level={-1}
+          className={classes(
+            "alveus-green-800 mb-6 mt-8 border-b-2 border-alveus-green-300/25 pb-2 text-4xl",
+            index === 0 && "sr-only",
+          )}
+          id={`${option}:${group}`}
+          link
+        >
+          {name}
+        </Heading>
       )}
-    </Lightbox>
+      <Lightbox
+        id={`collaborations-${name}`}
+        className="flex flex-wrap"
+        value={open}
+        onChange={setOpen}
+        ref={ref}
+      >
+        {({ Trigger }) => (
+          <>
+            {Object.entries(itemsWithSlugs).map(([slug, collaboration]) => (
+              <div
+                key={slug}
+                className="mx-auto flex basis-full flex-col items-center justify-start py-8 md:px-8 lg:basis-1/2"
+              >
+                <Heading
+                  level={2}
+                  className="flex flex-wrap items-end justify-center gap-x-8 gap-y-2 text-center"
+                  id={slug}
+                >
+                  {collaboration.link !== null ? (
+                    <Link
+                      href={collaboration.link}
+                      className="hover:text-alveus-green-600 hover:underline"
+                      external
+                      custom
+                    >
+                      {collaboration.name}
+                    </Link>
+                  ) : (
+                    collaboration.name
+                  )}
+                  <small className="text-xl text-alveus-green-600">
+                    <Link href={`#${slug}`} custom>
+                      {formatDateTime(collaboration.date, { style: "long" })}
+                    </Link>
+                  </small>
+                </Heading>
+
+                <Trigger
+                  videoId={collaboration.videoId}
+                  caption={`${collaboration.name}: ${formatDateTime(
+                    collaboration.date,
+                    {
+                      style: "long",
+                    },
+                  )}`}
+                  triggerId={slug}
+                  className="w-full max-w-2xl"
+                >
+                  <Preview videoId={collaboration.videoId} />
+                </Trigger>
+
+                {collaboration.vodId && (
+                  <p className="mt-2">
+                    (
+                    <Link
+                      href={`https://www.youtube.com/watch?v=${collaboration.vodId}&list=PLtQafKoimfLd6dM9CQqiLm79khNgxsoN3`}
+                      external
+                    >
+                      Full stream VoD
+                    </Link>
+                    )
+                  </p>
+                )}
+              </div>
+            ))}
+          </>
+        )}
+      </Lightbox>
+    </>
   );
-};
+});
+
+CollaborationItems.displayName = "CollaborationItems";
 
 const CollaborationsPage: NextPage = () => {
+  const { option, group, result } = useGrouped({
+    items: collaborations,
+    options: sortByOptions,
+    initial: "all",
+  });
+
   return (
     <>
       <Meta
@@ -368,22 +409,12 @@ const CollaborationsPage: NextPage = () => {
         />
 
         <Section className="flex-grow">
-          {collaborationsByYear.map(({ year, collaborations }, idx) => (
-            <div key={year}>
-              <Heading
-                level={-1}
-                className={classes(
-                  "alveus-green-800 mb-6 mt-8 border-b-2 border-alveus-green-300/25 pb-2 text-4xl",
-                  idx === 0 && "sr-only",
-                )}
-                id={year.toString()}
-                link
-              >
-                {year}
-              </Heading>
-              <CollaborationsSection items={collaborations} year={year} />
-            </div>
-          ))}
+          <Grouped
+            option={option}
+            group={group}
+            result={result}
+            component={CollaborationItems}
+          />
         </Section>
       </div>
     </>


### PR DESCRIPTION
## Describe your changes

Use the Grouped component/hook to handle the grouping and rendering of content on the events + collaborations pages. This provides some further consistency across all our pages that use grouping for content presentation, and sets the groundwork to enable #427.

Note that the dropdown has not been added to either page, as there is only one sort option (chronological) at present.

## Notes for testing your change

Events page now has year headings, with the current year being visually hidden.

Collaborations page visually remains the same (note that some anchors will have changed due to the logic changes).