### PR TITLE
Move events + collaborations arrays to data files

### DIFF
--- a/apps/website/src/data/collaborations.ts
+++ b/apps/website/src/data/collaborations.ts
@@ -1,0 +1,232 @@
+import { convertToSlug } from "@/utils/slugs";
+
+export type Collaboration = {
+  name: string;
+  slug: string;
+  link: string | null;
+  date: Date;
+  videoId: string;
+  vodId?: string;
+};
+
+const collaborations: Collaboration[] = (
+  [
+    {
+      name: "Emily Wang",
+      link: "https://www.twitch.tv/emilyywang",
+      date: new Date("2024-02-13"),
+      videoId: "CE-mNI_5eEI",
+    },
+    {
+      name: "Jinny",
+      link: "https://www.twitch.tv/jinnytty",
+      date: new Date("2024-02-08"),
+      videoId: "lpXtuG87BUM",
+      vodId: "c-EoBOEr1_g",
+    },
+    {
+      name: "JaidenAnimations & Alpharad",
+      link: null,
+      date: new Date("2024-02-02"),
+      videoId: "W74Ub2HR1Y4",
+      vodId: "U2HqCEr5_e4",
+    },
+    {
+      name: "Cinna",
+      link: "https://www.twitch.tv/cinna",
+      date: new Date("2024-01-28"),
+      videoId: "5YRrm5mDb6o",
+      vodId: "URSbZwAqLNE",
+    },
+    {
+      name: "Hasan",
+      link: "https://www.twitch.tv/hasanabi",
+      date: new Date("2024-01-26"),
+      videoId: "E_iO1ZKlHyM",
+      vodId: "MnPhxGBoY-I",
+    },
+    {
+      name: "Fanfan",
+      link: "https://www.twitch.tv/fanfan",
+      date: new Date("2023-11-13"),
+      videoId: "qHcy_sBJXmU",
+      vodId: "OCf7356WlNo",
+    },
+    {
+      name: "Alluux",
+      link: "https://www.twitch.tv/alluux",
+      date: new Date("2023-11-05"),
+      videoId: "L5r1isGll2I",
+      vodId: "x1KMHDgmsR0",
+    },
+    {
+      name: "Filian",
+      link: "https://www.twitch.tv/filian",
+      date: new Date("2023-10-11"),
+      videoId: "WaQcdQBrz0I",
+    },
+    {
+      name: "Trihex",
+      link: "https://www.twitch.tv/trihex",
+      date: new Date("2023-09-21"),
+      videoId: "lxks3skYeO4",
+      vodId: "H0gaJrLY5X0",
+    },
+    {
+      name: "Esfand",
+      link: "https://www.twitch.tv/esfandtv",
+      date: new Date("2023-08-26"),
+      videoId: "9aXebCBRonA",
+      vodId: "o7nyVU62rf8",
+    },
+    {
+      name: "ExtraEmily",
+      link: "https://www.twitch.tv/extraemily",
+      date: new Date("2023-06-22"),
+      videoId: "maJTBSkgA4Y",
+      vodId: "qbxV8xgA7Vg",
+    },
+    {
+      name: "Zoil",
+      link: "https://www.twitch.tv/zoil",
+      date: new Date("2023-06-13"),
+      videoId: "8M_qtYuSrys",
+      vodId: "n4KpVaUmrSE",
+    },
+    {
+      name: "PeachJars and Jessica Nigri",
+      link: "https://www.twitch.tv/peachjars",
+      date: new Date("2023-05-21"),
+      videoId: "-HuS6wbpqzQ",
+      vodId: "KF4HIypXiyc",
+    },
+    {
+      name: "Squeex",
+      link: "https://www.twitch.tv/squeex",
+      date: new Date("2023-05-19"),
+      videoId: "oUJxCDGQDlY",
+      vodId: "dCV8b8LcG-0",
+    },
+    {
+      name: "Caroline Kwan",
+      link: "https://www.twitch.tv/carolinekwan",
+      date: new Date("2023-05-09"),
+      videoId: "H5nV79y-Prg",
+      vodId: "4MmCFJadSg8",
+    },
+    {
+      name: "Lacari",
+      link: "https://www.twitch.tv/lacari",
+      date: new Date("2023-05-02"),
+      videoId: "IssAfvy_bmo",
+      vodId: "mVOypbE5YNs",
+    },
+    {
+      name: "Daily Dose",
+      link: "https://www.youtube.com/@DailyDoseOfInternet",
+      date: new Date("2023-04-25"),
+      videoId: "M9BBwvR3i-E",
+      vodId: "j8GxD4adNyk",
+    },
+    {
+      name: "Graycen",
+      link: "https://www.twitch.tv/graycen",
+      date: new Date("2023-04-18"),
+      videoId: "M3WBnThqRkg",
+    },
+    {
+      name: "Dareon",
+      link: "https://www.twitch.tv/dareon",
+      date: new Date("2023-04-11"),
+      videoId: "kqKnhu5zBIY",
+      vodId: "RCzMJs9uDSI",
+    },
+    {
+      name: "YungJeff",
+      link: "https://twitter.com/YUNGJEFF",
+      date: new Date("2023-04-04"),
+      videoId: "BXOEWQZ8C_Y",
+    },
+    {
+      name: "PointCrow",
+      link: "https://www.twitch.tv/pointcrow",
+      date: new Date("2023-03-24"),
+      videoId: "FhmkQkbV42U",
+      vodId: "Qz1Iniho9-g",
+    },
+    {
+      name: "Russel",
+      link: "https://www.twitch.tv/russel",
+      date: new Date("2023-03-20"),
+      videoId: "Xizgus_phn4",
+      vodId: "OUaYjkkLeFQ",
+    },
+    {
+      name: "Ludwig",
+      link: "https://www.youtube.com/@ludwig",
+      date: new Date("2023-02-25"),
+      videoId: "po1jytjDu4E",
+      vodId: "vuLMTU8QHAU",
+    },
+    {
+      name: "Alinity",
+      link: "https://www.twitch.tv/alinity",
+      date: new Date("2023-02-09"),
+      videoId: "bak3RqjCzE0",
+      vodId: "XHTEs94Cf4s",
+    },
+    {
+      name: "ConnorEatsPants",
+      link: "https://www.twitch.tv/connoreatspants",
+      date: new Date("2023-01-25"),
+      videoId: "nC8qlK3k96Q",
+      vodId: "SMEyEfVlzlM",
+    },
+    {
+      name: "The Botez Sisters",
+      link: "https://www.twitch.tv/botezlive",
+      date: new Date("2022-08-30"),
+      videoId: "QgvNy11kU6E",
+    },
+    {
+      name: "Knut",
+      link: "https://www.twitch.tv/knut",
+      date: new Date("2022-08-09"),
+      videoId: "lFhFx6kf2E4",
+    },
+    {
+      name: "MoistCr1TiKaL",
+      link: "https://www.twitch.tv/moistcr1tikal",
+      date: new Date("2022-04-30"),
+      videoId: "pb7MR59s1Z0",
+      vodId: "x-OPvwjGHEU",
+    },
+    {
+      name: "Jack Manifold",
+      link: "https://www.twitch.tv/jackmanifoldtv",
+      date: new Date("2022-04-21"),
+      videoId: "jzyxhnODe2g",
+    },
+  ] as const
+)
+  .toSorted((a, b) => b.date.getTime() - a.date.getTime())
+  .reduce(
+    ({ collaborations, slugs }, collaboration) => {
+      let slug = convertToSlug(collaboration.name);
+
+      // Some collaborators may visit multiple times, so append the year if we have a duplicate
+      if (slugs.has(slug)) {
+        slug = `${slug}-${collaboration.date.getUTCFullYear()}`;
+        if (slugs.has(slug))
+          throw new Error(`Duplicate collaboration slug: ${slug}`);
+      }
+
+      return {
+        collaborations: [...collaborations, { ...collaboration, slug }],
+        slugs: slugs.add(slug),
+      };
+    },
+    { collaborations: [] as Collaboration[], slugs: new Set<string>() },
+  ).collaborations;
+
+export default collaborations;

