### PR TITLE
Fix prettier PR check + existing violations

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run prettier
-        run: pnpm run prettier --check
+        run: pnpm run lint
 
   tests:
     runs-on: ubuntu-latest

--- a/apps/website/.eslintrc.json
+++ b/apps/website/.eslintrc.json
@@ -4,10 +4,7 @@
   "parserOptions": {
     "project": "./tsconfig.json"
   },
-  "plugins": [
-    "@typescript-eslint",
-    "import"
-  ],
+  "plugins": ["@typescript-eslint", "import"],
   "extends": [
     "next/core-web-vitals",
     "plugin:@typescript-eslint/recommended",
@@ -46,24 +43,18 @@
   },
   "overrides": [
     {
-      "files": [
-        "**/*.cjs"
-      ],
+      "files": ["**/*.cjs"],
       "rules": {
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/ban-ts-comment": "off"
       }
     },
     {
-      "files": [
-        "src/sw/**/*"
-      ],
+      "files": ["src/sw/**/*"],
       "parserOptions": {
         "project": "./src/sw/tsconfig.json"
       }
     }
   ],
-  "ignorePatterns": [
-    "public/*"
-  ]
+  "ignorePatterns": ["public/*"]
 }

--- a/apps/website/next-sitemap.config.js
+++ b/apps/website/next-sitemap.config.js
@@ -3,9 +3,10 @@
 const config = {
   // If there is a NEXT_PUBLIC_VERCEL_URL set, use that like NextAuth.js does
   // Fallback to localhost if we don't have a URL from the env for any reason
-  siteUrl: (process.env.NEXT_PUBLIC_VERCEL_URL
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-    : process.env.NEXT_PUBLIC_BASE_URL) || "http://localhost",
+  siteUrl:
+    (process.env.NEXT_PUBLIC_VERCEL_URL
+      ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+      : process.env.NEXT_PUBLIC_BASE_URL) || "http://localhost",
   // Create a single sitemap, and don't list some routes in it
   generateIndexSitemap: false,
   exclude: [

--- a/apps/website/src/data/tech/presets.ts
+++ b/apps/website/src/data/tech/presets.ts
@@ -79,7 +79,7 @@ const presets: Record<string, Camera> = {
       fennroll: { description: "fennroll's spot" },
       hillrightw: { description: "hill right wide" },
       belowplatform: { description: "directly under platform" },
-      down: { description: "View straight down from the cam, below the den"},
+      down: { description: "View straight down from the cam, below the den" },
     },
   },
   foxCorner: {
@@ -89,9 +89,9 @@ const presets: Record<string, Camera> = {
       den: { description: "the fox den" },
       table: { description: "table close to the entry" },
       hillright: { description: "right side of hill" },
-      tabletop: { description: "top of the spool on far end of main cam"},
-      insidedoor: { description: "view of the door to the inside space"},
-      training: { description: "Training spot by the entrace"},
+      tabletop: { description: "top of the spool on far end of main cam" },
+      insidedoor: { description: "view of the door to the inside space" },
+      training: { description: "Training spot by the entrace" },
     },
   },
   bb: {
@@ -112,7 +112,9 @@ const presets: Record<string, Camera> = {
     title: "Roaches",
     presets: {
       home: { description: "zoomed out view showing most of the tank" },
-      stickt: { description: "top of the large stick they spend a lot of time on" },
+      stickt: {
+        description: "top of the large stick they spend a lot of time on",
+      },
       sticktl: { description: "top left view of the stick" },
       stickb: { description: "bottom of the large stick" },
       tip: { description: "zoomed in view of the top of the stick" },
@@ -128,17 +130,17 @@ const presets: Record<string, Camera> = {
       window: { description: "upper crow window" },
       water: { description: "water bowl" },
       top: { description: "upper section of the indoor space" },
-      backcorner: { description: "back corner of the upper indoor space"},
+      backcorner: { description: "back corner of the upper indoor space" },
       outside: { description: "outer enclosure" },
       home: { description: "home" },
       entry: { description: "entryway" },
       down: { description: "down to the floor" },
       rightperch: { description: "right perch" },
       backleftcorner: { description: "back left corner perch" },
-      crowsleep: { description: "back perch where the crows usually sleep",},
-      back: { description: "back of the inside space"},
-      hose: { description: "the corner with the hose, not ccovered by entry"},
-      table: { description: "the folding bench by the door"},
+      crowsleep: { description: "back perch where the crows usually sleep" },
+      back: { description: "back of the inside space" },
+      hose: { description: "the corner with the hose, not ccovered by entry" },
+      table: { description: "the folding bench by the door" },
     },
   },
   crowOutdoor: {
@@ -157,13 +159,21 @@ const presets: Record<string, Camera> = {
       treet: { description: "left upper tree" },
       treeb: { description: "left tree" },
       tree: { description: "the entirety of the tree" },
-      platforminside: {description: "platform in the indoor enclosure"},
+      platforminside: { description: "platform in the indoor enclosure" },
       groundrc: { description: "right corner floor of the outside enclosure" },
-      entry: { description: "the door and hose"},
-      insideperch: { description: "the inside platform and indoor back corner perch"},
-      cache: { description: "The base of the outdoor platform where both crows cache food"},
-      table: { description: "the folding bench by the door"},
-      groundlc: { description: "view of both the outdoor ground left corner and the back of the inside"},
+      entry: { description: "the door and hose" },
+      insideperch: {
+        description: "the inside platform and indoor back corner perch",
+      },
+      cache: {
+        description:
+          "The base of the outdoor platform where both crows cache food",
+      },
+      table: { description: "the folding bench by the door" },
+      groundlc: {
+        description:
+          "view of both the outdoor ground left corner and the back of the inside",
+      },
     },
   },
   marmosetIndoor: {
@@ -251,10 +261,16 @@ const presets: Record<string, Camera> = {
       macaws2bowl: { description: "second macaws water dish" },
       parrotsw: { description: "wide view of both windows" },
       littlesoutside: { description: "Both little trees" },
-      littles2middle: { description: "the middle branch of the little2 tree"},
-      floor: { description: "Wide view of the floor of the nclosure (for mouse hunting"},
-      platform: { description: "alternative view of littlesplatform"},
-      training: { description: "right fence under the littles2 perching where the chickens hang"},
+      littles2middle: { description: "the middle branch of the little2 tree" },
+      floor: {
+        description:
+          "Wide view of the floor of the nclosure (for mouse hunting",
+      },
+      platform: { description: "alternative view of littlesplatform" },
+      training: {
+        description:
+          "right fence under the littles2 perching where the chickens hang",
+      },
     },
   },
 };

--- a/apps/website/src/sw/tsconfig.json
+++ b/apps/website/src/sw/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": [
-      "esnext"
-    ],
+    "lib": ["esnext"],
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
@@ -14,6 +12,6 @@
     "resolveJsonModule": true,
     "isolatedModules": false,
     "incremental": false,
-    "noUncheckedIndexedAccess": true
-  }
+    "noUncheckedIndexedAccess": true,
+  },
 }

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "checkJs": true,
     "skipLibCheck": true,
