### PR TITLE
Allow YouTube short URLs in Show and Tell

### DIFF
--- a/apps/website/src/utils/video-urls.ts
+++ b/apps/website/src/utils/video-urls.ts
@@ -14,7 +14,7 @@ export const videoPlatformConfigs = {
     replacement: (id: string) => `https://www.youtube.com/watch?v=${id}`,
     example: "https://www.youtube.com/watch?v=zEbsSAkVMpQ",
     regex:
-      /(?:https?:)?(?:\/\/)?(?:(?:www\.|m\.)?youtube(?:-nocookie)?\.com\/(?:(?:watch)?\?(?:app=[a-z]+&)?(?:feature=\w*&)?vi?=|embed\/|vi?\/|e\/)|youtu.be\/)([\w\-]{10,20})/i,
+      /(?:https?:)?(?:\/\/)?(?:(?:www\.|m\.)?youtube(?:-nocookie)?\.com\/(?:(?:watch)?\?(?:app=[a-z]+&)?(?:feature=\w*&)?vi?=|embed\/|vi?\/|e\/|shorts\/)|youtu.be\/)([\w\-]{10,20})/i,
     normalizedRegex: /https:\/\/www\.youtube\.com\/watch\?v=([\w\-]{10,20})/,
     embedUrl: (id: string) =>
       `https://www.youtube-nocookie.com/embed/${id}?modestbranding=1`,


### PR DESCRIPTION
## Describe your changes

Resolves #601.

## Notes for testing your change

YouTube short URLs can be submitted in show and tell, and that they embed without issue.
