### PR TITLE
Fix user roles being cached across requests

### DIFF
--- a/apps/website/src/pages/api/admin/bingo/[bingoId]/export-entries.ts
+++ b/apps/website/src/pages/api/admin/bingo/[bingoId]/export-entries.ts
@@ -19,7 +19,7 @@ const exportBingoEntries = async (
 ) => {
   const session = await getServerAuthSession({ req, res });
   const hasPermissions = session?.user?.id
-    ? await checkPermissions(permissions.manageBingos, session.user.id)
+    ? await checkPermissions(permissions.manageBingos, session.user)
     : false;
 
   if (!hasPermissions) {

--- a/apps/website/src/pages/api/admin/bingo/[bingoId]/export-entries.ts
+++ b/apps/website/src/pages/api/admin/bingo/[bingoId]/export-entries.ts
@@ -19,7 +19,7 @@ const exportBingoEntries = async (
 ) => {
   const session = await getServerAuthSession({ req, res });
   const hasPermissions = session?.user?.id
-    ? await checkPermissions(permissions.manageBingos, session.user)
+    ? checkPermissions(permissions.manageBingos, session.user)
     : false;
 
   if (!hasPermissions) {

--- a/apps/website/src/pages/api/admin/bingo/[bingoId]/winners.ts
+++ b/apps/website/src/pages/api/admin/bingo/[bingoId]/winners.ts
@@ -15,7 +15,7 @@ import { permissions } from "@/data/permissions";
 const winners = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getServerAuthSession({ req, res });
   const hasPermissions = session?.user?.id
-    ? await checkPermissions(permissions.manageBingos, session.user.id)
+    ? await checkPermissions(permissions.manageBingos, session.user)
     : false;
 
   if (!hasPermissions) {

--- a/apps/website/src/pages/api/admin/bingo/[bingoId]/winners.ts
+++ b/apps/website/src/pages/api/admin/bingo/[bingoId]/winners.ts
@@ -15,7 +15,7 @@ import { permissions } from "@/data/permissions";
 const winners = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getServerAuthSession({ req, res });
   const hasPermissions = session?.user?.id
-    ? await checkPermissions(permissions.manageBingos, session.user)
+    ? checkPermissions(permissions.manageBingos, session.user)
     : false;
 
   if (!hasPermissions) {

--- a/apps/website/src/server/db/users.ts
+++ b/apps/website/src/server/db/users.ts
@@ -1,20 +1,10 @@
 import { prisma } from "@/server/db/client";
 
-const cache = new Map<string, string[]>();
-
 export async function getRolesForUser(userId: string) {
-  const cachedRoles = cache.get(userId);
-  if (cachedRoles) {
-    return cachedRoles;
-  }
-
-  const roles = (
+  return (
     await prisma.userRole.findMany({
+      select: { role: true },
       where: { user: { id: userId } },
     })
-  ).map((role) => role.role);
-
-  cache.set(userId, roles);
-
-  return roles;
+  ).map(({ role }) => role);
 }

--- a/apps/website/src/server/trpc/trpc.ts
+++ b/apps/website/src/server/trpc/trpc.ts
@@ -37,7 +37,7 @@ const isAuthed = t.middleware(async ({ ctx, next }) => {
 
 export const createCheckPermissionMiddleware = (permission: PermissionConfig) =>
   isAuthed.unstable_pipe(async ({ ctx, next }) => {
-    const hasPermissions = await checkPermissions(permission, ctx.session.user);
+    const hasPermissions = checkPermissions(permission, ctx.session.user);
     if (!hasPermissions) {
       throw new TRPCError({ code: "UNAUTHORIZED" });
     }

--- a/apps/website/src/server/trpc/trpc.ts
+++ b/apps/website/src/server/trpc/trpc.ts
@@ -37,10 +37,7 @@ const isAuthed = t.middleware(async ({ ctx, next }) => {
 
 export const createCheckPermissionMiddleware = (permission: PermissionConfig) =>
   isAuthed.unstable_pipe(async ({ ctx, next }) => {
-    const hasPermissions = await checkPermissions(
-      permission,
-      ctx.session.user.id,
-    );
+    const hasPermissions = await checkPermissions(permission, ctx.session.user);
     if (!hasPermissions) {
       throw new TRPCError({ code: "UNAUTHORIZED" });
     }

--- a/apps/website/src/server/utils/admin.ts
+++ b/apps/website/src/server/utils/admin.ts
@@ -4,7 +4,6 @@ import type { PermissionConfig } from "@/data/permissions";
 import { checkRolesGivePermission, permissions } from "@/data/permissions";
 import { notEmpty } from "@/utils/helpers";
 import { checkIsSuperUserSession, checkPermissions } from "@/server/utils/auth";
-import { getRolesForUser } from "@/server/db/users";
 
 const menuItems = [
   {
@@ -65,25 +64,28 @@ export async function getAdminSSP(
 ) {
   const session = await getSession(context);
 
-  if (session?.user) {
-    const hasPermissions = await checkPermissions(permission, session.user.id);
-    if (hasPermissions) {
-      const roles = await getRolesForUser(session.user.id);
-      const isSuperUser = checkIsSuperUserSession(session);
-
-      const filteredMenuItems = menuItems
-        .map((item) =>
-          isSuperUser || checkRolesGivePermission(roles, item.permission)
-            ? { label: item.label, href: item.href }
-            : undefined,
-        )
-        .filter(notEmpty);
-
-      return {
-        isSuperUser,
-        menuItems: filteredMenuItems,
-      };
-    }
+  const user = session?.user;
+  if (!user) {
+    return false;
   }
-  return false;
+
+  const hasPermissions = await checkPermissions(permission, user);
+  if (!hasPermissions) {
+    return false;
+  }
+
+  const isSuperUser = checkIsSuperUserSession(session);
+
+  const filteredMenuItems = menuItems
+    .map((item) =>
+      isSuperUser || checkRolesGivePermission(user.roles, item.permission)
+        ? { label: item.label, href: item.href }
+        : undefined,
+    )
+    .filter(notEmpty);
+
+  return {
+    isSuperUser,
+    menuItems: filteredMenuItems,
+  };
 }

--- a/apps/website/src/server/utils/admin.ts
+++ b/apps/website/src/server/utils/admin.ts
@@ -69,7 +69,7 @@ export async function getAdminSSP(
     return false;
   }
 
-  const hasPermissions = await checkPermissions(permission, user);
+  const hasPermissions = checkPermissions(permission, user);
   if (!hasPermissions) {
     return false;
   }

--- a/apps/website/src/server/utils/auth.ts
+++ b/apps/website/src/server/utils/auth.ts
@@ -2,7 +2,6 @@ import type { Session } from "next-auth";
 
 import { env } from "@/env";
 import type { PermissionConfig } from "@/data/permissions";
-import { getRolesForUser } from "@/server/db/users";
 
 export function getSuperUserIds() {
   return env.SUPER_USER_IDS.split(",").map((id) => id.trim());
@@ -23,21 +22,19 @@ export function checkIsSuperUserSession(session: Session | null) {
 
 export async function checkPermissions(
   permissionConfig: PermissionConfig,
-  userId?: string,
+  user: Session["user"],
 ) {
-  if (!userId) {
+  if (!user) {
     return false;
   }
 
-  const isSuperUser = checkIsSuperUserId(userId);
+  const isSuperUser = checkIsSuperUserId(user.id);
   if (isSuperUser) {
     return true;
   }
 
   if (!permissionConfig.requiresSuperUser && permissionConfig.requiredRole) {
-    return (await getRolesForUser(userId)).includes(
-      permissionConfig.requiredRole,
-    );
+    return user.roles.includes(permissionConfig.requiredRole);
   }
 
   return false;

--- a/apps/website/src/server/utils/auth.ts
+++ b/apps/website/src/server/utils/auth.ts
@@ -20,7 +20,7 @@ export function checkIsSuperUserSession(session: Session | null) {
   return checkIsSuperUserId(session?.user?.id);
 }
 
-export async function checkPermissions(
+export function checkPermissions(
   permissionConfig: PermissionConfig,
   user: Session["user"],
 ) {


### PR DESCRIPTION
## Describe your changes

Instead of caching the user role lookup in a global cache object (map), we look it up on every request when the user session object is created and access the roles from there.

This fixes an issue where permissions/roles would not update for users because of the cache.

## Notes for testing your change

Check permission checks still work (positive and negative) and updates are applied immediately (on navigation).