### PR TITLE
Add API endpoint for weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Create a [Twitch application](https://dev.twitch.tv/console/apps/create), settin
    1. The vapid keys for web notifications have to be generated using `pnpx web-push generate-vapid-keys`
    2. The Next Auth secret (`NEXTAUTH_SECRET`), Action API secret (`ACTION_API_SECRET`) and Vercel Cron Secret (`CRON_SECRET`) have to be filled with 32-byte Base64-encoded secrets. See [Generate secrets](#generate-secrets) below.
    3. The data encryption passphrase (`DATA_ENCRYPTION_PASSPHRASE`) has to be filled with a 24-byte Base64-encoded secret. See [Generate secrets](#generate-secrets) below.
-   4. You may define privileged users once they have signed in in the `SUPER_USER_IDS` variable with their CUID (using comma separated values)
+   4. You may define a Weather API key (`WEATHER_API_KEY`) to use the weather API and stream overlay. See [Weather API](#weather-api) below.
+   5. You may define privileged users once they have signed in in the `SUPER_USER_IDS` variable with their CUID (using comma separated values)
 5. Push the database schema to the new database using `pnpm prisma db push` from within `apps/website`.
 6. Start the dev server using `pnpm dev` from within `apps/website`
 7. The website should be running at `http://localhost:3000/` (open in browser)
@@ -93,6 +94,14 @@ We use Base64-encoded random strings for various secrets. To generate these secr
   _You may need to call `python3` instead depending on your installation._
   - Generate a 32-byte secret: `python -c "import os, base64; print(base64.b64encode(os.urandom(32)).decode('utf-8'))"`
   - Generate a 24-byte secret: `python -c "import os, base64; print(base64.b64encode(os.urandom(24)).decode('utf-8'))"`
+
+### Weather API
+
+Alveus operates a weather station on-site that uploads data to wunderground.com. Wunderground provide an API via api.weather.com that we use to display the weather for the stream overlay (and in the API for the Twitch chat bot). Accessing the API required an API key, which is only granted to users that have a weather station on wunderground.com.
+
+It _seems_ that anyone can sign up for a Wunderground account and register a weather station on the site, at which point you'll be granted access to the API, without ever needing to actually connect a weather station and upload data. It _seems_ you can use this to get an API key to develop with the weather API locally.
+
+_In production, we use the actual API key for the account that is associated with the Alveus weather station, which does upload data to the site._
 
 ## Production deployment
 

--- a/apps/website/.env.example
+++ b/apps/website/.env.example
@@ -58,6 +58,13 @@ ACTION_API_SECRET=
 #   You can generate the secret via 'openssl rand -base64 32' on Linux
 CRON_SECRET=
 
+# Weather API secret
+#   You can add a weather station to wunderground.com for this
+# More info: https://www.wunderground.com/member/api-keys
+#            https://www.wunderground.com/pws/overview
+WEATHER_API_KEY=
+WEATHER_STATION_ID=INUNAV15
+
 # Web Push VAPID Key
 #   You can generate the keys via 'npx web-push generate-vapid-keys'
 NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY=

--- a/apps/website/src/env/index.js
+++ b/apps/website/src/env/index.js
@@ -55,6 +55,8 @@ export const env = createEnv({
     TWITCH_CLIENT_SECRET: z.string(),
     ACTION_API_SECRET: z.string(),
     CRON_SECRET: z.string().optional(),
+    WEATHER_API_KEY: z.string().optional(),
+    WEATHER_STATION_ID: z.string().optional(),
     SUPER_USER_IDS: z.string(),
     WEB_PUSH_VAPID_PRIVATE_KEY: z
       .string()
@@ -133,6 +135,8 @@ export const env = createEnv({
     TWITCH_CLIENT_SECRET: process.env.TWITCH_CLIENT_SECRET,
     ACTION_API_SECRET: process.env.ACTION_API_SECRET,
     CRON_SECRET: process.env.CRON_SECRET,
+    WEATHER_API_KEY: process.env.WEATHER_API_KEY,
+    WEATHER_STATION_ID: process.env.WEATHER_STATION_ID,
     SUPER_USER_IDS: process.env.SUPER_USER_IDS,
     WEB_PUSH_VAPID_PRIVATE_KEY: process.env.WEB_PUSH_VAPID_PRIVATE_KEY,
     WEB_PUSH_VAPID_SUBJECT: process.env.WEB_PUSH_VAPID_SUBJECT,

--- a/apps/website/src/pages/api/stream/weather.ts
+++ b/apps/website/src/pages/api/stream/weather.ts
@@ -1,0 +1,115 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { env } from "@/env";
+import { getCurrentObservation } from "@/server/utils/weather-api";
+import { rounded } from "@/utils/math";
+
+const getFeelsLike = (
+  temperature: number | null,
+  heatIndex: number | null,
+  windChill: number | null,
+) => {
+  if (temperature !== null) {
+    if (temperature >= 70 && heatIndex !== null) return heatIndex;
+    if (temperature <= 61 && windChill !== null) return windChill;
+  }
+  return temperature;
+};
+
+// API for overlay + chat bot
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (env.WEATHER_STATION_ID && env.WEATHER_API_KEY) {
+    try {
+      const weather = await getCurrentObservation(env.WEATHER_STATION_ID, true);
+      const feelsLike = getFeelsLike(
+        weather.imperial.temp,
+        weather.imperial.heatIndex,
+        weather.imperial.windChill,
+      );
+
+      res.setHeader(
+        "Cache-Control",
+        "max-age=60, s-maxage=300, stale-while-revalidate",
+      );
+      return res.json({
+        time: {
+          local: weather.obsTimeLocal,
+          utc: weather.obsTimeUtc,
+        },
+        uvIndex: weather.uv,
+        humidity: weather.humidity,
+        temperature: {
+          fahrenheit: weather.imperial.temp,
+          celsius:
+            weather.imperial.temp !== null
+              ? rounded(((weather.imperial.temp - 32) * 5) / 9, 2)
+              : null,
+          heatIndex: {
+            fahrenheit: weather.imperial.heatIndex,
+            celsius:
+              weather.imperial.heatIndex !== null
+                ? rounded(((weather.imperial.heatIndex - 32) * 5) / 9, 2)
+                : null,
+          },
+          windChill: {
+            fahrenheit: weather.imperial.windChill,
+            celsius:
+              weather.imperial.windChill !== null
+                ? rounded(((weather.imperial.windChill - 32) * 5) / 9, 2)
+                : null,
+          },
+          feelsLike: {
+            fahrenheit: feelsLike,
+            celsius: feelsLike ? rounded(((feelsLike - 32) * 5) / 9, 2) : null,
+          },
+        },
+        pressure: {
+          inches: weather.imperial.pressure,
+          millibars:
+            weather.imperial.pressure !== null
+              ? rounded(weather.imperial.pressure * 33.86375, 2)
+              : null,
+        },
+        wind: {
+          speed: {
+            miles: weather.imperial.windSpeed,
+            kilometers:
+              weather.imperial.windSpeed !== null
+                ? rounded(weather.imperial.windSpeed * 1.60934, 2)
+                : null,
+          },
+          gusts: {
+            miles: weather.imperial.windGust,
+            kilometers:
+              weather.imperial.windGust !== null
+                ? rounded(weather.imperial.windGust * 1.60934, 2)
+                : null,
+          },
+          direction: weather.winddir,
+        },
+        precipitation: {
+          rate: {
+            inches: weather.imperial.precipRate,
+            millimeters:
+              weather.imperial.precipRate !== null
+                ? rounded(weather.imperial.precipRate * 25.4, 2)
+                : null,
+          },
+          total: {
+            inches: weather.imperial.precipTotal,
+            millimeters:
+              weather.imperial.precipTotal !== null
+                ? rounded(weather.imperial.precipTotal * 25.4, 2)
+                : null,
+          },
+        },
+      });
+    } catch (err) {
+      console.error("Error getting weather", err);
+    }
+  }
+
+  return res.status(500).send("Error getting weather");
+}

--- a/apps/website/src/server/utils/weather-api.ts
+++ b/apps/website/src/server/utils/weather-api.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+import { env } from "@/env";
+
+// https://ibm.co/v2PWSCC
+// https://ibm.co/APICom
+const observationSchema = z
+  .object({
+    country: z.string().nullable(),
+    epoch: z.number().nullable(),
+    humidity: z.number().nullable(),
+    lat: z.number().nullable(),
+    lon: z.number().nullable(),
+    neighborhood: z.string().nullable(),
+    obsTimeLocal: z.string().nullable(),
+    obsTimeUtc: z.string().datetime().nullable(),
+    qcStatus: z.number().min(-1).max(1).int(),
+    realtimeFrequency: z.number().nullable(),
+    softwareType: z.string().nullable(),
+    solarRadiation: z.number().nullable(),
+    stationID: z.string(),
+    uv: z.number().nullable(),
+    winddir: z.number().nullable(),
+  })
+  .strict();
+
+const unitsSchema = z
+  .object({
+    dewpt: z.number().nullable(),
+    elev: z.number().nullable(),
+    heatIndex: z.number().nullable(),
+    precipRate: z.number().nullable(),
+    precipTotal: z.number().nullable(),
+    pressure: z.number().nullable(),
+    temp: z.number().nullable(),
+    windChill: z.number().nullable(),
+    windGust: z.number().nullable(),
+    windSpeed: z.number().nullable(),
+  })
+  .strict();
+
+const metricSchema = observationSchema
+  .extend({
+    metric: unitsSchema,
+  })
+  .strict();
+
+const imperialSchema = observationSchema
+  .extend({
+    imperial: unitsSchema,
+  })
+  .strict();
+
+type CurrentObservation<T extends boolean> = z.infer<
+  T extends true ? typeof imperialSchema : typeof metricSchema
+>;
+
+const currentObservationsSchema = (imperial: boolean) =>
+  z
+    .object({
+      observations: z
+        .array(imperial ? imperialSchema : metricSchema)
+        .nonempty()
+        .length(1),
+    })
+    .strict();
+
+export async function getCurrentObservation<T extends boolean>(
+  stationId: string,
+  imperial: T,
+): Promise<CurrentObservation<T>> {
+  if (!env.WEATHER_API_KEY) throw new Error("WEATHER_API_KEY is not set!");
+
+  const response = await fetch(
+    `https://api.weather.com/v2/pws/observations/current?stationId=${encodeURIComponent(stationId)}&format=json&units=${imperial ? "e" : "m"}&numericPrecision=decimal&apiKey=${encodeURIComponent(env.WEATHER_API_KEY)}`,
+  );
+
+  const json = await response.json();
+  if (response.status !== 200) {
+    console.error(json);
+    throw new Error("Could not get current observations!");
+  }
+
+  const data = await currentObservationsSchema(imperial).parseAsync(json);
+  return data.observations[0] as CurrentObservation<T>;
+}

--- a/apps/website/src/utils/math.ts
+++ b/apps/website/src/utils/math.ts
@@ -14,3 +14,8 @@ export function transposeMatrix<T = unknown>(matrix: T[][]) {
 
   return transposed;
 }
+
+export function rounded(value: number, precision = 0) {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}


### PR DESCRIPTION
## Describe your changes

Adds an endpoint to proxy the Weather API, for use in the Twitch chat bot, and in the soon-to-be-created stream overlay built within this repo.

My only concern here is caching, perhaps we'll want to store this in the DB temporarily, or have a memcached-esque service?

## Notes for testing your change

API endpoint works and has a sensible structure with correct unit conversions.
