### PR TITLE
Fix Show and Tell text shortened date to match deployment

### DIFF
--- a/apps/website/src/data/show-and-tell.ts
+++ b/apps/website/src/data/show-and-tell.ts
@@ -3,7 +3,7 @@ export const MAX_VIDEOS = 6;
 
 export const MAX_TEXT_HTML_LENGTH = 1_000; // We allow more total html length than characters (ignoring tags)
 
-const dateWhenTextShortened = new Date(2024, 3, 26);
+const dateWhenTextShortened = new Date(2024, 3, 27, 15, 19, 0, 0);
 
 export const getMaxTextLengthForCreatedAt = (createdAt?: Date) =>
   createdAt && createdAt < dateWhenTextShortened ? 700 : 300;


### PR DESCRIPTION
## Describe your changes

FeelsDankMan I kinda did not think about the time between commit and deployment where people could still write >300 char posts. This should fix it, by moving the check to the time of deployment.

## Notes for testing your change

Check posts are editable with the appropriate text length limits (esp. on 2024-04-26/2024-04-27).