### PR TITLE
Add JSON-LD data to AQ episodes

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -73,6 +73,7 @@
     "react-textarea-autosize": "^8.5.3",
     "reactflow": "^11.10.3",
     "remark-heading-id": "^1.0.1",
+    "schema-dts": "^1.1.2",
     "sharp": "^0.33.2",
     "slugify": "^1.6.6",
     "smooth-scroll-into-view-if-needed": "^2.0.2",

--- a/apps/website/src/components/content/JsonLD.tsx
+++ b/apps/website/src/components/content/JsonLD.tsx
@@ -1,0 +1,10 @@
+import type { Thing, WithContext } from "schema-dts";
+
+const JsonLD = <T extends Thing>({ data }: { data: WithContext<T> }) => (
+  <script
+    type="application/ld+json"
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+  />
+);
+
+export default JsonLD;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       remark-heading-id:
         specifier: ^1.0.1
         version: 1.0.1
+      schema-dts:
+        specifier: ^1.1.2
+        version: 1.1.2(typescript@5.3.3)
       sharp:
         specifier: ^0.33.2
         version: 0.33.2
@@ -8902,6 +8905,14 @@ packages:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
+    dev: false
+
+  /schema-dts@1.1.2(typescript@5.3.3):
+    resolution: {integrity: sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==}
+    peerDependencies:
+      typescript: '>=4.1.0'
+    dependencies:
+      typescript: 5.3.3
     dev: false
 
   /schema-utils@3.3.0:


### PR DESCRIPTION
## Describe your changes

Adds JSON-LD (#136) to the Animal Quest episode pages, in yet another attempt to get Google to recognise them as videos.

## Notes for testing your change

https://search.google.com/test/rich-results detects the video

https://validator.schema.org/ reports no schema issues
