### PR TITLE
Fix overlay upcoming event refreshing + relative formatting

### DIFF
--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -2,53 +2,17 @@ import { type NextPage } from "next";
 import Image from "next/image";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Transition } from "@headlessui/react";
-import { DateTime } from "luxon";
 
 import { trpc } from "@/utils/trpc";
 import {
   DATETIME_ALVEUS_ZONE,
-  type DateTimeFormat,
-  type DateTimeOptions,
   formatDateTimeParts,
+  formatDateTimeRelative,
 } from "@/utils/datetime";
 
 import logoImage from "@/assets/logo.png";
 
 import { type WeatherResponse } from "../api/stream/weather";
-
-const formatDateTimeRelative = (
-  date: Date,
-  format: Partial<DateTimeFormat> = {},
-  options: Partial<DateTimeOptions> = {},
-) => {
-  // Format the date
-  const parts = formatDateTimeParts(date, format, options);
-
-  // Determine how many days away the date is
-  const dateToday = DateTime.now().setZone(options.zone ?? "UTC");
-  const dateGiven = DateTime.fromJSDate(date).setZone(options.zone ?? "UTC");
-  const daysToday = dateToday.startOf("day").toUnixInteger() / (60 * 60 * 24);
-  const daysGiven = dateGiven.startOf("day").toUnixInteger() / (60 * 60 * 24);
-
-  // If they are the same, or the given is one day away, show relative
-  const days = daysGiven - daysToday;
-  if (days === 0 || days === 1) {
-    // Get the year -> day parts
-    const yearIdx = parts.findIndex((part) => part.type === "year");
-    const monthIdx = parts.findIndex((part) => part.type === "month");
-    const dayIdx = parts.findIndex((part) => part.type === "day");
-    const minIdx = Math.min(yearIdx, monthIdx, dayIdx);
-    const maxIdx = Math.max(yearIdx, monthIdx, dayIdx);
-
-    // Replace the year -> day parts with the relative date
-    parts.splice(minIdx, maxIdx - minIdx + 1, {
-      type: "literal",
-      value: days === 0 ? "Today" : "Tomorrow",
-    });
-  }
-
-  return parts.map((part) => part.value).join("");
-};
 
 const OverlayPage: NextPage = () => {
   // Get the current time and date

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -138,8 +138,8 @@ const OverlayPage: NextPage = () => {
         <p className="text-4xl">{time.date}</p>
         {weather && (
           <p className="text-3xl">
-            {weather.temperature.fahrenheit} °F{" "}
-            <span className="text-xl">({weather.temperature.celsius} °C)</span>
+            {weather.temperature.fahrenheit}°F{" "}
+            <span className="text-xl">({weather.temperature.celsius}°C)</span>
           </p>
         )}
       </div>

--- a/apps/website/src/utils/datetime.ts
+++ b/apps/website/src/utils/datetime.ts
@@ -90,8 +90,12 @@ export const formatDateTimeRelative = (
   // Determine how many days away the date is
   const dateToday = DateTime.now().setZone(zone ?? undefined);
   const dateGiven = DateTime.fromJSDate(dateTime).setZone(zone ?? undefined);
-  const daysToday = dateToday.startOf("day").toUnixInteger() / (60 * 60 * 24);
-  const daysGiven = dateGiven.startOf("day").toUnixInteger() / (60 * 60 * 24);
+  const daysToday = Math.floor(
+    dateToday.startOf("day").toUnixInteger() / (60 * 60 * 24),
+  );
+  const daysGiven = Math.floor(
+    dateGiven.startOf("day").toUnixInteger() / (60 * 60 * 24),
+  );
 
   // If they are the same, or the given is one day away, show relative
   const days = daysGiven - daysToday;


### PR DESCRIPTION
## Describe your changes

While the old code was fetching events every 60s, the time range it was using was fixed 🤦 The logic has now been updated so that the time range is refreshed every 60s, which then triggers events to be prefetched.

Additionally, added some relative date formatting for the events, so we'll show "Today"/"Tomorrow" instead of a date (falling back to a date for anything else).

## Notes for testing your change

Events are fetched every 60s, with events previously shown that are in the past no longer being shown.