### PR TITLE
Hide weather in overlay if 15m stale

### DIFF
--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -78,6 +78,16 @@ const OverlayPage: NextPage = () => {
     return () => clearInterval(weatherInterval.current);
   }, []);
 
+  // Remove the weather data if older than 15m
+  const weatherStaleTimer = useRef<NodeJS.Timeout>();
+  useEffect(() => {
+    if (!weather) return;
+
+    const updateWeather = () => setWeather(undefined);
+    weatherStaleTimer.current = setTimeout(updateWeather, 15 * 60 * 1000);
+    return () => clearTimeout(weatherStaleTimer.current);
+  }, [weather]);
+
   // Set the range for upcoming events to the next 3 days
   // Refresh every 60s
   const [upcomingRange, setUpcomingRange] = useState<[Date, Date]>();


### PR DESCRIPTION
## Describe your changes

While we persist the weather in the overlay for when the station has a blip, it can sometimes go offline for prolonged periods of time, leading to inaccurate weather info displaying on the stream. This adds a bit of logic to the overlay to remove the previous weather data after 15 minutes of it being stale.

## Notes for testing your change

Change timeout to 30s, observe weather shows for 30s, then is hidden for 30s, and then reappears when new weather data is fetched.
