### PR TITLE
Secure cron API w/ Vercel's CRON_SECRET + timing-safe token comparison for protected APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Create a [Twitch application](https://dev.twitch.tv/console/apps/create), settin
 3. Run `docker compose up -d` from within `apps/website` to start a local MySQL database, and an S3 bucket with MinIO.
 4. Copy `apps/website/.env.example` to `apps/website/.env` and open your copy in a text editor and fill it:
    1. The vapid keys for web notifications have to be generated using `pnpx web-push generate-vapid-keys`
-   2. The Next Auth secret (`NEXTAUTH_SECRET`) and Action API secret (`ACTION_API_SECRET`) have to be filled with 32-byte Base64-encoded secrets. See [Generate secrets](#generate-secrets) below.
+   2. The Next Auth secret (`NEXTAUTH_SECRET`), Action API secret (`ACTION_API_SECRET`) and Vercel Cron Secret (`CRON_SECRET`) have to be filled with 32-byte Base64-encoded secrets. See [Generate secrets](#generate-secrets) below.
    3. The data encryption passphrase (`DATA_ENCRYPTION_PASSPHRASE`) has to be filled with a 24-byte Base64-encoded secret. See [Generate secrets](#generate-secrets) below.
    4. You may define privileged users once they have signed in in the `SUPER_USER_IDS` variable with their CUID (using comma separated values)
 5. Push the database schema to the new database using `pnpm prisma db push` from within `apps/website`.

--- a/apps/website/.env.example
+++ b/apps/website/.env.example
@@ -54,6 +54,10 @@ DISCORD_CHANNEL_WEBHOOK_URLS_ANNOUNCEMENT=https://discord.com/api/webhooks/ccc/x
 #   You can generate the secret via 'openssl rand -base64 32' on Linux
 ACTION_API_SECRET=
 
+# Vercel Cron secret (see https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs)
+#   You can generate the secret via 'openssl rand -base64 32' on Linux
+CRON_SECRET=
+
 # Web Push VAPID Key
 #   You can generate the keys via 'npx web-push generate-vapid-keys'
 NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY=

--- a/apps/website/src/env/index.js
+++ b/apps/website/src/env/index.js
@@ -54,6 +54,7 @@ export const env = createEnv({
     TWITCH_CLIENT_ID: z.string(),
     TWITCH_CLIENT_SECRET: z.string(),
     ACTION_API_SECRET: z.string(),
+    CRON_SECRET: z.string().optional(),
     SUPER_USER_IDS: z.string(),
     WEB_PUSH_VAPID_PRIVATE_KEY: z
       .string()
@@ -131,6 +132,7 @@ export const env = createEnv({
     TWITCH_CLIENT_ID: process.env.TWITCH_CLIENT_ID,
     TWITCH_CLIENT_SECRET: process.env.TWITCH_CLIENT_SECRET,
     ACTION_API_SECRET: process.env.ACTION_API_SECRET,
+    CRON_SECRET: process.env.CRON_SECRET,
     SUPER_USER_IDS: process.env.SUPER_USER_IDS,
     WEB_PUSH_VAPID_PRIVATE_KEY: process.env.WEB_PUSH_VAPID_PRIVATE_KEY,
     WEB_PUSH_VAPID_SUBJECT: process.env.WEB_PUSH_VAPID_SUBJECT,

--- a/apps/website/src/pages/api/cron.ts
+++ b/apps/website/src/pages/api/cron.ts
@@ -1,10 +1,23 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
+import { env } from "@/env";
+import timingSafeCompareString from "@/server/utils/timing-safe-compare-string";
 import { runScheduledTasks } from "@/server/scheduler";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
+  // Check for secret to confirm this is a valid request
+  const authHeader = req.headers["authorization"];
+  if (
+    env.CRON_SECRET &&
+    (authHeader === undefined ||
+      !timingSafeCompareString(authHeader, `Bearer ${env.CRON_SECRET}`))
+  ) {
+    return res.status(401).json({ message: "Invalid token" });
+  }
+
   try {
     await runScheduledTasks();
     res.status(200).json({ success: true });

--- a/apps/website/src/pages/api/cron.ts
+++ b/apps/website/src/pages/api/cron.ts
@@ -9,11 +9,11 @@ export default async function handler(
   res: NextApiResponse,
 ) {
   // Check for secret to confirm this is a valid request
-  const authHeader = req.headers["authorization"];
+  const { authorization } = req.headers;
   if (
     env.CRON_SECRET &&
-    (authHeader === undefined ||
-      !timingSafeCompareString(authHeader, `Bearer ${env.CRON_SECRET}`))
+    (authorization === undefined ||
+      !timingSafeCompareString(authorization, `Bearer ${env.CRON_SECRET}`))
   ) {
     return res.status(401).json({ message: "Invalid token" });
   }

--- a/apps/website/src/pages/api/show-and-tell/revalidate.ts
+++ b/apps/website/src/pages/api/show-and-tell/revalidate.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { env } from "@/env";
+import timingSafeCompareString from "@/server/utils/timing-safe-compare-string";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
   // Check for secret to confirm this is a valid request
-  if (req.query.secret !== env.ACTION_API_SECRET) {
+  if (
+    req.query.secret === undefined ||
+    !timingSafeCompareString(String(req.query.secret), env.ACTION_API_SECRET)
+  ) {
     return res.status(401).json({ message: "Invalid token" });
   }
 

--- a/apps/website/src/server/utils/api.ts
+++ b/apps/website/src/server/utils/api.ts
@@ -1,7 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { ZodType } from "zod/lib/types";
 import type { z } from "zod";
+
 import { env } from "@/env";
+import timingSafeCompareString from "@/server/utils/timing-safe-compare-string";
 
 export function createTokenProtectedApiHandler<T extends ZodType>(
   schema: T,
@@ -16,7 +18,10 @@ export function createTokenProtectedApiHandler<T extends ZodType>(
 
     const { authorization } = req.headers;
 
-    if (authorization !== `Bearer ${env.ACTION_API_SECRET}`) {
+    if (
+      authorization === undefined ||
+      !timingSafeCompareString(authorization, `Bearer ${env.ACTION_API_SECRET}`)
+    ) {
       res.status(401).json({ success: false });
       return;
     }

--- a/apps/website/src/server/utils/timing-safe-compare-string.ts
+++ b/apps/website/src/server/utils/timing-safe-compare-string.ts
@@ -1,0 +1,13 @@
+import { timingSafeEqual } from "node:crypto";
+
+// Perform a timing-safe string comparison
+export default function timingSafeCompareString(a: string, b: string) {
+  const bufferA = Buffer.from(a, "utf16le");
+  const bufferB = Buffer.from(b, "utf16le");
+  if (bufferA.byteLength !== bufferB.byteLength) {
+    timingSafeEqual(bufferA, bufferA);
+    return false;
+  }
+
+  return timingSafeEqual(bufferA, bufferB);
+}


### PR DESCRIPTION
## Describe your changes

This adds a check for the cron endpoint, checking the Authorization header againts the `CRON_SECRET` env, provided by the Vercel environment (or locally through the `.env` file). This will also use a timing safe string comparison for the tokens of this and existing protected APIs using the `ACTION_API_SECRET`.

## Notes for testing your change

Check the APIs are still callable with and only with the correct tokens. Check the cron task still gets run on Vercel.