### PR TITLE
Hide video in footer from known crawlers

### DIFF
--- a/apps/website/src/components/Consent.tsx
+++ b/apps/website/src/components/Consent.tsx
@@ -13,6 +13,7 @@ import {
   consentExplainer,
   type ConsentKey,
 } from "@/hooks/consent";
+import useCrawler from "@/hooks/crawler";
 
 import Link from "@/components/content/Link";
 
@@ -34,15 +35,7 @@ const Consent = ({
   // Get the current user consent state
   // If this is "indexable", we'll ignore consent for known crawlers
   const { consent, update, loaded } = useConsent();
-  const crawling = useMemo(
-    () =>
-      indexable &&
-      typeof navigator !== "undefined" &&
-      ["googlebot", "bingbot", "linkedinbot"].some((bot) =>
-        navigator.userAgent.toLowerCase().includes(bot),
-      ),
-    [indexable],
-  );
+  const crawler = useCrawler();
 
   // When the user clicks the consent button, update the state
   const clicked = useCallback<MouseEventHandler<HTMLButtonElement>>(
@@ -61,7 +54,7 @@ const Consent = ({
       )}
     >
       {loaded &&
-        (crawling || consent[key] ? (
+        ((indexable && crawler) || consent[key] ? (
           <>
             <p className="absolute -z-10 m-auto text-2xl" aria-hidden="true">
               Loading {item}...

--- a/apps/website/src/components/layout/footer/Socials.tsx
+++ b/apps/website/src/components/layout/footer/Socials.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 
 import usePrefersReducedMotion from "@/hooks/motion";
+import useCrawler from "@/hooks/crawler";
 
 import reelVideo from "@/assets/socials/georgie-reel-clip.mp4?quality=low";
 import pic from "@/assets/socials/twitter-pic-winnie.jpg";
@@ -23,6 +24,10 @@ const buttonClasses =
 const Socials = () => {
   const reducedMotion = usePrefersReducedMotion();
 
+  // If this is a known crawler, we'll not load the video
+  // This is an attempt to stop Google reporting unindexable video pages
+  const crawler = useCrawler();
+
   return (
     <Section dark className="z-0 py-0">
       <div className="flex flex-wrap-reverse gap-y-4 pt-8">
@@ -37,15 +42,25 @@ const Socials = () => {
               <span className="sr-only">
                 Open Instagram post of Georgie, Alveus&apos; African Bullfrog
               </span>
-              <Video
-                sources={reelVideo.sources}
-                poster={reelVideo.poster}
-                className="absolute inset-0"
-                autoPlay={!reducedMotion}
-                loop
-                muted
-                playsInline
-              />
+              {crawler || reducedMotion ? (
+                <Image
+                  src={reelVideo.poster}
+                  alt=""
+                  width={400}
+                  loading="lazy"
+                  className="absolute inset-0"
+                />
+              ) : (
+                <Video
+                  sources={reelVideo.sources}
+                  poster={reelVideo.poster}
+                  className="absolute inset-0"
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                />
+              )}
               <IconInstagram
                 className="absolute right-0 top-0 m-3 opacity-60"
                 size={30}

--- a/apps/website/src/hooks/crawler.tsx
+++ b/apps/website/src/hooks/crawler.tsx
@@ -1,0 +1,13 @@
+import { useMemo } from "react";
+
+const useCrawler = () =>
+  useMemo(
+    () =>
+      typeof navigator !== "undefined" &&
+      ["googlebot", "google-inspectiontool", "bingbot", "linkedinbot"].some(
+        (bot) => navigator.userAgent.toLowerCase().includes(bot),
+      ),
+    [],
+  );
+
+export default useCrawler;


### PR DESCRIPTION
## Describe your changes

As part of my continued effort to get Google to like the AQ pages more, I have observed in search console that Google seems to be seeing the footer video on _all_ our pages and (correctly) noting that it isn't the main content and so won't be indexed...

However, on the AQ pages where we also have a bunch of meta data pointing to the Twitch player as a legitimate video on the page, Google is reporting the footer video there and seems to be implying it thinks it is all the same, and so is not indexing video content on the page because the video it is detecting on the page is the footer video which is not the main content.

Hopefully, this change will completely remove the footer video from the DOM for Google, so it can't index it and get confused.

## Notes for testing your change

Override UA to be a Googlebot UA. Observe Twitch player load by default on AQ page, observe no video in footer.