--- a/apps/website/src/data/events/index.tsx
+++ b/apps/website/src/data/events/index.tsx
@@ -1,0 +1,400 @@
+import type { ReactNode } from "react";
+
+import { convertToSlug } from "@/utils/slugs";
+
+import Link from "@/components/content/Link";
+
+import valentines2024Video from "@/assets/events/valentines-2024.mp4";
+import fallCarnival2023Video from "@/assets/events/fall-carnival-2023.mp4";
+import summerCamp2023Video from "@/assets/events/summer-camp-2023.mp4";
+import artAuction2023Video from "@/assets/events/art-auction-2023.mp4";
+import valentines2023Video from "@/assets/events/valentines-2023.mp4";
+import artAuction2022Video from "@/assets/events/art-auction-2022.mp4";
+import halloween2021Video from "@/assets/events/halloween-2021.mp4";
+import fundathon2021Video from "@/assets/events/fundathon-2021.mp4";
+
+export type Event = {
+  name: string;
+  slug: string;
+  date: Date;
+  video: Video;
+  stats: Record<string, { title: string; stat: string }>;
+  info: ReactNode;
+};
+
+const events: Event[] = (
+  [
+    {
+      name: "Valentine's Day 2024",
+      date: new Date("2024-02-14"),
+      video: valentines2024Video,
+      stats: {
+        totalDonations: {
+          title: "Raised for Alveus Sanctuary",
+          stat: "$32,697",
+        },
+        signedPostcards: {
+          title: "Signed postcards sent to donors",
+          stat: "467",
+        },
+        plushies: {
+          title: "Hand-crafted plushies distributed",
+          stat: "18",
+        },
+        revealed: {
+          title: "New ambassador revealed",
+          stat: "1",
+        },
+      },
+      info: (
+        <>
+          <p>
+            Celebrating Valentine&apos;s Day once again, live viewers joined us
+            for a short fundraising stream. They were able to donate $25 or more
+            to get a signed postcard with artwork featuring the ambassadors to
+            commemorate the event, and an entry into the raffle. During the
+            event, we were able to raise $32,697 for the sanctuary, with 467
+            postcards sent out to donors. The top 3 donors during the event were
+            able to pick the plushie they would like, and the remaining 15
+            plushies, all handcrafted by Maya, were distributed to random raffle
+            winners from those who donated $25 or more.
+          </p>
+          <p>
+            We also revealed a new ambassador during the event, introducing
+            everyone to <Link href="/ambassadors/push-pop">Push Pop</Link>, our
+            Sulcata Tortoise. Live viewers also got to meet many of our other
+            ambassadors as we headed around the property to distribute
+            Valentine&apos;s-themed enrichment (crafted items to help encourage
+            natural behaviors like foraging) to them. Thanks to everyone who
+            tuned in and supported this event!
+          </p>
+        </>
+      ),
+    },
+    {
+      name: "Fall Carnival 2023",
+      date: new Date("2023-11-04"),
+      video: fallCarnival2023Video,
+      stats: {
+        totalDonations: {
+          title: "Raised for Alveus Sanctuary",
+          stat: "$16,057",
+        },
+        signedTickets: {
+          title: "Signed tickets sent to donors",
+          stat: "330",
+        },
+        ambassadorPolaroids: {
+          title: "Ambassador polaroids distributed",
+          stat: "36",
+        },
+        uniqueDonors: {
+          title: "Unique donors during the broadcast",
+          stat: "200",
+        },
+      },
+      info: (
+        <>
+          <p>
+            A fun-filled event at Alveus Sanctuary, where live viewers on the
+            stream could compete against each other and ambassadors at Alveus to
+            earn virtual points. To help raise funds for Alveus, any donation
+            over $25 would get a signed ticket sent to them, and any donation
+            over $250 would get a signed polaroid of one of the ambassadors.
+          </p>
+          <p>
+            Live viewers could earn points in a variety of events, including a
+            rat maze with riddles to solve in each room as the ambassadors
+            explored the maze, ring toss with{" "}
+            <Link href="/ambassadors/abbott">Abbott</Link> the crow, and a race
+            with the{" "}
+            <Link href="/ambassadors/barbara-baked-bean">cockroaches</Link>.
+            Throughout the whole event a game of bingo was also being played
+            with the live viewers, with ambassadors around the property picking
+            out numbers.
+          </p>
+          <p>
+            By the end of the 3-hour-long event, we were able to raise $16,057
+            for Alveus Sanctuary, with 330 signed carnival tickets being sent to
+            the donors and 36 ambassador polaroids being sent out to those that
+            went the extra mile in their donations. Thank you to everyone that
+            watched and supported this spooky event!
+          </p>
+        </>
+      ),
+    },
+    {
+      name: "Summer Camp 2023",
+      date: new Date("2023-07-21"),
+      video: summerCamp2023Video,
+      stats: {
+        totalDonations: {
+          title: "Raised for Alveus Sanctuary",
+          stat: "$14,070",
+        },
+        uniqueViewers: {
+          title: "Unique viewers tuned in",
+          stat: "414,000",
+        },
+        craftsAuctioned: {
+          title: "Summer crafts auctioned off",
+          stat: "16",
+        },
+        minutesStreamed: {
+          title: "Minutes streamed live",
+          stat: "1,495",
+        },
+      },
+      info: (
+        <>
+          <p>
+            A 24-hour-long livestream event, featuring many of the Alveus staff
+            camping in the Session Yard at Alveus. There were plenty of
+            activities for the staff to participate in, including an archery
+            competition to start the event off, a water balloon fight later in
+            the day, cooking dinner around a campfire, late-night beer pong and
+            feeding the pasture with a catapult.
+          </p>
+          <p>
+            After camping overnight, still on the stream, the event ended with a
+            craft auction where viewers could bid and donate on 16 different
+            crafts made by the staff for the event, including multiple
+            friendship bracelets, two different Summer Camp paintings, a few
+            ambassador-themed hats, two handcrafted pet rocks, a rubber chicken
+            and the Summer Camp Spirit Stick itself.
+          </p>
+          <p>
+            Over the course of the 24-hour stream, a total of $14,070 was raised
+            for Alveus Sanctuary, with $6,291 of that coming from the craft
+            auction. Thank you to everyone that watched the stream, and to
+            everyone that donated to support the sanctuary!
+          </p>
+        </>
+      ),
+    },
+    {
+      name: "Art Auction 2023",
+      date: new Date("2023-04-22"),
+      video: artAuction2023Video,
+      stats: {
+        totalDonations: {
+          title: "Raised for Alveus Sanctuary",
+          stat: "$63,019",
+        },
+        signedPrints: {
+          title: "Signed postcards for donors",
+          stat: "261",
+        },
+        ambassadorPaintings: {
+          title: "Ambassador paintings sold",
+          stat: "33",
+        },
+        averagePrice: {
+          title: "Paid for each painting on average",
+          stat: "$570",
+        },
+      },
+      info: (
+        <>
+          <p>
+            Hosted in the Session Yard at Alveus, with Connor and Alex from the
+            Alveus team as the auctioneers, the Art Auction 2023 was a huge
+            success. Livestream viewers were able to bid on paintings created by
+            the ambassadors at Alveus via chat, with 33 paintings being sold
+            this year. For viewers who were unable to win a painting, they had
+            the option to donate $25 or more to get a signed postcard for the
+            event, and 261 wonderful donors claimed one.
+          </p>
+          <p>
+            The event raised $63,019 for Alveus Sanctuary over the course of the
+            3.5-hour-long event, with $31,500 of that from an incredibly
+            generous donation by Rotary at the end of the event.{" "}
+            <Link href="/ambassadors/georgie">Georgie</Link> was our most
+            successful ambassador artist this year, with his four paintings
+            raising $4,225 in donations, with the top one selling for $2.1k.
+            Thank you to everyone that watched and supported this event!
+          </p>
+        </>
+      ),
+    },
+    {
+      name: "Valentine's Day 2023",
+      date: new Date("2023-02-14"),
+      video: valentines2023Video,
+      stats: {
+        totalDonations: {
+          title: "Raised for Alveus Sanctuary",
+          stat: "$40,076",
+        },
+        signedPostcards: {
+          title: "Signed postcards sent to donors",
+          stat: "596",
+        },
+        dabloons: {
+          title: "Dabloons distributed to donors",
+          stat: "1,600",
+        },
+        viewers: {
+          title: "Peak viewers on the stream",
+          stat: "9,729",
+        },
+      },
+      info: (
+        <>
+          <p>
+            To celebrate Valentine&apos;s Day, we hosted a short livestream
+            fundraiser. Viewers were able to donate $25 or more to get a signed
+            postcard for the event, and the chance to win an ambassador plushie
+            handcrafted by Maya. We were able to raise $40,076 for Alveus over
+            the 3-hour-long event, with 596 donors claiming a postcard.
+          </p>
+          <p>
+            Each donation of $25 or more would also include some 3D-printed
+            dabloons ($25 per dabloon), which also represented an entry into the
+            plushie giveaway (one free entry was available for anyone unable to
+            donate). The top 5 donors during the event were able to pick which
+            plushie they would like, and the remaining 19 plushies were
+            distributed based on random golden dabloons amongst the 1,600
+            dabloons sent out to donors. Thank you to everyone that watched and
+            supported this event!
+          </p>
+        </>
+      ),
+    },
+    {
+      name: "Art Auction 2022",
+      date: new Date("2022-04-22"),
+      video: artAuction2022Video,
+      stats: {
+        totalDonations: {
+          title: "Raised for Alveus Sanctuary",
+          stat: "$42,104",
+        },
+        signedPrints: {
+          title: "Signed prints sent to donors",
+          stat: "199",
+        },
+        auctionWinners: {
+          title: "Auction winners",
+          stat: "23",
+        },
+        ambassadorPaintings: {
+          title: "Ambassador paintings sold",
+          stat: "30",
+        },
+      },
+      info: (
+        <p>
+          30 incredible paintings produced by the ambassadors at Alveus (with
+          help from our animal care staff) were up for auction, with livestream
+          viewers able to bid in real-time to get one. Alongside the paintings,
+          anyone was able to donate $100 or more to claim a signed print of a
+          painting containing all the ambassadors. During the event, we raised
+          $42,104 for Alveus Sanctuary, with 199 donors claiming a print. Thank
+          you for your support!
+        </p>
+      ),
+    },
+    {
+      name: "Halloween 2021",
+      date: new Date("2021-10-31"),
+      video: halloween2021Video,
+      stats: {
+        totalDonations: {
+          title: "Raised for Alveus Sanctuary",
+          stat: "$101,971",
+        },
+        uniqueDonors: {
+          title: "Unique donors during the broadcast",
+          stat: "1,235",
+        },
+        namesWritten: {
+          title: "Names written on the wall by creators",
+          stat: "244",
+        },
+        creators: {
+          title: "Creators attended the event",
+          stat: "34",
+        },
+        viewers: {
+          title: "Peak viewers on the stream",
+          stat: "93,000",
+        },
+      },
+      info: (
+        <>
+          <p>
+            The Halloween event at Alveus was a massive success, with 34
+            creators from across the streaming space descending on the sanctuary
+            to help raise money for the animals. During the event, anyone that
+            donated $250 or more had their name written on the side wall of the
+            Nutrition House, with the wall being sealed after the event. Over
+            the evening, 5 hours of live content, we were able to raise $101,971
+            for Alveus Sanctuary, with 1,235 donors claiming a name on the wall.
+          </p>
+          <p>
+            Two teams were formed from the creators, and they competed in many
+            activities around the property throughout the event. A game of apple
+            bobbing started the evening off, followed by hale bale throwing to
+            see which team had better technique. A little while later, we had a
+            game of badminton on the grass, followed by trivia and then the dunk
+            tank. We rounded off the evening with some mud wrestling. Thank you
+            to all the creators that joined us, and everyone who watched and
+            donated!
+          </p>
+        </>
+      ),
+    },
+    {
+      name: "Fund-a-thon 2021",
+      date: new Date("2021-02-10"),
+      video: fundathon2021Video,
+      stats: {
+        totalDonations: {
+          title: "Raised for Alveus Sanctuary",
+          stat: "$573,004",
+        },
+        uniqueDonors: {
+          title: "Unique donors during the broadcast",
+          stat: "3,904",
+        },
+        leaves: {
+          title: "Engraved leaves on the donator trees",
+          stat: "2,455",
+        },
+        viewers: {
+          title: "Peak viewers on the stream",
+          stat: "82,000",
+        },
+      },
+      info: (
+        <p>
+          The event that started it all! A 20-hour-long mega-stream with a bunch
+          of donation goals along the way, aiming to raise as much money as
+          possible to kick-start Alveus. Each donor that donated $100 or more
+          got their name engraved on a golden leaf that form part of six donor
+          trees now affixed to the back of the studio building. The final goal
+          for the stream was that at $500k raised Maya would shave her head, and
+          we were able to reach that goal with $573,004 raised for Alveus over
+          the whole stream. Thank you to all the leafers, everyone that donated
+          and everyone that watched!
+        </p>
+      ),
+    },
+  ] as const
+)
+  .toSorted((a, b) => b.date.getTime() - a.date.getTime())
+  .reduce(
+    ({ events, slugs }, event) => {
+      const slug = convertToSlug(event.name);
+      if (slugs.has(slug)) throw new Error(`Duplicate event slug: ${slug}`);
+
+      return {
+        events: [...events, { ...event, slug }],
+        slugs: slugs.add(slug),
+      };
+    },
+    { events: [] as Event[], slugs: new Set<string>() },
+  ).events;
+
+export default events;

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useMemo, useState } from "react";
+import { forwardRef, useEffect, useState } from "react";
 import { type NextPage } from "next";
 import Image from "next/image";
 
