### PR TITLE
Only allow stale weather to be served for 5 minutes

### DIFF
--- a/apps/website/src/pages/api/stream/weather.ts
+++ b/apps/website/src/pages/api/stream/weather.ts
@@ -81,7 +81,7 @@ export default async function handler(
 
       res.setHeader(
         "Cache-Control",
-        "max-age=60, s-maxage=300, stale-while-revalidate",
+        "max-age=60, s-maxage=60, stale-while-revalidate=300",
       );
       return res.json({
         time: {

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -78,13 +78,13 @@ const OverlayPage: NextPage = () => {
     return () => clearInterval(weatherInterval.current);
   }, []);
 
-  // Remove the weather data if older than 15m
+  // Remove the weather data if older than 10m
   const weatherStaleTimer = useRef<NodeJS.Timeout>();
   useEffect(() => {
     if (!weather) return;
 
     const updateWeather = () => setWeather(undefined);
-    weatherStaleTimer.current = setTimeout(updateWeather, 15 * 60 * 1000);
+    weatherStaleTimer.current = setTimeout(updateWeather, 10 * 60 * 1000);
     return () => clearTimeout(weatherStaleTimer.current);
   }, [weather]);
 


### PR DESCRIPTION
## Describe your changes

Resolves #722 -- hopefully this should stop Vercel indefinitely serving cached stale weather data when the weather station is offline.

## Notes for testing your change

N/A
