### PR TITLE
Use error-boundary + try/catch around Show and Tell content

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -68,6 +68,7 @@
     "react": "18.2.0",
     "react-aria": "^3.31.1",
     "react-dom": "18.2.0",
+    "react-error-boundary": "^4.0.13",
     "react-markdown": "^9.0.1",
     "react-quill": "^2.0.0",
     "react-stately": "^3.29.1",

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -93,58 +93,10 @@ const parseOptions: HTMLReactParserOptions = {
   },
 };
 
-export const ShowAndTellEntry = forwardRef<
-  HTMLElement | null,
-  ShowAndTellEntryProps
->(function ShowAndTellEntry(
-  {
-    entry,
-    isPresentationView,
-    //showPermalink = false,
-  },
-  forwardedRef,
-) {
-  const wrapperRef = useRef<HTMLElement | null>(null);
-  const imageAttachments = entry.attachments
-    .filter(({ attachmentType }) => attachmentType === "image")
-    .map(({ imageAttachment }) => imageAttachment)
-    .filter(notEmpty);
-  const videoAttachments = entry.attachments
-    .filter(({ attachmentType }) => attachmentType === "video")
-    .map(({ linkAttachment }) => linkAttachment)
-    .filter(notEmpty);
-
-  let featureImageUrl = imageAttachments[0]?.url;
-  if (!featureImageUrl) {
-    for (const videoAttachment of videoAttachments) {
-      const parsedVideoUrl = parseVideoUrl(videoAttachment.url);
-      if (!parsedVideoUrl) continue;
-      const videoPlatformConfig = videoPlatformConfigs[parsedVideoUrl.platform];
-      if (!("previewUrl" in videoPlatformConfig)) continue;
-      featureImageUrl = videoPlatformConfig.previewUrl(parsedVideoUrl.id);
-      break;
-    }
-  }
-
-  const handleRef = useCallback(
-    (node: HTMLElement) => {
-      wrapperRef.current = node;
-      if (typeof forwardedRef === "function") {
-        forwardedRef(node);
-      } else if (forwardedRef) {
-        forwardedRef.current = node;
-      }
-    },
-    [forwardedRef],
-  );
-
-  const content = useMemo(
-    () => parse(`<root>${entry.text}</root>`, parseOptions),
-    [entry.text],
-  );
-
+const Header = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
   const hours = entry.volunteeringMinutes && entry.volunteeringMinutes / 60;
-  const header = (
+
+  return (
     <header
       className={`p-4 px-10 drop-shadow-xl ${
         isPresentationView ? "" : "text-center"
@@ -216,6 +168,76 @@ export const ShowAndTellEntry = forwardRef<
       </p>
     </header>
   );
+};
+
+const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
+  const content = useMemo(
+    () => parse(`<root>${entry.text}</root>`, parseOptions),
+    [entry.text],
+  );
+
+  return (
+    isValidElement(content) &&
+    content.type !== Empty && (
+      <div className="-m-4 mt-0 bg-white/70 p-4 text-gray-900 backdrop-blur-sm">
+        <div
+          className={`mx-auto w-fit  ${
+            isPresentationView ? "scrollbar-none max-h-[66vh] pb-6" : ""
+          }`}
+        >
+          <div className="alveus-ugc max-w-[1100px] hyphens-auto leading-relaxed md:text-lg xl:text-2xl">
+            {content}
+          </div>
+        </div>
+      </div>
+    )
+  );
+};
+
+export const ShowAndTellEntry = forwardRef<
+  HTMLElement | null,
+  ShowAndTellEntryProps
+>(function ShowAndTellEntry(
+  {
+    entry,
+    isPresentationView,
+    // showPermalink = false,
+  },
+  forwardedRef,
+) {
+  const wrapperRef = useRef<HTMLElement | null>(null);
+  const imageAttachments = entry.attachments
+    .filter(({ attachmentType }) => attachmentType === "image")
+    .map(({ imageAttachment }) => imageAttachment)
+    .filter(notEmpty);
+  const videoAttachments = entry.attachments
+    .filter(({ attachmentType }) => attachmentType === "video")
+    .map(({ linkAttachment }) => linkAttachment)
+    .filter(notEmpty);
+
+  let featureImageUrl = imageAttachments[0]?.url;
+  if (!featureImageUrl) {
+    for (const videoAttachment of videoAttachments) {
+      const parsedVideoUrl = parseVideoUrl(videoAttachment.url);
+      if (!parsedVideoUrl) continue;
+      const videoPlatformConfig = videoPlatformConfigs[parsedVideoUrl.platform];
+      if (!("previewUrl" in videoPlatformConfig)) continue;
+      featureImageUrl = videoPlatformConfig.previewUrl(parsedVideoUrl.id);
+      break;
+    }
+  }
+
+  const handleRef = useCallback(
+    (node: HTMLElement) => {
+      wrapperRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        forwardedRef.current = node;
+      }
+    },
+    [forwardedRef],
+  );
 
   return (
     <article
@@ -262,7 +284,7 @@ export const ShowAndTellEntry = forwardRef<
         ) : (
           header
         ) */}
-        {header}
+        <Header entry={entry} isPresentationView={isPresentationView} />
 
         <ShowAndTellGallery
           isPresentationView={isPresentationView}
@@ -271,19 +293,7 @@ export const ShowAndTellEntry = forwardRef<
           videoAttachments={videoAttachments}
         />
 
-        {isValidElement(content) && content.type !== Empty && (
-          <div className="-m-4 mt-0 bg-white/70 p-4 text-gray-900 backdrop-blur-sm">
-            <div
-              className={`mx-auto w-fit  ${
-                isPresentationView ? "scrollbar-none max-h-[66vh] pb-6" : ""
-              }`}
-            >
-              <div className="alveus-ugc max-w-[1100px] hyphens-auto leading-relaxed md:text-lg xl:text-2xl">
-                {content}
-              </div>
-            </div>
-          </div>
-        )}
+        <Content entry={entry} isPresentationView={isPresentationView} />
       </div>
     </article>
   );

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -175,8 +175,10 @@ const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
   const content = useMemo(() => {
     try {
       return parse(`<root>${entry.text}</root>`, parseOptions);
-    } catch (e) {}
-  }, [entry.text]);
+    } catch (e) {
+      console.error(`Failed to parse Show and Tell entry ${entry.id}`, e);
+    }
+  }, [entry.text, entry.id]);
 
   return (
     isValidElement(content) &&
@@ -188,7 +190,17 @@ const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
           }`}
         >
           <div className="alveus-ugc max-w-[1100px] hyphens-auto leading-relaxed md:text-lg xl:text-2xl">
-            <ErrorBoundary FallbackComponent={Empty}>{content}</ErrorBoundary>
+            <ErrorBoundary
+              FallbackComponent={Empty}
+              onError={(err) =>
+                console.error(
+                  `Failed to render Show and Tell entry ${entry.id}`,
+                  err,
+                )
+              }
+            >
+              {content}
+            </ErrorBoundary>
           </div>
         </div>
       </div>

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -22,6 +22,7 @@ import parse, {
   type DOMNode,
   type HTMLReactParserOptions,
 } from "html-react-parser";
+import { ErrorBoundary } from "react-error-boundary";
 
 import { parseVideoUrl, videoPlatformConfigs } from "@/utils/video-urls";
 import { notEmpty } from "@/utils/helpers";
@@ -171,10 +172,11 @@ const Header = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
 };
 
 const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
-  const content = useMemo(
-    () => parse(`<root>${entry.text}</root>`, parseOptions),
-    [entry.text],
-  );
+  const content = useMemo(() => {
+    try {
+      return parse(`<root>${entry.text}</root>`, parseOptions);
+    } catch (e) {}
+  }, [entry.text]);
 
   return (
     isValidElement(content) &&
@@ -186,7 +188,7 @@ const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
           }`}
         >
           <div className="alveus-ugc max-w-[1100px] hyphens-auto leading-relaxed md:text-lg xl:text-2xl">
-            {content}
+            <ErrorBoundary FallbackComponent={Empty}>{content}</ErrorBoundary>
           </div>
         </div>
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      react-error-boundary:
+        specifier: ^4.0.13
+        version: 4.0.13(react@18.2.0)
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.2.48)(react@18.2.0)
@@ -8554,6 +8557,15 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-error-boundary@4.0.13(react@18.2.0):
+    resolution: {integrity: sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.23.9
+      react: 18.2.0
     dev: false
 
   /react-is@16.13.1:


### PR DESCRIPTION
## Describe your changes

Resolves #216.

I don't think this will ever be needed, but should ensure that malformed content doesn't ever cause Show and Tell to outright error out and not work.

Note that error boundaries can only catch client errors, so we also need a regular ol' try/catch around the parse for the server-side rendering.

## Notes for testing your change

Not sure how to test this really, other than that legitimate content continues to render.