### PR TITLE
Use full brand name in navigation

### DIFF
--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -160,7 +160,7 @@ export function DesktopMenu() {
         className="flex items-center gap-4 border-t border-white pt-2"
       >
         <Link href="/" className="font-serif text-3xl font-bold">
-          Alveus
+          Alveus Sanctuary
         </Link>
         <ul className="flex flex-grow justify-end">
           {Object.entries(mainNavStructure).map(([key, link]) => (

--- a/apps/website/src/components/layout/navbar/Navbar.tsx
+++ b/apps/website/src/components/layout/navbar/Navbar.tsx
@@ -23,7 +23,7 @@ export const Navbar = () => {
             {/* Logo */}
             <Link
               href="/"
-              className="flex items-center px-1 lg:-ml-4 lg:px-0"
+              className="flex flex-shrink-0 items-center px-1 lg:-ml-4 lg:px-0"
               aria-label="Alveus Sanctuary Inc."
             >
               <Image
@@ -38,9 +38,9 @@ export const Navbar = () => {
             <DesktopMenu />
 
             {/* Mobile menu toggle */}
-            <div className="flex flex-grow items-center justify-center lg:hidden">
+            <div className="flex flex-grow items-center justify-center text-center lg:hidden">
               <Link href="/" className="font-serif text-3xl font-bold">
-                Alveus
+                Alveus Sanctuary
               </Link>
             </div>
             <div className="flex items-center lg:hidden">


### PR DESCRIPTION
## Describe your changes

As requested by the Alveus team, use the full brand name in the navigation on the site.

## Notes for testing your change

Mobile + desktop nav updated to use the full name. Responsive across all viewport sizes.
