### PR TITLE
Fix schedule missing some events for clients with time zones > UTC

### DIFF
--- a/apps/website/src/components/notifications/Schedule.tsx
+++ b/apps/website/src/components/notifications/Schedule.tsx
@@ -78,10 +78,10 @@ export function Schedule() {
     [startOfMonth],
   );
 
-  const events = trpc.calendarEvents.getCalendarEvents.useQuery({
-    start: startOfMonth,
-    end: endOfMonth,
-  });
+  const events = trpc.calendarEvents.getCalendarEvents.useQuery(
+    { start: startOfMonth, end: endOfMonth },
+    { enabled: startOfMonth !== undefined || endOfMonth !== undefined },
+  );
 
   const byDay = useMemo(
     () =>

--- a/apps/website/src/components/notifications/Schedule.tsx
+++ b/apps/website/src/components/notifications/Schedule.tsx
@@ -64,19 +64,23 @@ export function Schedule() {
     () => today && new Date(today.getFullYear(), today.getMonth(), 1),
     [today],
   );
-  const daysInMonth = useMemo(
+  const endOfMonth = useMemo(
     () =>
       startOfMonth &&
       new Date(
         startOfMonth.getFullYear(),
         startOfMonth.getMonth() + 1,
         0,
-      ).getDate(),
+        23,
+        59,
+        59,
+      ),
     [startOfMonth],
   );
 
   const events = trpc.calendarEvents.getCalendarEvents.useQuery({
     start: startOfMonth,
+    end: endOfMonth,
   });
 
   const byDay = useMemo(
@@ -88,13 +92,13 @@ export function Schedule() {
     [events.data],
   );
 
-  if (events.isLoading || !today || !startOfMonth || !daysInMonth)
+  if (events.isLoading || !today || !startOfMonth || !endOfMonth)
     return <p>Loading schedule...</p>;
   if (!events.data) return <p>No schedule is available currently.</p>;
 
   const startDay = 1; // 1 = Monday, 0 = Sunday
   const startOffset = (7 + startOfMonth.getDay() - startDay) % 7;
-  const weeks = Math.ceil((startOffset + daysInMonth) / 7);
+  const weeks = Math.ceil((startOffset + endOfMonth.getDate()) / 7);
 
   return (
     <>
@@ -127,7 +131,7 @@ export function Schedule() {
                 const date = i + 1 + week * 7 - startOffset;
 
                 // Render empty cells for days outside of the month
-                if (date < 1 || date > daysInMonth)
+                if (date < 1 || date > endOfMonth.getDate())
                   return (
                     <Day
                       key={date}

--- a/apps/website/src/components/notifications/Schedule.tsx
+++ b/apps/website/src/components/notifications/Schedule.tsx
@@ -80,7 +80,7 @@ export function Schedule() {
 
   const events = trpc.calendarEvents.getCalendarEvents.useQuery(
     { start: startOfMonth, end: endOfMonth },
-    { enabled: startOfMonth !== undefined || endOfMonth !== undefined },
+    { enabled: startOfMonth !== undefined && endOfMonth !== undefined },
   );
 
   const byDay = useMemo(

--- a/apps/website/src/components/notifications/Schedule.tsx
+++ b/apps/website/src/components/notifications/Schedule.tsx
@@ -167,7 +167,7 @@ export function Schedule() {
                         fullDate.getTime() < today.getTime() && "opacity-50",
                       )}
                     >
-                      {date.toLocaleString("en-US", {
+                      {date.toLocaleString(undefined, {
                         minimumIntegerDigits: 2,
                       })}
 
@@ -191,7 +191,7 @@ export function Schedule() {
                       >
                         <p className="font-semibold">{event.title}</p>
                         <p className="text-sm tabular-nums">
-                          {event.startAt.toLocaleTimeString("en-US", {
+                          {event.startAt.toLocaleTimeString(undefined, {
                             hour: "numeric",
                             minute: "2-digit",
                             timeZoneName: "short",

--- a/apps/website/src/components/notifications/Schedule.tsx
+++ b/apps/website/src/components/notifications/Schedule.tsx
@@ -66,16 +66,9 @@ export function Schedule() {
   );
   const endOfMonth = useMemo(
     () =>
-      startOfMonth &&
-      new Date(
-        startOfMonth.getFullYear(),
-        startOfMonth.getMonth() + 1,
-        0,
-        23,
-        59,
-        59,
-      ),
-    [startOfMonth],
+      today &&
+      new Date(today.getFullYear(), today.getMonth() + 1, 0, 23, 59, 59),
+    [today],
   );
 
   const events = trpc.calendarEvents.getCalendarEvents.useQuery(

--- a/apps/website/src/components/notifications/Schedule.tsx
+++ b/apps/website/src/components/notifications/Schedule.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 
 import type { inferRouterOutputs } from "@trpc/server";
 import type { AppRouter } from "@/server/trpc/router/_app";
@@ -39,7 +39,7 @@ function Day({
   children,
   className,
 }: {
-  children?: React.ReactNode;
+  children?: ReactNode;
   className?: string;
 }) {
   return (

--- a/apps/website/src/components/notifications/Schedule.tsx
+++ b/apps/website/src/components/notifications/Schedule.tsx
@@ -65,9 +65,7 @@ export function Schedule() {
     [today],
   );
   const endOfMonth = useMemo(
-    () =>
-      today &&
-      new Date(today.getFullYear(), today.getMonth() + 1, 0, 23, 59, 59),
+    () => today && new Date(today.getFullYear(), today.getMonth() + 1, 1),
     [today],
   );
 

--- a/apps/website/src/components/notifications/Schedule.tsx
+++ b/apps/website/src/components/notifications/Schedule.tsx
@@ -68,6 +68,11 @@ export function Schedule() {
     () => today && new Date(today.getFullYear(), today.getMonth() + 1, 1),
     [today],
   );
+  const daysInMonth = useMemo(
+    () =>
+      today && new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate(),
+    [today],
+  );
 
   const events = trpc.calendarEvents.getCalendarEvents.useQuery(
     { start: startOfMonth, end: endOfMonth },
@@ -83,13 +88,13 @@ export function Schedule() {
     [events.data],
   );
 
-  if (events.isLoading || !today || !startOfMonth || !endOfMonth)
+  if (events.isLoading || !today || !startOfMonth || !daysInMonth)
     return <p>Loading schedule...</p>;
   if (!events.data) return <p>No schedule is available currently.</p>;
 
   const startDay = 1; // 1 = Monday, 0 = Sunday
   const startOffset = (7 + startOfMonth.getDay() - startDay) % 7;
-  const weeks = Math.ceil((startOffset + endOfMonth.getDate()) / 7);
+  const weeks = Math.ceil((startOffset + daysInMonth) / 7);
 
   return (
     <>
@@ -122,7 +127,7 @@ export function Schedule() {
                 const date = i + 1 + week * 7 - startOffset;
 
                 // Render empty cells for days outside of the month
-                if (date < 1 || date > endOfMonth.getDate())
+                if (date < 1 || date > daysInMonth)
                   return (
                     <Day
                       key={date}


### PR DESCRIPTION
## Describe your changes

Instead of calculating the end of the month on the server in UTC, calculate it on the client in the display time zone.

This PR also changes the time display in the client to use local format (`20:00 CET` instead of `8:00 PM GMT+1`) and prevents double fetches when date calculations are incomplete (one effect-loop).

## Notes for testing your change

Test events show properly with different client and server timezones. Good luck.