### PR TITLE
Fix push service worker being built with the wrong file extension

### DIFF
--- a/apps/website/sw.tsup.config.ts
+++ b/apps/website/sw.tsup.config.ts
@@ -15,6 +15,7 @@ const config = defineConfig((options) => ({
   minify: !options.watch,
   platform: "browser",
   outDir: "public/",
+  format: "esm",
   tsconfig: "src/sw/tsconfig.json",
   esbuildOptions(options, _context) {
     options.define = {


### PR DESCRIPTION
## Describe your changes

Set the output format to `esm` in the tsup config because tsup defaults to `cjs` and since we changed the global module type in the `package.json` to `module` (aka `esm`) in #561, tsup started generating the files with the `.cjs` extension which breaks the SW registration path.

With this change the output format is set to ESM which matches the `package.json` `type` and the generated file extension is back to `.js`. This is also the proper module format for Service workers (even though we do not import any).

## Notes for testing your change

Check the service worker registration loads properly (`/push/alveus/PushServiceWorker.js`).