@@ -21,18 +17,16 @@
     "incremental": true,
     "noUncheckedIndexedAccess": true,
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
+      "@/*": ["./src/*"],
       "photoswipe/lightbox": [
-        "./node_modules/photoswipe/dist/types/lightbox/lightbox.d.ts"
-      ]
+        "./node_modules/photoswipe/dist/types/lightbox/lightbox.d.ts",
+      ],
     },
     "plugins": [
       {
-        "name": "next"
-      }
-    ]
+        "name": "next",
+      },
+    ],
   },
   "include": [
     "next-env.d.ts",
@@ -40,11 +34,7 @@
     "**/*.tsx",
     "**/*.cjs",
     "**/*.js",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
   ],
-  "exclude": [
-    "node_modules",
-    "src/sw",
-    "public"
-  ]
+  "exclude": ["node_modules", "src/sw", "public"],
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "prepare": "husky",
     "lint-staged": "lint-staged --relative",
-    "prettier": "prettier . --write"
+    "lint": "prettier . --check",
+    "format": "prettier . --write"
   },
   "pnpm": {
     "patchedDependencies": {


### PR DESCRIPTION
## Describe your changes

Noticed in #575 that prettier was reporting issues but writing them, rather than failing on them. This splits the prettier calls into discrete --write and --check commands, so we know which we're calling always.

## Notes for testing your change

You can see in https://github.com/alveusgg/alveusgg/actions/runs/8134241363/job/22226901539?pr=578 that the check now fails when there are issues.

`pnpm run lint` passes locally.

Introduce a malformed bit of code, `pnpm run format` fixes locally.
