### PR TITLE
Suggest frequent calendar event links

### DIFF
--- a/apps/website/src/components/admin/calendar-events/CalendarEventForm.tsx
+++ b/apps/website/src/components/admin/calendar-events/CalendarEventForm.tsx
@@ -1,5 +1,5 @@
 import type { FormEvent } from "react";
-import { useCallback } from "react";
+import { useState, useCallback } from "react";
 
 import type { CalendarEvent } from "@prisma/client";
 import { useRouter } from "next/router";
@@ -10,6 +10,7 @@ import {
   inputValueDatetimeLocalToUtc,
   utcToInputValueDatetimeLocal,
 } from "@/utils/local-datetime";
+import { frequentLinks } from "@/data/calendar-events";
 
 import type { CalendarEventSchema } from "@/server/db/calendar-events";
 
@@ -93,6 +94,9 @@ export function CalendarEventForm({
     [action, calendarEvent, router, submitMutation, onCreate],
   );
 
+  // NOTE: We have to use a controlled value for the link so the reset button works
+  const [link, setLink] = useState(calendarEvent?.link || "");
+
   return (
     <form
       className={classes("flex flex-col gap-10", className)}
@@ -134,16 +138,27 @@ export function CalendarEventForm({
         />
 
         <TextField
-          defaultValue={calendarEvent?.link || ""}
           label="Link"
           name="link"
           inputMode="url"
           isRequired
           type="url"
+          list="calendar-event-link-suggestions"
+          showResetButton={true}
           inputClassName="font-mono"
-          placeholder="https://twitch.tv/alveussanctuary"
+          placeholder={frequentLinks[0]?.url}
+          value={link}
+          onChange={(value) => setLink(value)}
         />
       </Fieldset>
+
+      <datalist id="calendar-event-link-suggestions">
+        {frequentLinks.map((link) => (
+          <option key={link.url} value={link.url}>
+            {link.label}
+          </option>
+        ))}
+      </datalist>
 
       <Fieldset legend="Time and date">
         <FieldGroup>
@@ -151,11 +166,12 @@ export function CalendarEventForm({
             label="Start (Central Time)"
             name="startAt"
             defaultValue={utcToInputValueDatetimeLocal(calendarEvent?.startAt)}
+            className="max-w-[calc(20ch)]"
           />
         </FieldGroup>
       </Fieldset>
 
-      <Fieldset legend="">
+      <div className="flex flex-col gap-2">
         <Button type="submit" className={defaultButtonClasses}>
           {action === "create" ? "Create" : "Update"}
         </Button>
@@ -170,7 +186,7 @@ export function CalendarEventForm({
             Delete
           </Button>
         )}
-      </Fieldset>
+      </div>
     </form>
   );
 }

--- a/apps/website/src/components/admin/notifications/SendNotificationForm.tsx
+++ b/apps/website/src/components/admin/notifications/SendNotificationForm.tsx
@@ -148,13 +148,14 @@ export function SendNotificationForm() {
           <TextField
             label="Link"
             name="url"
+            inputMode="url"
             type="url"
-            autoComplete="url"
             list="notification-link-suggestions"
             showResetButton={true}
+            pattern="https?://.*"
+            inputClassName="font-mono"
             value={link}
             onChange={(value) => setLink(value)}
-            pattern="https?://.*"
           />
 
           <datalist id="notification-link-suggestions">

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -1,0 +1,23 @@
+type FrequentLink = {
+  label: string;
+  url: string;
+};
+
+export const frequentLinks: FrequentLink[] = [
+  {
+    label: "Alveus Twitch",
+    url: "https://twitch.tv/AlveusSanctuary",
+  },
+  {
+    label: "Alveus YouTube",
+    url: "https://youtube.com/@AlveusSanctuary",
+  },
+  {
+    label: "Maya Twitch",
+    url: "https://twitch.tv/maya",
+  },
+  {
+    label: "Maya YouTube",
+    url: "https://youtube.com/@mayahiga",
+  },
+] as const;


### PR DESCRIPTION
## Describe your changes

Resolves #591

Adds a list of suggested links to the link field using `<datalist>`. Also enable a reset button which needs the input to use a controlled value for some reason. Firefox will show the suggestions on the second click or when typing, Chrome shows it on first click/focus.

Firefox:
 ![ff-event-links](https://github.com/alveusgg/alveusgg/assets/684458/d670e52a-773f-4b1c-b2b2-86a668c851ae)

Chrome:
![chrome-event-links](https://github.com/alveusgg/alveusgg/assets/684458/265ae287-5e79-49ec-9a0f-cd619fa109a3) 

I also tweaked the notification url field to be monospace and use the same "inputMode" and limited the width of the date/time field to make clicking the date picker button easier.

## Notes for testing your change

Check suggestions are shown, and the reset button actually resets the input.