### PR TITLE
Remove "exotic" mentions in content

### DIFF
--- a/apps/website/src/pages/about/alveus.tsx
+++ b/apps/website/src/pages/about/alveus.tsx
@@ -412,7 +412,7 @@ const AboutAlveusPage: NextPage = () => {
     <>
       <Meta
         title="About Alveus"
-        description="Alveus is a nonprofit organization founded by Maya Higa that functions as an exotic animal sanctuary and as a virtual education center facility to provide permanent homes to non-releasable exotic animals."
+        description="Alveus is a nonprofit organization founded by Maya Higa that functions as a wildlife sanctuary and as a virtual education center facility to provide permanent homes to non-releasable animal ambassadors."
       />
 
       {/* Nav background */}
@@ -428,9 +428,9 @@ const AboutAlveusPage: NextPage = () => {
 
           <p className="text-lg">
             Alveus is a nonprofit organization founded by Maya Higa that
-            functions as an exotic animal sanctuary and as a virtual education
-            center facility to provide permanent homes to non-releasable exotic
-            animals.
+            functions as a wildlife sanctuary and as a virtual education center
+            facility to provide permanent homes to non-releasable animal
+            ambassadors.
           </p>
 
           <p className="text-lg">

--- a/apps/website/src/pages/about/maya.tsx
+++ b/apps/website/src/pages/about/maya.tsx
@@ -105,7 +105,7 @@ const AboutMayaPage: NextPage = () => {
     <>
       <Meta
         title="About Maya"
-        description="Maya Higa is one of the top female streamers on Twitch and a rising star on YouTube. Maya founded Alveus Sanctuary, a non-profit exotic animal sanctuary and virtual education center in central Texas, and raised more than $500,000 during her first fundraising stream thanks to her amazing community and fellow streamers."
+        description="Maya Higa is one of the top female streamers on Twitch and a rising star on YouTube. Maya founded Alveus Sanctuary, a non-profit wildlife sanctuary and virtual education center in central Texas, and raised more than $500,000 during her first fundraising stream thanks to her amazing community and fellow streamers."
       />
 
       {/* Nav background */}
@@ -132,7 +132,7 @@ const AboutMayaPage: NextPage = () => {
               podcast in 2019 which has since aired more than 60 episodes on her
               channel and raised more than $92,000 for wildlife protection
               organizations around the globe. Maya founded Alveus Sanctuary, a
-              non-profit exotic animal sanctuary and virtual education center in
+              non-profit wildlife sanctuary and virtual education center in
               central Texas and raised more than $500,000 during her first
               fundraising stream thanks to her amazing community and fellow
               streamers.

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -172,7 +172,7 @@ const Home: NextPage = () => {
 
             <p className="mt-8 text-lg">
               Alveus is a virtual education center following the journeys of our
-              non-releasable exotic ambassadors, aiming to educate and spark an
+              non-releasable animal ambassadors, aiming to educate and spark an
               appreciation for them and their wild counterparts.
             </p>
 
@@ -239,11 +239,11 @@ const Home: NextPage = () => {
               </p>
               <p className="my-4 text-lg">
                 Alveus is a nonprofit organization founded by Maya Higa that
-                functions as an exotic animal sanctuary and as a virtual
-                education center facility to provide permanent homes to
-                non-releasable exotic animals. These animals function as
-                ambassadors, so viewers can watch their journeys, get to know
-                the animals, and gain an appreciation for their species.
+                functions as a wildlife sanctuary and as a virtual education
+                center facility to provide permanent homes to non-releasable
+                animal ambassadors. These animals function as ambassadors, so
+                viewers can watch their journeys, get to know the animals, and
+                gain an appreciation for their species.
               </p>
               <p className="my-4 text-lg">
                 Alveus hosts content collaborations where creators can visit and


### PR DESCRIPTION
## Describe your changes

Request from the folks at Alveus, Alveus should be referred to as a wildlife sanctuary, not an exotic animal sanctuary.

## Notes for testing your change

All mentions of exotic removed, content still reads fine.