@@ -6,7 +6,8 @@ import useGrouped, { type GroupedItems, type Options } from "@/hooks/grouped";
 
 import { formatDateTime } from "@/utils/datetime";
 import { classes } from "@/utils/classes";
-import { convertToSlug } from "@/utils/slugs";
+
+import collaborations, { type Collaboration } from "@/data/collaborations";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";
@@ -20,220 +21,12 @@ import leafRightImage2 from "@/assets/floral/leaf-right-2.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
 
-type Collaboration = {
-  name: string;
-  link: string | null;
-  date: Date;
-  videoId: string;
-  vodId?: string;
-};
-
-const collaborations: Collaboration[] = [
-  {
-    name: "Emily Wang",
-    link: "https://www.twitch.tv/emilyywang",
-    date: new Date("2024-02-13"),
-    videoId: "CE-mNI_5eEI",
-  },
-  {
-    name: "Jinny",
-    link: "https://www.twitch.tv/jinnytty",
-    date: new Date("2024-02-08"),
-    videoId: "lpXtuG87BUM",
-    vodId: "c-EoBOEr1_g",
-  },
-  {
-    name: "JaidenAnimations & Alpharad",
-    link: null,
-    date: new Date("2024-02-02"),
-    videoId: "W74Ub2HR1Y4",
-    vodId: "U2HqCEr5_e4",
-  },
-  {
-    name: "Cinna",
-    link: "https://www.twitch.tv/cinna",
-    date: new Date("2024-01-28"),
-    videoId: "5YRrm5mDb6o",
-    vodId: "URSbZwAqLNE",
-  },
-  {
-    name: "Hasan",
-    link: "https://www.twitch.tv/hasanabi",
-    date: new Date("2024-01-26"),
-    videoId: "E_iO1ZKlHyM",
-    vodId: "MnPhxGBoY-I",
-  },
-  {
-    name: "Fanfan",
-    link: "https://www.twitch.tv/fanfan",
-    date: new Date("2023-11-13"),
-    videoId: "qHcy_sBJXmU",
-    vodId: "OCf7356WlNo",
-  },
-  {
-    name: "Alluux",
-    link: "https://www.twitch.tv/alluux",
-    date: new Date("2023-11-05"),
-    videoId: "L5r1isGll2I",
-    vodId: "x1KMHDgmsR0",
-  },
-  {
-    name: "Filian",
-    link: "https://www.twitch.tv/filian",
-    date: new Date("2023-10-11"),
-    videoId: "WaQcdQBrz0I",
-  },
-  {
-    name: "Trihex",
-    link: "https://www.twitch.tv/trihex",
-    date: new Date("2023-09-21"),
-    videoId: "lxks3skYeO4",
-    vodId: "H0gaJrLY5X0",
-  },
-  {
-    name: "Esfand",
-    link: "https://www.twitch.tv/esfandtv",
-    date: new Date("2023-08-26"),
-    videoId: "9aXebCBRonA",
-    vodId: "o7nyVU62rf8",
-  },
-  {
-    name: "ExtraEmily",
-    link: "https://www.twitch.tv/extraemily",
-    date: new Date("2023-06-22"),
-    videoId: "maJTBSkgA4Y",
-    vodId: "qbxV8xgA7Vg",
-  },
-  {
-    name: "Zoil",
-    link: "https://www.twitch.tv/zoil",
-    date: new Date("2023-06-13"),
-    videoId: "8M_qtYuSrys",
-    vodId: "n4KpVaUmrSE",
-  },
-  {
-    name: "PeachJars and Jessica Nigri",
-    link: "https://www.twitch.tv/peachjars",
-    date: new Date("2023-05-21"),
-    videoId: "-HuS6wbpqzQ",
-    vodId: "KF4HIypXiyc",
-  },
-  {
-    name: "Squeex",
-    link: "https://www.twitch.tv/squeex",
-    date: new Date("2023-05-19"),
-    videoId: "oUJxCDGQDlY",
-    vodId: "dCV8b8LcG-0",
-  },
-  {
-    name: "Caroline Kwan",
-    link: "https://www.twitch.tv/carolinekwan",
-    date: new Date("2023-05-09"),
-    videoId: "H5nV79y-Prg",
-    vodId: "4MmCFJadSg8",
-  },
-  {
-    name: "Lacari",
-    link: "https://www.twitch.tv/lacari",
-    date: new Date("2023-05-02"),
-    videoId: "IssAfvy_bmo",
-    vodId: "mVOypbE5YNs",
-  },
-  {
-    name: "Daily Dose",
-    link: "https://www.youtube.com/@DailyDoseOfInternet",
-    date: new Date("2023-04-25"),
-    videoId: "M9BBwvR3i-E",
-    vodId: "j8GxD4adNyk",
-  },
-  {
-    name: "Graycen",
-    link: "https://www.twitch.tv/graycen",
-    date: new Date("2023-04-18"),
-    videoId: "M3WBnThqRkg",
-  },
-  {
-    name: "Dareon",
-    link: "https://www.twitch.tv/dareon",
-    date: new Date("2023-04-11"),
-    videoId: "kqKnhu5zBIY",
-    vodId: "RCzMJs9uDSI",
-  },
-  {
-    name: "YungJeff",
-    link: "https://twitter.com/YUNGJEFF",
-    date: new Date("2023-04-04"),
-    videoId: "BXOEWQZ8C_Y",
-  },
-  {
-    name: "PointCrow",
-    link: "https://www.twitch.tv/pointcrow",
-    date: new Date("2023-03-24"),
-    videoId: "FhmkQkbV42U",
-    vodId: "Qz1Iniho9-g",
-  },
-  {
-    name: "Russel",
-    link: "https://www.twitch.tv/russel",
-    date: new Date("2023-03-20"),
-    videoId: "Xizgus_phn4",
-    vodId: "OUaYjkkLeFQ",
-  },
-  {
-    name: "Ludwig",
-    link: "https://www.youtube.com/@ludwig",
-    date: new Date("2023-02-25"),
-    videoId: "po1jytjDu4E",
-    vodId: "vuLMTU8QHAU",
-  },
-  {
-    name: "Alinity",
-    link: "https://www.twitch.tv/alinity",
-    date: new Date("2023-02-09"),
-    videoId: "bak3RqjCzE0",
-    vodId: "XHTEs94Cf4s",
-  },
-  {
-    name: "ConnorEatsPants",
-    link: "https://www.twitch.tv/connoreatspants",
-    date: new Date("2023-01-25"),
-    videoId: "nC8qlK3k96Q",
-    vodId: "SMEyEfVlzlM",
-  },
-  {
-    name: "The Botez Sisters",
-    link: "https://www.twitch.tv/botezlive",
-    date: new Date("2022-08-30"),
-    videoId: "QgvNy11kU6E",
-  },
-  {
-    name: "Knut",
-    link: "https://www.twitch.tv/knut",
-    date: new Date("2022-08-09"),
-    videoId: "lFhFx6kf2E4",
-  },
-  {
-    name: "MoistCr1TiKaL",
-    link: "https://www.twitch.tv/moistcr1tikal",
-    date: new Date("2022-04-30"),
-    videoId: "pb7MR59s1Z0",
-    vodId: "x-OPvwjGHEU",
-  },
-  {
-    name: "Jack Manifold",
-    link: "https://www.twitch.tv/jackmanifoldtv",
-    date: new Date("2022-04-21"),
-    videoId: "jzyxhnODe2g",
-  },
-];
-
 const sortByOptions = {
   all: {
     label: "All Collaborations",
     sort: (collaborations) =>
-      [...collaborations]
-        .sort((a, b) => b.date.getTime() - a.date.getTime())
-        .reduce<GroupedItems<Collaboration>>((map, collaboration) => {
+      collaborations.reduce<GroupedItems<Collaboration>>(
+        (map, collaboration) => {
           const year = collaboration.date.getUTCFullYear().toString();
 
           map.set(year, {
@@ -241,7 +34,9 @@ const sortByOptions = {
             items: [...(map.get(year)?.items || []), collaboration],
           });
           return map;
-        }, new Map()),
+        },
+        new Map(),
+      ),
   },
 } as const satisfies Options<Collaboration>;
 
@@ -249,24 +44,12 @@ const CollaborationItems = forwardRef<
   HTMLDivElement,
   GroupedProps<Collaboration>
 >(({ items, option, group, name, index }, ref) => {
-  const itemsWithSlugs = useMemo(
-    () =>
-      items.reduce(
-        (acc, item) => {
-          const slug = convertToSlug(item.name);
-          return { ...acc, [slug]: item };
-        },
-        {} as Record<string, Collaboration>,
-      ),
-    [items],
-  );
-
   const [open, setOpen] = useState<string>();
   useEffect(() => {
     const hash = window.location.hash.slice(1);
-    if (Object.prototype.hasOwnProperty.call(itemsWithSlugs, hash))
+    if (items.some((collaboration) => collaboration.slug === hash))
       setOpen(hash);
-  }, [itemsWithSlugs]);
+  }, [items]);
 
   return (
     <>
@@ -292,15 +75,15 @@ const CollaborationItems = forwardRef<
       >
         {({ Trigger }) => (
           <>
-            {Object.entries(itemsWithSlugs).map(([slug, collaboration]) => (
+            {items.map((collaboration) => (
               <div
-                key={slug}
+                key={collaboration.slug}
                 className="mx-auto flex basis-full flex-col items-center justify-start py-8 md:px-8 lg:basis-1/2"
               >
                 <Heading
                   level={2}
                   className="flex flex-wrap items-end justify-center gap-x-8 gap-y-2 text-center"
-                  id={slug}
+                  id={collaboration.slug}
                 >
                   {collaboration.link !== null ? (
                     <Link
@@ -315,7 +98,7 @@ const CollaborationItems = forwardRef<
                     collaboration.name
                   )}
                   <small className="text-xl text-alveus-green-600">
-                    <Link href={`#${slug}`} custom>
+                    <Link href={`#${collaboration.slug}`} custom>
                       {formatDateTime(collaboration.date, { style: "long" })}
                     </Link>
                   </small>
@@ -329,7 +112,7 @@ const CollaborationItems = forwardRef<
                       style: "long",
                     },
                   )}`}
-                  triggerId={slug}
+                  triggerId={collaboration.slug}
                   className="w-full max-w-2xl"
                 >
                   <Preview videoId={collaboration.videoId} />

--- a/apps/website/src/pages/events/index.tsx
+++ b/apps/website/src/pages/events/index.tsx
@@ -1,514 +1,121 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import { forwardRef, useMemo, type ReactNode } from "react";
+import { forwardRef } from "react";
 
 import useGrouped, { type GroupedItems, type Options } from "@/hooks/grouped";
 
 import { formatDateTime } from "@/utils/datetime";
 import { classes } from "@/utils/classes";
-import { convertToSlug } from "@/utils/slugs";
+
+import events, { type Event } from "@/data/events";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";
 import VideoPlayer from "@/components/content/Video";
 import Meta from "@/components/content/Meta";
-import Link from "@/components/content/Link";
 import Grouped, { type GroupedProps } from "@/components/content/Grouped";
-
-import valentines2024Video from "@/assets/events/valentines-2024.mp4";
-import fallCarnival2023Video from "@/assets/events/fall-carnival-2023.mp4";
-import summerCamp2023Video from "@/assets/events/summer-camp-2023.mp4";
-import artAuction2023Video from "@/assets/events/art-auction-2023.mp4";
-import valentines2023Video from "@/assets/events/valentines-2023.mp4";
-import artAuction2022Video from "@/assets/events/art-auction-2022.mp4";
-import halloween2021Video from "@/assets/events/halloween-2021.mp4";
-import fundathon2021Video from "@/assets/events/fundathon-2021.mp4";
 
 import leafRightImage1 from "@/assets/floral/leaf-right-1.png";
 import leafRightImage2 from "@/assets/floral/leaf-right-2.png";
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
 import leafLeftImage2 from "@/assets/floral/leaf-left-2.png";
 
-type Event = {
-  name: string;
-  date: Date;
-  video: Video;
-  stats: Record<string, { title: string; stat: string }>;
-  info: ReactNode;
-};
-
-const events: Event[] = [
-  {
-    name: "Valentine's Day 2024",
-    date: new Date("2024-02-14"),
-    video: valentines2024Video,
-    stats: {
-      totalDonations: {
-        title: "Raised for Alveus Sanctuary",
-        stat: "$32,697",
-      },
-      signedPostcards: {
-        title: "Signed postcards sent to donors",
-        stat: "467",
-      },
-      plushies: {
-        title: "Hand-crafted plushies distributed",
-        stat: "18",
-      },
-      revealed: {
-        title: "New ambassador revealed",
-        stat: "1",
-      },
-    },
-    info: (
-      <>
-        <p>
-          Celebrating Valentine&apos;s Day once again, live viewers joined us
-          for a short fundraising stream. They were able to donate $25 or more
-          to get a signed postcard with artwork featuring the ambassadors to
-          commemorate the event, and an entry into the raffle. During the event,
-          we were able to raise $32,697 for the sanctuary, with 467 postcards
-          sent out to donors. The top 3 donors during the event were able to
-          pick the plushie they would like, and the remaining 15 plushies, all
-          handcrafted by Maya, were distributed to random raffle winners from
-          those who donated $25 or more.
-        </p>
-        <p>
-          We also revealed a new ambassador during the event, introducing
-          everyone to <Link href="/ambassadors/push-pop">Push Pop</Link>, our
-          Sulcata Tortoise. Live viewers also got to meet many of our other
-          ambassadors as we headed around the property to distribute
-          Valentine&apos;s-themed enrichment (crafted items to help encourage
-          natural behaviors like foraging) to them. Thanks to everyone who tuned
-          in and supported this event!
-        </p>
-      </>
-    ),
-  },
-  {
-    name: "Fall Carnival 2023",
-    date: new Date("2023-11-04"),
-    video: fallCarnival2023Video,
-    stats: {
-      totalDonations: {
-        title: "Raised for Alveus Sanctuary",
-        stat: "$16,057",
-      },
-      signedTickets: {
-        title: "Signed tickets sent to donors",
-        stat: "330",
-      },
-      ambassadorPolaroids: {
-        title: "Ambassador polaroids distributed",
-        stat: "36",
-      },
-      uniqueDonors: {
-        title: "Unique donors during the broadcast",
-        stat: "200",
-      },
-    },
-    info: (
-      <>
-        <p>
-          A fun-filled event at Alveus Sanctuary, where live viewers on the
-          stream could compete against each other and ambassadors at Alveus to
-          earn virtual points. To help raise funds for Alveus, any donation over
-          $25 would get a signed ticket sent to them, and any donation over $250
-          would get a signed polaroid of one of the ambassadors.
-        </p>
-        <p>
-          Live viewers could earn points in a variety of events, including a rat
-          maze with riddles to solve in each room as the ambassadors explored
-          the maze, ring toss with{" "}
-          <Link href="/ambassadors/abbott">Abbott</Link> the crow, and a race
-          with the{" "}
-          <Link href="/ambassadors/barbara-baked-bean">cockroaches</Link>.
-          Throughout the whole event a game of bingo was also being played with
-          the live viewers, with ambassadors around the property picking out
-          numbers.
-        </p>
-        <p>
-          By the end of the 3-hour-long event, we were able to raise $16,057 for
-          Alveus Sanctuary, with 330 signed carnival tickets being sent to the
-          donors and 36 ambassador polaroids being sent out to those that went
-          the extra mile in their donations. Thank you to everyone that watched
-          and supported this spooky event!
-        </p>
-      </>
-    ),
-  },
-  {
-    name: "Summer Camp 2023",
-    date: new Date("2023-07-21"),
-    video: summerCamp2023Video,
-    stats: {
-      totalDonations: {
-        title: "Raised for Alveus Sanctuary",
-        stat: "$14,070",
-      },
-      uniqueViewers: {
-        title: "Unique viewers tuned in",
-        stat: "414,000",
-      },
-      craftsAuctioned: {
-        title: "Summer crafts auctioned off",
-        stat: "16",
-      },
-      minutesStreamed: {
-        title: "Minutes streamed live",
-        stat: "1,495",
-      },
-    },
-    info: (
-      <>
-        <p>
-          A 24-hour-long livestream event, featuring many of the Alveus staff
-          camping in the Session Yard at Alveus. There were plenty of activities
-          for the staff to participate in, including an archery competition to
-          start the event off, a water balloon fight later in the day, cooking
-          dinner around a campfire, late-night beer pong and feeding the pasture
-          with a catapult.
-        </p>
-        <p>
-          After camping overnight, still on the stream, the event ended with a
-          craft auction where viewers could bid and donate on 16 different
-          crafts made by the staff for the event, including multiple friendship
-          bracelets, two different Summer Camp paintings, a few
-          ambassador-themed hats, two handcrafted pet rocks, a rubber chicken
-          and the Summer Camp Spirit Stick itself.
-        </p>
-        <p>
-          Over the course of the 24-hour stream, a total of $14,070 was raised
-          for Alveus Sanctuary, with $6,291 of that coming from the craft
-          auction. Thank you to everyone that watched the stream, and to
-          everyone that donated to support the sanctuary!
-        </p>
-      </>
-    ),
-  },
-  {
-    name: "Art Auction 2023",
-    date: new Date("2023-04-22"),
-    video: artAuction2023Video,
-    stats: {
-      totalDonations: {
-        title: "Raised for Alveus Sanctuary",
-        stat: "$63,019",
-      },
-      signedPrints: {
-        title: "Signed postcards for donors",
-        stat: "261",
-      },
-      ambassadorPaintings: {
-        title: "Ambassador paintings sold",
-        stat: "33",
-      },
-      averagePrice: {
-        title: "Paid for each painting on average",
-        stat: "$570",
-      },
-    },
-    info: (
-      <>
-        <p>
-          Hosted in the Session Yard at Alveus, with Connor and Alex from the
-          Alveus team as the auctioneers, the Art Auction 2023 was a huge
-          success. Livestream viewers were able to bid on paintings created by
-          the ambassadors at Alveus via chat, with 33 paintings being sold this
-          year. For viewers who were unable to win a painting, they had the
-          option to donate $25 or more to get a signed postcard for the event,
-          and 261 wonderful donors claimed one.
-        </p>
-        <p>
-          The event raised $63,019 for Alveus Sanctuary over the course of the
-          3.5-hour-long event, with $31,500 of that from an incredibly generous
-          donation by Rotary at the end of the event.{" "}
-          <Link href="/ambassadors/georgie">Georgie</Link> was our most
-          successful ambassador artist this year, with his four paintings
-          raising $4,225 in donations, with the top one selling for $2.1k. Thank
-          you to everyone that watched and supported this event!
-        </p>
-      </>
-    ),
-  },
-  {
-    name: "Valentine's Day 2023",
-    date: new Date("2023-02-14"),
-    video: valentines2023Video,
-    stats: {
-      totalDonations: {
-        title: "Raised for Alveus Sanctuary",
-        stat: "$40,076",
-      },
-      signedPostcards: {
-        title: "Signed postcards sent to donors",
-        stat: "596",
-      },
-      dabloons: {
-        title: "Dabloons distributed to donors",
-        stat: "1,600",
-      },
-      viewers: {
-        title: "Peak viewers on the stream",
-        stat: "9,729",
-      },
-    },
-    info: (
-      <>
-        <p>
-          To celebrate Valentine&apos;s Day, we hosted a short livestream
-          fundraiser. Viewers were able to donate $25 or more to get a signed
-          postcard for the event, and the chance to win an ambassador plushie
-          handcrafted by Maya. We were able to raise $40,076 for Alveus over the
-          3-hour-long event, with 596 donors claiming a postcard.
-        </p>
-        <p>
-          Each donation of $25 or more would also include some 3D-printed
-          dabloons ($25 per dabloon), which also represented an entry into the
-          plushie giveaway (one free entry was available for anyone unable to
-          donate). The top 5 donors during the event were able to pick which
-          plushie they would like, and the remaining 19 plushies were
-          distributed based on random golden dabloons amongst the 1,600 dabloons
-          sent out to donors. Thank you to everyone that watched and supported
-          this event!
-        </p>
-      </>
-    ),
-  },
-  {
-    name: "Art Auction 2022",
-    date: new Date("2022-04-22"),
-    video: artAuction2022Video,
-    stats: {
-      totalDonations: {
-        title: "Raised for Alveus Sanctuary",
-        stat: "$42,104",
-      },
-      signedPrints: {
-        title: "Signed prints sent to donors",
-        stat: "199",
-      },
-      auctionWinners: {
-        title: "Auction winners",
-        stat: "23",
-      },
-      ambassadorPaintings: {
-        title: "Ambassador paintings sold",
-        stat: "30",
-      },
-    },
-    info: (
-      <p>
-        30 incredible paintings produced by the ambassadors at Alveus (with help
-        from our animal care staff) were up for auction, with livestream viewers
-        able to bid in real-time to get one. Alongside the paintings, anyone was
-        able to donate $100 or more to claim a signed print of a painting
-        containing all the ambassadors. During the event, we raised $42,104 for
-        Alveus Sanctuary, with 199 donors claiming a print. Thank you for your
-        support!
-      </p>
-    ),
-  },
-  {
-    name: "Halloween 2021",
-    date: new Date("2021-10-31"),
-    video: halloween2021Video,
-    stats: {
-      totalDonations: {
-        title: "Raised for Alveus Sanctuary",
-        stat: "$101,971",
-      },
-      uniqueDonors: {
-        title: "Unique donors during the broadcast",
-        stat: "1,235",
-      },
-      namesWritten: {
-        title: "Names written on the wall by creators",
-        stat: "244",
-      },
-      creators: {
-        title: "Creators attended the event",
-        stat: "34",
-      },
-      viewers: {
-        title: "Peak viewers on the stream",
-        stat: "93,000",
-      },
-    },
-    info: (
-      <>
-        <p>
-          The Halloween event at Alveus was a massive success, with 34 creators
-          from across the streaming space descending on the sanctuary to help
-          raise money for the animals. During the event, anyone that donated
-          $250 or more had their name written on the side wall of the Nutrition
-          House, with the wall being sealed after the event. Over the evening, 5
-          hours of live content, we were able to raise $101,971 for Alveus
-          Sanctuary, with 1,235 donors claiming a name on the wall.
-        </p>
-        <p>
-          Two teams were formed from the creators, and they competed in many
-          activities around the property throughout the event. A game of apple
-          bobbing started the evening off, followed by hale bale throwing to see
-          which team had better technique. A little while later, we had a game
-          of badminton on the grass, followed by trivia and then the dunk tank.
-          We rounded off the evening with some mud wrestling. Thank you to all
-          the creators that joined us, and everyone who watched and donated!
-        </p>
-      </>
-    ),
-  },
-  {
-    name: "Fund-a-thon 2021",
-    date: new Date("2021-02-10"),
-    video: fundathon2021Video,
-    stats: {
-      totalDonations: {
-        title: "Raised for Alveus Sanctuary",
-        stat: "$573,004",
-      },
-      uniqueDonors: {
-        title: "Unique donors during the broadcast",
-        stat: "3,904",
-      },
-      leaves: {
-        title: "Engraved leaves on the donator trees",
-        stat: "2,455",
-      },
-      viewers: {
-        title: "Peak viewers on the stream",
-        stat: "82,000",
-      },
-    },
-    info: (
-      <p>
-        The event that started it all! A 20-hour-long mega-stream with a bunch
-        of donation goals along the way, aiming to raise as much money as
-        possible to kick-start Alveus. Each donor that donated $100 or more got
-        their name engraved on a golden leaf that form part of six donor trees
-        now affixed to the back of the studio building. The final goal for the
-        stream was that at $500k raised Maya would shave her head, and we were
-        able to reach that goal with $573,004 raised for Alveus over the whole
-        stream. Thank you to all the leafers, everyone that donated and everyone
-        that watched!
-      </p>
-    ),
-  },
-];
-
 const sortByOptions = {
   all: {
     label: "All Events",
-    sort: (events) =>
-      [...events]
-        .sort((a, b) => b.date.getTime() - a.date.getTime())
-        .reduce<GroupedItems<Event>>((map, event) => {
-          const year = event.date.getUTCFullYear().toString();
+    sort: (items) =>
+      items.reduce<GroupedItems<Event>>((map, event) => {
+        const year = event.date.getUTCFullYear().toString();
 
-          map.set(year, {
-            name: year,
-            items: [...(map.get(year)?.items || []), event],
-          });
-          return map;
-        }, new Map()),
+        map.set(year, {
+          name: year,
+          items: [...(map.get(year)?.items || []), event],
+        });
+        return map;
+      }, new Map()),
   },
 } as const satisfies Options<Event>;
 
 const EventItems = forwardRef<HTMLDivElement, GroupedProps<Event>>(
-  ({ items, option, group, name, index }, ref) => {
-    const itemsWithSlugs = useMemo(
-      () =>
-        items.reduce(
-          (acc, item) => {
-            const slug = convertToSlug(item.name);
-            return { ...acc, [slug]: item };
-          },
-          {} as Record<string, Event>,
-        ),
-      [items],
-    );
-
-    return (
-      <>
-        {name && (
-          <Heading
-            level={-1}
+  ({ items, option, group, name, index }, ref) => (
+    <>
+      {name && (
+        <Heading
+          level={-1}
+          className={classes(
+            "alveus-green-800 mb-6 mt-8 border-b-2 border-alveus-green-300/25 pb-2 text-4xl",
+            index === 0 && "sr-only",
+          )}
+          id={`${option}:${group}`}
+          link
+        >
+          {name}
+        </Heading>
+      )}
+      <div ref={ref}>
+        {items.map((event, idx, arr) => (
+          <div
+            key={event.slug}
             className={classes(
-              "alveus-green-800 mb-6 mt-8 border-b-2 border-alveus-green-300/25 pb-2 text-4xl",
-              index === 0 && "sr-only",
+              "flex flex-wrap gap-y-8 pb-12 pt-8",
+              idx === 0 ? "lg:pb-16" : "lg:py-16",
+              idx !== arr.length - 1 && "border-b-2 border-alveus-green-300/15",
             )}
-            id={`${option}:${group}`}
-            link
           >
-            {name}
-          </Heading>
-        )}
-        <div ref={ref}>
-          {Object.entries(itemsWithSlugs).map(([slug, event], idx, arr) => (
-            <div
-              key={slug}
-              className={classes(
-                "flex flex-wrap gap-y-8 pb-12 pt-8",
-                idx === 0 ? "lg:pb-16" : "lg:py-16",
-                idx !== arr.length - 1 &&
-                  "border-b-2 border-alveus-green-300/15",
-              )}
-            >
-              <div className="mx-auto flex basis-full flex-col px-8 lg:basis-1/2">
-                <Heading
-                  level={2}
-                  className="my-4 scroll-mt-8 text-center text-4xl"
-                  id={slug}
-                  link
-                  linkClassName="flex flex-wrap items-end justify-center gap-x-8 gap-y-2"
-                >
-                  {event.name}
-                  <small className="text-xl text-alveus-green-600">
-                    {formatDateTime(event.date, { style: "long" })}
-                  </small>
-                </Heading>
-
-                <div className="my-auto flex flex-wrap py-2">
-                  {Object.entries(event.stats).map(([key, stat]) => (
-                    <div
-                      key={key}
-                      className="mx-auto basis-full py-2 text-center sm:basis-1/2 lg:px-2"
-                    >
-                      <p className="text-3xl font-bold">{stat.stat}</p>
-                      <p className="text-xl text-alveus-green-700">
-                        {stat.title}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              <div
-                className={classes(
-                  "mx-auto flex basis-full flex-col px-8 lg:basis-1/2",
-                  idx % 2 === 0 && "lg:order-first",
-                )}
+            <div className="mx-auto flex basis-full flex-col px-8 lg:basis-1/2">
+              <Heading
+                level={2}
+                className="my-4 scroll-mt-8 text-center text-4xl"
+                id={event.slug}
+                link
+                linkClassName="flex flex-wrap items-end justify-center gap-x-8 gap-y-2"
               >
-                <VideoPlayer
-                  className="my-auto aspect-video w-full rounded-xl"
-                  poster={event.video.poster}
-                  sources={event.video.sources}
-                  autoPlay
-                  loop
-                  muted
-                  playsInline
-                />
-              </div>
+                {event.name}
+                <small className="text-xl text-alveus-green-600">
+                  {formatDateTime(event.date, { style: "long" })}
+                </small>
+              </Heading>
 
-              <div className="flex basis-full flex-col gap-3 px-8 text-lg text-gray-600">
-                {event.info}
+              <div className="my-auto flex flex-wrap py-2">
+                {Object.entries(event.stats).map(([key, stat]) => (
+                  <div
+                    key={key}
+                    className="mx-auto basis-full py-2 text-center sm:basis-1/2 lg:px-2"
+                  >
+                    <p className="text-3xl font-bold">{stat.stat}</p>
+                    <p className="text-xl text-alveus-green-700">
+                      {stat.title}
+                    </p>
+                  </div>
+                ))}
               </div>
             </div>
-          ))}
-        </div>
-      </>
-    );
-  },
+
+            <div
+              className={classes(
+                "mx-auto flex basis-full flex-col px-8 lg:basis-1/2",
+                idx % 2 === 0 && "lg:order-first",
+              )}
+            >
+              <VideoPlayer
+                className="my-auto aspect-video w-full rounded-xl"
+                poster={event.video.poster}
+                sources={event.video.sources}
+                autoPlay
+                loop
+                muted
+                playsInline
+              />
+            </div>
+
+            <div className="flex basis-full flex-col gap-3 px-8 text-lg text-gray-600">
+              {event.info}
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  ),
 );
 
 EventItems.displayName = "EventItems";


### PR DESCRIPTION
## Describe your changes

Separates the page rendering logic from the data definitions for cleanliness. Also, sets up the duplicate slug logic in the collaborations file ready for Jack Manifold's upcoming second collaboration.

## Notes for testing your change

Collabs + events all still render correctly, with the same heading IDs as before.