### PR TITLE
Intelligently truncate event title on stream overlay

### DIFF
--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -14,6 +14,17 @@ import logoImage from "@/assets/logo.png";
 
 import { type WeatherResponse } from "../api/stream/weather";
 
+const truncate = (value: string, max: number) => {
+  if (value.length <= max) return value;
+
+  for (const pattern of [" - ", " | ", ": "]) {
+    const index = value.indexOf(pattern);
+    if (index !== -1 && index < max) return value.slice(0, index);
+  }
+
+  return value.slice(0, max - 3) + "...";
+};
+
 const OverlayPage: NextPage = () => {
   // Get the current time and date
   // Refresh every 250ms
@@ -174,7 +185,7 @@ const OverlayPage: NextPage = () => {
           <div className="text-stroke absolute bottom-2 left-2 font-bold text-white">
             <p>Upcoming:</p>
             <p className="text-xl">
-              {event.title}
+              {truncate(event.title, 30)}
               {" @ "}
               {event.link.toLowerCase().replace(/^(https?:)?\/\/(www\.)?/, "")}
             </p>

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -22,7 +22,7 @@ const truncate = (value: string, max: number) => {
     if (index !== -1 && index < max) return value.slice(0, index);
   }
 
-  return value.slice(0, max - 3) + "...";
+  return value.slice(0, max - 3) + "…";
 };
 
 const OverlayPage: NextPage = () => {


### PR DESCRIPTION
## Describe your changes

If an event has a rather long title, such as `Connor Stream - Lowe's trip, finishing wolf enclosure and building catapults!`, it looks visually messy on the overlay as it will intersect multiple cams on the stream.

<img width="1414" alt="image" src="https://github.com/alveusgg/alveusgg/assets/12371363/20bff238-3543-44c6-b309-c8c32833854d">

To solve for this, truncate the string to a maximum of 30 chars, but attempt to intelligently split the title on `-`, `|`, or `:` before resorting to chopping the string with an ellipsis.

## Notes for testing your change

Events with titles under 30 chars are rendered as is.

Events with titles over 30 chars with no `-`/`|`/`:` are truncated with ellipsis.

Events with titles over 30 chars containing `-`/`|`/`:`, with the first section being under 30 chars, are truncated to show just the first section.

Events with titles over 30 chars containing `-`/`|`/`:`, with the first section being over 30 chars, are truncated to show just the first section which is also truncated with ellipsis.
