### PR TITLE
Fix text stroke on overlay

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -85,7 +85,6 @@
   },
   "devDependencies": {
     "@designbycode/tailwindcss-text-shadow": "^2.0.0",
-    "@designbycode/tailwindcss-text-stroke": "^1.2.1",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.1.2",
     "@types/country-list": "^2.1.4",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -84,7 +84,6 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@designbycode/tailwindcss-text-shadow": "^2.0.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.1.2",
     "@types/country-list": "^2.1.4",

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -16,7 +16,7 @@ import logoImage from "@/assets/logo.png";
 import { type WeatherResponse } from "../api/stream/weather";
 
 const overlayText =
-  "paint-order-sfm text-shadow text-white text-stroke-1 text-shadow-x-0 text-shadow-y-0 text-shadow-black";
+  "text-shadow text-white text-shadow-x-0 text-shadow-y-0 text-shadow-black";
 
 const OverlayPage: NextPage = () => {
   // Get the current time and date
@@ -129,10 +129,10 @@ const OverlayPage: NextPage = () => {
           "absolute right-2 top-2 flex flex-col gap-1 text-right font-medium tabular-nums tracking-widest",
         )}
       >
-        <p className="text-4xl text-stroke-3">{time.time}</p>
-        <p className="text-4xl text-stroke-3">{time.date}</p>
+        <p className="text-4xl">{time.time}</p>
+        <p className="text-4xl">{time.date}</p>
         {weather && (
-          <p className="text-3xl text-stroke-3">
+          <p className="text-3xl">
             {weather.temperature.fahrenheit} °F{" "}
             <span className="text-xl">({weather.temperature.celsius} °C)</span>
           </p>
@@ -156,12 +156,12 @@ const OverlayPage: NextPage = () => {
             )}
           >
             <p>Upcoming:</p>
-            <p className="text-xl text-stroke-2">
+            <p className="text-xl">
               {event.title}
               {" @ "}
               {event.link.toLowerCase().replace(/^(https?:)?\/\/(www\.)?/, "")}
             </p>
-            <p className="text-xl text-stroke-2">
+            <p className="text-xl">
               {formatDateTime(
                 event.startAt,
                 {

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -16,7 +16,7 @@ import logoImage from "@/assets/logo.png";
 import { type WeatherResponse } from "../api/stream/weather";
 
 const overlayText =
-  "text-shadow text-white text-shadow-x-0 text-shadow-y-0 text-shadow-black";
+  "text-shadow text-white text-shadow-x-0 text-shadow-y-0 text-shadow-black text-shadow-blur-3";
 
 const OverlayPage: NextPage = () => {
   // Get the current time and date
@@ -126,7 +126,7 @@ const OverlayPage: NextPage = () => {
       <div
         className={classes(
           overlayText,
-          "absolute right-2 top-2 flex flex-col gap-1 text-right font-medium tabular-nums tracking-widest",
+          "absolute right-2 top-2 flex flex-col gap-1 text-right font-medium tabular-nums tracking-widest text-shadow-blur-4",
         )}
       >
         <p className="text-4xl">{time.time}</p>

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -9,7 +9,6 @@ import {
   formatDateTime,
   formatDateTimeParts,
 } from "@/utils/datetime";
-import { classes } from "@/utils/classes";
 
 import logoImage from "@/assets/logo.png";
 

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -190,7 +190,7 @@ const OverlayPage: NextPage = () => {
             src={logoImage}
             alt=""
             height={64}
-            className="h-16 w-auto opacity-50 brightness-125 contrast-200 drop-shadow grayscale saturate-200"
+            className="h-16 w-auto opacity-75 brightness-150 contrast-125 drop-shadow grayscale"
           />
 
           <div className={classes(overlayText, "text-xl font-bold")}>

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -79,18 +79,18 @@ const OverlayPage: NextPage = () => {
     return () => clearInterval(weatherInterval.current);
   }, []);
 
-  // Get the events for the next day
+  // Get the events for the next three days
   // Refresh every 60s
-  const [nextDay, setNextDay] = useState<[Date, Date]>();
+  const [upcomingRange, setUpcomingRange] = useState<[Date, Date]>();
   useEffect(() => {
     const now = new Date();
     const next = new Date(now);
-    next.setDate(next.getDate() + 1);
-    setNextDay([now, next]);
+    next.setDate(next.getDate() + 3);
+    setUpcomingRange([now, next]);
   }, []);
   const events = trpc.calendarEvents.getCalendarEvents.useQuery(
-    { start: nextDay?.[0], end: nextDay?.[1] },
-    { enabled: nextDay !== undefined, refetchInterval: 60 * 1000 },
+    { start: upcomingRange?.[0], end: upcomingRange?.[1] },
+    { enabled: upcomingRange !== undefined, refetchInterval: 60 * 1000 },
   );
   const firstEventId = events.data?.[0]?.id;
 

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -15,9 +15,6 @@ import logoImage from "@/assets/logo.png";
 
 import { type WeatherResponse } from "../api/stream/weather";
 
-const overlayText =
-  "text-shadow text-white text-shadow-x-0 text-shadow-y-0 text-shadow-black text-shadow-blur-3";
-
 const OverlayPage: NextPage = () => {
   // Get the current time and date
   // Refresh every 250ms
@@ -123,12 +120,7 @@ const OverlayPage: NextPage = () => {
 
   return (
     <div className="h-screen w-full">
-      <div
-        className={classes(
-          overlayText,
-          "absolute right-2 top-2 flex flex-col gap-1 text-right font-mono font-medium text-shadow-blur-4",
-        )}
-      >
+      <div className="absolute right-2 top-2 flex flex-col gap-1 text-right font-mono font-medium text-white text-stroke-2">
         <p className="text-4xl">{time.time}</p>
         <p className="text-4xl">{time.date}</p>
         {weather && (
@@ -149,12 +141,7 @@ const OverlayPage: NextPage = () => {
         leaveTo="opacity-0"
       >
         {event && (
-          <div
-            className={classes(
-              overlayText,
-              "absolute bottom-2 left-2 font-bold",
-            )}
-          >
+          <div className="text-stroke absolute bottom-2 left-2 font-bold text-white">
             <p>Upcoming:</p>
             <p className="text-xl">
               {event.title}
@@ -193,7 +180,7 @@ const OverlayPage: NextPage = () => {
             className="h-16 w-auto opacity-75 brightness-150 contrast-125 drop-shadow grayscale"
           />
 
-          <div className={classes(overlayText, "text-xl font-bold")}>
+          <div className="text-stroke text-xl font-bold text-white">
             <p>alveussanctuary.org</p>
             <p>@alveussanctuary</p>
           </div>

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -126,7 +126,7 @@ const OverlayPage: NextPage = () => {
       <div
         className={classes(
           overlayText,
-          "absolute right-2 top-2 flex flex-col gap-1 text-right font-medium tabular-nums tracking-widest text-shadow-blur-4",
+          "absolute right-2 top-2 flex flex-col gap-1 text-right font-mono font-medium text-shadow-blur-4",
         )}
       >
         <p className="text-4xl">{time.time}</p>

--- a/apps/website/src/styles/globals.css
+++ b/apps/website/src/styles/globals.css
@@ -24,30 +24,6 @@
     height: 0;
     display: none;
   }
-
-  .paint-order-fsm {
-    paint-order: fill stroke markers;
-  }
-
-  .paint-order-fms {
-    paint-order: fill markers stroke;
-  }
-
-  .paint-order-sfm {
-    paint-order: stroke fill markers;
-  }
-
-  .paint-order-smf {
-    paint-order: stroke markers fill;
-  }
-
-  .paint-order-msf {
-    paint-order: markers stroke fill;
-  }
-
-  .paint-order-mfs {
-    paint-order: markers fill stroke;
-  }
 }
 
 @layer components {

--- a/apps/website/src/types/designbycode.d.ts
+++ b/apps/website/src/types/designbycode.d.ts
@@ -1,5 +1,0 @@
-declare module "@designbycode/tailwindcss-text-shadow" {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  const plugin: ReturnType<typeof import("tailwindcss/plugin")>;
-  export default plugin;
-}

--- a/apps/website/src/types/designbycode.d.ts
+++ b/apps/website/src/types/designbycode.d.ts
@@ -1,9 +1,3 @@
-declare module "@designbycode/tailwindcss-text-stroke" {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  const plugin: ReturnType<typeof import("tailwindcss/plugin")>;
-  export default plugin;
-}
-
 declare module "@designbycode/tailwindcss-text-shadow" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const plugin: ReturnType<typeof import("tailwindcss/plugin")>;

--- a/apps/website/src/types/tailwindcss.d.ts
+++ b/apps/website/src/types/tailwindcss.d.ts
@@ -1,0 +1,6 @@
+declare module "tailwindcss/lib/util/flattenColorPalette" {
+  const flattenColorPalette: (
+    obj: Record<string, Record<string, string | Record<string, string>>>,
+  ) => Record<string, string>;
+  export default flattenColorPalette;
+}

--- a/apps/website/tailwind.config.ts
+++ b/apps/website/tailwind.config.ts
@@ -1,5 +1,6 @@
 import { type Config } from "tailwindcss";
 import { fontFamily } from "tailwindcss/defaultTheme";
+import flattenColorPalette from "tailwindcss/lib/util/flattenColorPalette";
 import colors from "tailwindcss/colors";
 import plugin from "tailwindcss/plugin";
 import textShadow from "@designbycode/tailwindcss-text-shadow";
@@ -173,6 +174,63 @@ const config = {
         },
       );
     }),
+    plugin(
+      ({ addBase, addComponents, matchUtilities, theme }) => {
+        const generateShadows = (steps: number = 1) => {
+          const classes: string[] = [];
+          for (let step = 1; step <= steps; step++) {
+            classes.push(
+              `0px -${step}px 0px var(--ts-text-stroke-color)`, // top
+              `${step}px -${step}px 0px var(--ts-text-stroke-color)`, // top right
+              `${step}px 0px 0px var(--ts-text-stroke-color)`, // right
+              `${step}px ${step}px 0px var(--ts-text-stroke-color)`, // bottom right
+              `0px ${step}px 0px var(--ts-text-stroke-color)`, // bottom
+              `-${step}px ${step}px 0px var(--ts-text-stroke-color)`, // bottom left
+              `-${step}px 0px 0px var(--ts-text-stroke-color)`, // left
+              `-${step}px -${step}px 0px var(--ts-text-stroke-color)`, // top left
+            );
+          }
+          return classes.toString();
+        };
+
+        addBase({
+          ":root": {
+            "--ts-text-stroke-color": "rgb(0, 0, 0)",
+          },
+        });
+
+        addComponents({
+          ".text-stroke": {
+            textShadow: generateShadows(),
+          },
+        });
+
+        matchUtilities(
+          {
+            "text-stroke": (value) => ({
+              "--ts-text-stroke-color": value,
+            }),
+          },
+          {
+            values: flattenColorPalette(theme("colors")),
+            type: "color",
+          },
+        );
+
+        matchUtilities(
+          {
+            "text-stroke": (value) => ({
+              textShadow: generateShadows(value),
+            }),
+          },
+          {
+            values: theme("textShadow"),
+            type: "number",
+          },
+        );
+      },
+      { theme: { textShadow: { 1: 1, 2: 2, 3: 3, 4: 4 } } },
+    ),
     textShadow,
   ],
 } satisfies Config;

--- a/apps/website/tailwind.config.ts
+++ b/apps/website/tailwind.config.ts
@@ -223,12 +223,12 @@ const config = {
             }),
           },
           {
-            values: theme("textShadow"),
+            values: theme("textStroke"),
             type: "number",
           },
         );
       },
-      { theme: { textShadow: { 1: 1, 2: 2, 3: 3, 4: 4 } } },
+      { theme: { textStroke: { 1: 1, 2: 2, 3: 3, 4: 4 } } },
     ),
   ],
 } satisfies Config;

--- a/apps/website/tailwind.config.ts
+++ b/apps/website/tailwind.config.ts
@@ -2,7 +2,6 @@ import { type Config } from "tailwindcss";
 import { fontFamily } from "tailwindcss/defaultTheme";
 import colors from "tailwindcss/colors";
 import plugin from "tailwindcss/plugin";
-import textStroke from "@designbycode/tailwindcss-text-stroke";
 import textShadow from "@designbycode/tailwindcss-text-shadow";
 
 const config = {
@@ -174,7 +173,6 @@ const config = {
         },
       );
     }),
-    textStroke,
     textShadow,
   ],
 } satisfies Config;

