### PR TITLE
Add caveat to tracked hour submission for Give an Hour

### DIFF
--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -421,7 +421,9 @@ export function ShowAndTellEntryForm({
           </div>
 
           <p className="text-sm italic opacity-75">
-            <strong>Give an Hour</strong> {trackingStatus.text}
+            <strong>Give an Hour</strong> {trackingStatus.text}. Activities
+            submitted with tracked hours must occur while the Give an Hour
+            initiative is active.
           </p>
         </Fieldset>
 


### PR DESCRIPTION
## Describe your changes

Adds some text to make it clearer to folks they can't submit prior activities with tracked hours as part of the initiative.

## Notes for testing your change

Wording is clear, makes sense.
