### PR TITLE
Show and Tell: Permanently Enable Tracking Volunteering Hours

### DIFF
--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -353,14 +353,15 @@ export function ShowAndTellEntryForm({
       </div>
 
       <div className="space-y-10">
-        <Fieldset legend="Give an Hour">
+        <Fieldset legend="Give an hour for earth">
           <p>
             Do you want to track hours you spent on this activity as part of the
-            Alveus community total for WWF&apos;s{" "}
+            Alveus communities effort to give an hour for earth? This started as
+            part of WWF&apos;s{" "}
             <Link href="/show-and-tell/give-an-hour" external>
               Give an Hour
             </Link>{" "}
-            initiative?
+            initiative.
           </p>
 
           <div className="flex items-center gap-8">

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -362,7 +362,7 @@ export function ShowAndTellEntryForm({
         <Fieldset legend="Give an hour for Earth">
           <p>
             Do you want to track hours you spent on this activity as part of the
-            Alveus communities effort to give an hour for Earth? This started as
+            Alveus community&apos;s effort to give an hour for Earth? Originally
             part of WWF&apos;s{" "}
             <Link href="/show-and-tell/give-an-hour" external>
               Give an Hour

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -34,6 +34,8 @@ import {
 } from "../shared/form/VideoLinksField";
 import Link from "../content/Link";
 
+const dateWhenTextShortened = new Date(2024, 3, 26);
+
 export const allowedFileTypes = [
   "image/png",
   "image/jpeg",
@@ -287,7 +289,11 @@ export function ShowAndTellEntryForm({
               label="Content"
               name="text"
               defaultValue={entry?.text}
-              maxLength={700}
+              maxLength={
+                entry?.createdAt && entry.createdAt < dateWhenTextShortened
+                  ? 700
+                  : 300
+              }
             />
           </Fieldset>
         </div>

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -359,10 +359,10 @@ export function ShowAndTellEntryForm({
       </div>
 
       <div className="space-y-10">
-        <Fieldset legend="Give an hour for earth">
+        <Fieldset legend="Give an hour for Earth">
           <p>
             Do you want to track hours you spent on this activity as part of the
-            Alveus communities effort to give an hour for earth? This started as
+            Alveus communities effort to give an hour for Earth? This started as
             part of WWF&apos;s{" "}
             <Link href="/show-and-tell/give-an-hour" external>
               Give an Hour

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -3,18 +3,12 @@ import { useRouter } from "next/router";
 
 import type { ShowAndTellSubmitInput } from "@/server/db/show-and-tell";
 
-import {
-  giveAnHourStart,
-  giveAnHourEnd,
-  MAX_IMAGES,
-  MAX_VIDEOS,
-} from "@/data/show-and-tell";
+import { MAX_IMAGES, MAX_VIDEOS } from "@/data/show-and-tell";
 
 import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
 import { notEmpty } from "@/utils/helpers";
 import { getEntityStatus } from "@/utils/entity-helpers";
-import { formatDateTime } from "@/utils/datetime";
 
 import IconLoading from "@/icons/IconLoading";
 import IconWarningTriangle from "@/icons/IconWarningTriangle";
@@ -105,36 +99,9 @@ export function ShowAndTellEntryForm({
   const review = trpc.adminShowAndTell.review.useMutation();
   const isLoading = create.isLoading || update.isLoading || review.isLoading;
 
-  const trackingStatus = useMemo(() => {
-    // Check local time is in date range
-    const now = new Date();
-    // Parsing the date time strings without explicit timezone makes it local time
-    const start = new Date(giveAnHourStart);
-    const end = new Date(giveAnHourEnd);
-    // Using zone: null to display the time in local time (default is UTC)
-    const trackingStatusFrom = formatDateTime(start, undefined, { zone: null });
-    const trackingStatusTo = formatDateTime(end, undefined, { zone: null });
-
-    let active = true;
-    let verb = "is";
-    if (now < start) {
-      active = false;
-      verb = "will be";
-    } else if (now > end) {
-      active = false;
-      verb = "was";
-    }
-
-    return {
-      active,
-      text: `tracking ${verb} available from ${trackingStatusFrom} to ${trackingStatusTo}`,
-    };
-  }, []);
-
   const [wantsToTrackGiveAnHour, setWantsToTrackGiveAnHour] = useState(
     !!entry?.volunteeringMinutes,
   );
-  const enableTrackGiveAnHour = trackingStatus.active && wantsToTrackGiveAnHour;
 
   const imageAttachmentsData = useUploadAttachmentsData(
     useMemo(
@@ -180,7 +147,7 @@ export function ShowAndTellEntryForm({
       text: formData.get("text") as string,
       imageAttachments: { create: [], update: {} },
       videoLinks: videoLinksData.videoUrls,
-      volunteeringMinutes: enableTrackGiveAnHour && hours ? hours * 60 : null,
+      volunteeringMinutes: hours ? hours * 60 : null,
     };
 
     for (const fileReference of imageAttachmentsData.files) {
@@ -399,15 +366,11 @@ export function ShowAndTellEntryForm({
           <div className="flex items-center gap-8">
             <label
               htmlFor="giveAnHourTracked"
-              className={classes(
-                "flex items-center gap-4",
-                !trackingStatus.active && "cursor-not-allowed",
-              )}
+              className="flex items-center gap-4"
             >
               <input
                 type="checkbox"
                 id="giveAnHourTracked"
-                disabled={!trackingStatus.active}
                 checked={wantsToTrackGiveAnHour}
                 onChange={(e) => setWantsToTrackGiveAnHour(e.target.checked)}
               />
@@ -415,18 +378,12 @@ export function ShowAndTellEntryForm({
             </label>
 
             <GiveAnHourInput
-              enabled={enableTrackGiveAnHour}
+              enabled
               defaultValue={
                 entry?.volunteeringMinutes ? entry.volunteeringMinutes / 60 : 1
               }
             />
           </div>
-
-          <p className="text-sm italic opacity-75">
-            <strong>Give an Hour</strong> {trackingStatus.text}. Activities
-            submitted with tracked hours must occur while the Give an Hour
-            initiative is active.
-          </p>
         </Fieldset>
 
         {error && <MessageBox variant="failure">{error}</MessageBox>}

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -3,7 +3,11 @@ import { useRouter } from "next/router";
 
 import type { ShowAndTellSubmitInput } from "@/server/db/show-and-tell";
 
-import { MAX_IMAGES, MAX_VIDEOS } from "@/data/show-and-tell";
+import {
+  MAX_IMAGES,
+  MAX_VIDEOS,
+  getMaxTextLengthForCreatedAt,
+} from "@/data/show-and-tell";
 
 import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
@@ -33,8 +37,6 @@ import {
   VideoLinksField,
 } from "../shared/form/VideoLinksField";
 import Link from "../content/Link";
-
-const dateWhenTextShortened = new Date(2024, 3, 26);
 
 export const allowedFileTypes = [
   "image/png",
@@ -289,11 +291,7 @@ export function ShowAndTellEntryForm({
               label="Content"
               name="text"
               defaultValue={entry?.text}
-              maxLength={
-                entry?.createdAt && entry.createdAt < dateWhenTextShortened
-                  ? 700
-                  : 300
-              }
+              maxLength={getMaxTextLengthForCreatedAt(entry?.createdAt)}
             />
           </Fieldset>
         </div>

--- a/apps/website/src/data/show-and-tell.ts
+++ b/apps/website/src/data/show-and-tell.ts
@@ -1,5 +1,2 @@
 export const MAX_IMAGES = 16;
 export const MAX_VIDEOS = 6;
-
-export const giveAnHourStart = "2024-03-01T00:00:00";
-export const giveAnHourEnd = "2024-04-22T23:59:59";

--- a/apps/website/src/data/show-and-tell.ts
+++ b/apps/website/src/data/show-and-tell.ts
@@ -1,2 +1,9 @@
 export const MAX_IMAGES = 16;
 export const MAX_VIDEOS = 6;
+
+export const MAX_TEXT_HTML_LENGTH = 1_000; // We allow more total html length than characters (ignoring tags)
+
+const dateWhenTextShortened = new Date(2024, 3, 26);
+
+export const getMaxTextLengthForCreatedAt = (createdAt?: Date) =>
+  createdAt && createdAt < dateWhenTextShortened ? 700 : 300;

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -78,7 +78,7 @@ const GiveAnHourPage: NextPage = () => (
   <>
     <Meta
       title="Give an Hour | Show and Tell"
-      description="Join the Alveus community and WWF to Give an Hour for Earth! Discover what actions you can take to help the environment and wildlife."
+      description="Join the Alveus community and give an hour for earth! Discover what actions you can take to help the environment and wildlife."
       image={giveAnHourPoster.src}
     />
 
@@ -94,9 +94,10 @@ const GiveAnHourPage: NextPage = () => (
         <Heading>Give an Hour for Earth</Heading>
 
         <p className="text-lg">
-          Join the Alveus community and WWF in participating in Give an Hour for
-          Earth from March 1st to April 22nd. Discover what actions you can take
-          to help the environment and wildlife.
+          Join the Alveus community in giving hours for earth. Discover what
+          actions you can take to help the environment and wildlife. This
+          initiative started March 1st to April 22nd as part of WWF&apos;s Give
+          an Hour for Earth campaign in 2024 but will continue beyond that date.
         </p>
 
         <p className="text-md mt-8">
@@ -283,8 +284,8 @@ const GiveAnHourPage: NextPage = () => (
       </div>
 
       <Share
-        title="Give an Hour for Earth with Alveus Sanctuary and WWF"
-        text="Join the Alveus community and WWF to Give an Hour for Earth! Discover what actions you can take to help the environment and wildlife."
+        title="Give an Hour for Earth with Alveus Sanctuary"
+        text="Join the Alveus community to give an hour for earth! Discover what actions you can take to help the environment and wildlife."
         path="/give-an-hour"
         dark
       />

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -95,9 +95,9 @@ const GiveAnHourPage: NextPage = () => (
 
         <p className="text-lg">
           Join the Alveus community in giving hours for Earth. Discover what
-          actions you can take to help the environment and wildlife. This
-          initiative started March 1st to April 22nd as part of WWF&apos;s Give
-          an Hour for Earth campaign in 2024 but will continue beyond that date.
+          actions you can take to help the environment and wildlife. Originally
+          part of WWF&apos;s Give an Hour for Earth campaign in 2024, we&apos;re
+          now tracking everything we do for Earth!
         </p>
 
         <p className="text-md mt-8">

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -78,7 +78,7 @@ const GiveAnHourPage: NextPage = () => (
   <>
     <Meta
       title="Give an Hour | Show and Tell"
-      description="Join the Alveus community and give an hour for earth! Discover what actions you can take to help the environment and wildlife."
+      description="Join the Alveus community and give an hour for Earth! Discover what actions you can take to help the environment and wildlife."
       image={giveAnHourPoster.src}
     />
 
@@ -94,7 +94,7 @@ const GiveAnHourPage: NextPage = () => (
         <Heading>Give an Hour for Earth</Heading>
 
         <p className="text-lg">
-          Join the Alveus community in giving hours for earth. Discover what
+          Join the Alveus community in giving hours for Earth. Discover what
           actions you can take to help the environment and wildlife. This
           initiative started March 1st to April 22nd as part of WWF&apos;s Give
           an Hour for Earth campaign in 2024 but will continue beyond that date.
@@ -285,7 +285,7 @@ const GiveAnHourPage: NextPage = () => (
 
       <Share
         title="Give an Hour for Earth with Alveus Sanctuary"
-        text="Join the Alveus community to give an hour for earth! Discover what actions you can take to help the environment and wildlife."
+        text="Join the Alveus community to give an hour for Earth! Discover what actions you can take to help the environment and wildlife."
         path="/give-an-hour"
         dark
       />

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -357,8 +357,12 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
 
           <p className="mt-8">
             As a community, we&apos;re tracking the hours we spend giving back
-            to the planet, as part of WWF&apos;s{" "}
-            <Link href="/show-and-tell/give-an-hour" dark>
+            to the planet, originally as part of WWF&apos;s{" "}
+            <Link
+              href="/show-and-tell/give-an-hour"
+              dark
+              className="whitespace-nowrap"
+            >
               Give an Hour
             </Link>{" "}
             initiative.

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -244,23 +244,12 @@ export async function getPosts({
   });
 }
 
-export async function getVolunteeringMinutes({
-  from,
-  to,
-}: {
-  from?: Date;
-  to?: Date;
-} = {}) {
+export async function getVolunteeringMinutes() {
   return (
     (
       await prisma.showAndTellEntry.aggregate({
         _sum: { volunteeringMinutes: true },
-        where: {
-          AND: [
-            getPostFilter("approved"),
-            { createdAt: { gte: from, lte: to } },
-          ],
-        },
+        where: getPostFilter("approved"),
       })
     )._sum.volunteeringMinutes ?? 0
   );

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -3,7 +3,11 @@ import { TRPCError } from "@trpc/server";
 
 import { env } from "@/env";
 
-import { MAX_IMAGES, MAX_VIDEOS } from "@/data/show-and-tell";
+import {
+  MAX_IMAGES,
+  MAX_VIDEOS,
+  MAX_TEXT_HTML_LENGTH,
+} from "@/data/show-and-tell";
 
 import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 import { prisma } from "@/server/db/client";
@@ -88,7 +92,7 @@ export type ShowAndTellSubmitInput = z.infer<
 const showAndTellSharedInputSchema = z.object({
   displayName: z.string().max(100),
   title: z.string().max(100),
-  text: z.string().max(1_000),
+  text: z.string().max(MAX_TEXT_HTML_LENGTH),
   imageAttachments: imageAttachmentsSchema,
   videoLinks: videoLinksSchema.max(MAX_VIDEOS),
   volunteeringMinutes: z.number().int().positive().nullable(),

--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -24,8 +24,6 @@ import {
 import { allowedFileTypes } from "@/components/show-and-tell/ShowAndTellEntryForm";
 import { env } from "@/env";
 import { notEmpty } from "@/utils/helpers";
-import { giveAnHourStart, giveAnHourEnd } from "@/data/show-and-tell";
-import { earliestTimeZone, latestTimeZone } from "@/utils/datetime";
 
 const uploadPrefix = "show-and-tell/";
 
@@ -57,10 +55,7 @@ export const showAndTellRouter = router({
     }),
 
   getGiveAnHourProgress: publicProcedure.query(async () => {
-    const minutes = await getVolunteeringMinutes({
-      from: new Date(giveAnHourStart + earliestTimeZone),
-      to: new Date(giveAnHourEnd + latestTimeZone),
-    });
+    const minutes = await getVolunteeringMinutes();
     return Math.round(minutes / 60);
   }),
 

--- a/apps/website/src/utils/datetime.ts
+++ b/apps/website/src/utils/datetime.ts
@@ -1,9 +1,6 @@
 import { DateTime } from "luxon";
 import type { PartialDateString } from "@alveusgg/data/src/types";
 
-export const earliestTimeZone = "+14:00";
-export const latestTimeZone = "-12:00";
-
 export type DateTimeFormat = {
   style: "short" | "long";
   time: "minutes" | "seconds" | undefined;


### PR DESCRIPTION
## Describe your changes

As decided by the executive director, Alveus will continue the Give an Hour initiative beyond the official WWF campaign. This PR removes the restrictions on volunteering hours and adapts the wording.

This will also reduce the number of characters allowed for new posts as requested by the CEO to keep the posts short for stream :)

I am very unsure on the wording and if we keep the WWF logo, but I think this makes it clear its not part of the official campaign anymore without needing to replace all the original branding.

## Notes for testing your change

- Check existing posts are still fully readable and editable
- Check new posts can be submitted, reviewed and seen incl. volunteering hours (or no hours)
- Check wording is fine