--- a/apps/website/tailwind.config.ts
+++ b/apps/website/tailwind.config.ts
@@ -3,7 +3,6 @@ import { fontFamily } from "tailwindcss/defaultTheme";
 import flattenColorPalette from "tailwindcss/lib/util/flattenColorPalette";
 import colors from "tailwindcss/colors";
 import plugin from "tailwindcss/plugin";
-import textShadow from "@designbycode/tailwindcss-text-shadow";
 
 const config = {
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
@@ -231,7 +230,6 @@ const config = {
       },
       { theme: { textShadow: { 1: 1, 2: 2, 3: 3, 4: 4 } } },
     ),
-    textShadow,
   ],
 } satisfies Config;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,9 +240,6 @@ importers:
         specifier: ^3.22.4
         version: 3.22.4
     devDependencies:
-      '@designbycode/tailwindcss-text-shadow':
-        specifier: ^2.0.0
-        version: 2.0.0(tailwindcss@3.4.1)
       '@ffmpeg-installer/ffmpeg':
         specifier: ^1.1.0
         version: 1.1.0
@@ -1140,14 +1137,6 @@ packages:
     dependencies:
       tslib: 2.6.2
     dev: false
-
-  /@designbycode/tailwindcss-text-shadow@2.0.0(tailwindcss@3.4.1):
-    resolution: {integrity: sha512-Dm2NZYXMjeyd0NeptuuG5SejLsTNY4YKovmUMSrqkAzn1eehqxfAvS9UsDgHTuOeT/rklXd/Rwg3axB+AyGV6g==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || >=3.0.0-alpha.1'
-    dependencies:
-      tailwindcss: 3.4.1
-    dev: true
 
   /@emnapi/runtime@0.45.0:
     resolution: {integrity: sha512-Txumi3td7J4A/xTTwlssKieHKTGl3j4A1tglBx72auZ49YK7ePY6XZricgIg9mnZT4xPfA+UPCUdnhRuEFDL+w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,9 +243,6 @@ importers:
       '@designbycode/tailwindcss-text-shadow':
         specifier: ^2.0.0
         version: 2.0.0(tailwindcss@3.4.1)
-      '@designbycode/tailwindcss-text-stroke':
-        specifier: ^1.2.1
-        version: 1.2.1(tailwindcss@3.4.1)
       '@ffmpeg-installer/ffmpeg':
         specifier: ^1.1.0
         version: 1.1.0
@@ -1146,14 +1143,6 @@ packages:
 
   /@designbycode/tailwindcss-text-shadow@2.0.0(tailwindcss@3.4.1):
     resolution: {integrity: sha512-Dm2NZYXMjeyd0NeptuuG5SejLsTNY4YKovmUMSrqkAzn1eehqxfAvS9UsDgHTuOeT/rklXd/Rwg3axB+AyGV6g==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || >=3.0.0-alpha.1'
-    dependencies:
-      tailwindcss: 3.4.1
-    dev: true
-
-  /@designbycode/tailwindcss-text-stroke@1.2.1(tailwindcss@3.4.1):
-    resolution: {integrity: sha512-6SqiFuMjJaWWv5Mm+RIu8Ui3Kc/8AK3m0qSocPOFhk4yS6aMVioy8QLghAj5KOR/8lsfZe3r7I1uJ7YM1FimUA==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || >=3.0.0-alpha.1'
     dependencies:


### PR DESCRIPTION
## Describe your changes

The version of Chromium used in OBS does not support paint-order, so the native text stroke was rendering on top of the text fill, resulting in black text.

We tried just using a shadow behind the text w/o stroke, but this was not readable enough.

Instead, I've added a custom plugin (based on the text-shadow/stroke plugins) that replicates a stroke effect using good ol' text-shadow, which seems to work well when tested on the stream.

Also, increase the date range for upcoming events, to cover weekends.

## Notes for testing your change

Looks good?
