### PR TITLE
Give an Hour: Fix date display (using local timezone instead of UTC)

### DIFF
--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -107,10 +107,12 @@ export function ShowAndTellEntryForm({
   const trackingStatus = useMemo(() => {
     // Check local time is in date range
     const now = new Date();
+    // Parsing the date time strings without explicit timezone makes it local time
     const start = new Date(giveAnHourStart);
     const end = new Date(giveAnHourEnd);
-    const trackingStatusFrom = formatDateTime(start);
-    const trackingStatusTo = formatDateTime(end);
+    // Using zone: null to display the time in local time (default is UTC)
+    const trackingStatusFrom = formatDateTime(start, undefined, { zone: null });
+    const trackingStatusTo = formatDateTime(end, undefined, { zone: null });
 
     let active = true;
     let verb = "is";


### PR DESCRIPTION
## Describe your changes

Since we use the local timezone to check the tracking status using local time, we parse the start and end time without an explicit timezone (= local time). This PR will make sure, the date is displayed in the local time to prevent a different date from being shown. By default UTC is used to format the date so we need to set it to null (= use user time zone).

## Notes for testing your change

- set local timezone to something > UTC and check the correct start date is shown (03/01)
- set local timezone to something < UTC and check the correct end date is shown (04/22)