### PR TITLE
Show and Tell: Fix volunteering minutes always being set

### DIFF
--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -151,7 +151,7 @@ export function ShowAndTellEntryForm({
       text: formData.get("text") as string,
       imageAttachments: { create: [], update: {} },
       videoLinks: videoLinksData.videoUrls,
-      volunteeringMinutes: hours ? hours * 60 : null,
+      volunteeringMinutes: wantsToTrackGiveAnHour && hours ? hours * 60 : null,
     };
 
     for (const fileReference of imageAttachmentsData.files) {

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -383,7 +383,7 @@ export function ShowAndTellEntryForm({
             </label>
 
             <GiveAnHourInput
-              enabled
+              enabled={wantsToTrackGiveAnHour}
               defaultValue={
                 entry?.volunteeringMinutes ? entry.volunteeringMinutes / 60 : 1
               }


### PR DESCRIPTION
## Describe your changes

Fix volunteering minutes always being set even if checkbox not checked

## Notes for testing your change

Check that you can submit the posts with and without volunteering minutes **and** its showing the correct thing after saving/reloading!
