### PR TITLE
Fix MinIO ACLs + path generation

### DIFF
--- a/apps/website/.env.example
+++ b/apps/website/.env.example
@@ -65,7 +65,7 @@ FILE_STORAGE_ENDPOINT=http://localhost:9000
 FILE_STORAGE_SECRET=alveusgg_secret
 FILE_STORAGE_REGION=us-east-1
 FILE_STORAGE_KEY=alveusgg_key
-FILE_STORAGE_CDN_URL=http://localhost:9000
+FILE_STORAGE_CDN_URL=
 FILE_STORAGE_BUCKET=alveusgg
 FILE_STORAGE_PATH_STYLE=true # MinIO requires path style
 

--- a/apps/website/docker-compose.yaml
+++ b/apps/website/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   db:
     image: mysql:8
@@ -11,10 +10,11 @@ services:
     image: bitnami/minio:latest
     ports:
       - 9000:9000
+      - 9001:9001
     environment:
       MINIO_ROOT_USER: alveusgg_key
       MINIO_ROOT_PASSWORD: alveusgg_secret
-      MINIO_DEFAULT_BUCKETS: alveusgg
+      MINIO_DEFAULT_BUCKETS: alveusgg:download
     volumes:
       - s3:/bitnami/minio/data
 

--- a/apps/website/src/server/utils/file-storage.ts
+++ b/apps/website/src/server/utils/file-storage.ts
@@ -15,7 +15,7 @@ import { probeImageMeta } from "@/server/utils/probe-image-meta";
 export function getBucketUrl() {
   const endpointUrl = new URL(env.FILE_STORAGE_ENDPOINT);
   if (env.FILE_STORAGE_PATH_STYLE)
-    endpointUrl.pathname = `/${env.FILE_STORAGE_BUCKET}`;
+    endpointUrl.pathname = `/${env.FILE_STORAGE_BUCKET}/`;
   else
     endpointUrl.hostname = `${env.FILE_STORAGE_BUCKET}.${endpointUrl.hostname}`;
   return endpointUrl.toString();


### PR DESCRIPTION
## Describe your changes

Unsure how #616 / #631 were ever working when we tested/merged them, but I noticed while testing #694 that local uploads were not working.

After _much_ debugging locally, it looks like it came down to two things:

1. MinIO requires path-style names, and with the path as `/alveusgg`, calling `new URL('other-path', 'http://host/alveusgg')` would result in `/alveusgg` being eaten, replaced by `/other-path`. So, I've ensured that the path-style name now results in a path as `/alveusgg/`.

2. Even with the path fixed, the image probing (which does not use auth) was unable to access the uploaded images. It turns out MinIO does not appear to support object ACLs, rather they recommend using per-bucket (and per-path) bucket ACLs. So, I've set the default policy for the whole bucket to be read-only (download).

## Notes for testing your change

Show and tell uploads work locally.

Show and tell uploads work w/ a remote bucket as in prod.