### PR TITLE
Fix image attachment schema not allowing enough chars

### DIFF
--- a/apps/website/prisma/schema.prisma
+++ b/apps/website/prisma/schema.prisma
@@ -301,7 +301,7 @@ model ShortLinksTracking {
 }
 
 model CalendarEvent {
-  id          String @id @default(cuid())
+  id          String   @id @default(cuid())
   title       String
   description String?
   category    String
@@ -453,12 +453,12 @@ model ImageMetadata {
 
 model ImageAttachment {
   id                  String @id @default(cuid())
-  name                String
-  title               String
-  alternativeText     String
-  caption             String
-  description         String
-  url                 String
+  name                String @db.VarChar(200)
+  title               String @db.VarChar(200)
+  alternativeText     String @db.VarChar(300)
+  caption             String @db.VarChar(200)
+  description         String @db.VarChar(200)
+  url                 String @db.VarChar(200)
   fileStorageObjectId String @unique
 
   fileStorageObject          FileStorageObject           @relation(fields: [fileStorageObjectId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Describe your changes

There currently is a mismatch between the database schema (strings of 191 chars - the default for VARCHAR = String in MySQL/Prisma) and the max length of input fields (caption and alt text). This commit alters the table to allow the same number of characters as the input fields to prevent errors.

Resolves #606

## Notes for testing your change

Test show and tell post submission. Attach image(s) and fill the fields with lots of chars :)
