### PR TITLE
Show & Tell: Add posts remaining counter

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -70,11 +70,6 @@ const config = {
         protocol: "https",
         hostname: "alveus.nyc3.cdn.digitaloceanspaces.com",
       },
-      // Local Dev
-      {
-        protocol: "http",
-        hostname: "localhost",
-      },
     ],
   },
   redirects: async () => [

--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -70,6 +70,11 @@ const config = {
         protocol: "https",
         hostname: "alveus.nyc3.cdn.digitaloceanspaces.com",
       },
+      // Local Dev
+      {
+        protocol: "http",
+        hostname: "localhost",
+      },
     ],
   },
   redirects: async () => [

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -1,50 +1,50 @@
-import type { InferGetStaticPropsType, NextPage } from "next";
-import Image from "next/image";
 import {
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
-  type KeyboardEventHandler,
   type WheelEvent,
+  type KeyboardEventHandler,
 } from "react";
+import type { InferGetStaticPropsType, NextPage } from "next";
+import Image from "next/image";
 import scrollIntoView from "smooth-scroll-into-view-if-needed";
 
+import { delay } from "@/utils/delay";
+import { trpc } from "@/utils/trpc";
 import {
   getPosts,
   getPostsCount,
   getPostsToShow,
   getUsersCount,
 } from "@/server/db/show-and-tell";
-import { delay } from "@/utils/delay";
-import { trpc } from "@/utils/trpc";
 
 import useOnToggleNativeFullscreen from "@/hooks/fullscreen";
 import useIntersectionObserver from "@/hooks/intersection";
 import useLocaleString from "@/hooks/locale";
 
+import IconLoading from "@/icons/IconLoading";
+import IconArrowUp from "@/icons/IconArrowUp";
 import IconArrowDown from "@/icons/IconArrowDown";
 import IconArrowsIn from "@/icons/IconArrowsIn";
 import IconArrowsOut from "@/icons/IconArrowsOut";
-import IconArrowUp from "@/icons/IconArrowUp";
-import IconLoading from "@/icons/IconLoading";
 import IconPencil from "@/icons/IconPencil";
 
-import Heading from "@/components/content/Heading";
-import Link from "@/components/content/Link";
 import Meta from "@/components/content/Meta";
 import Section from "@/components/content/Section";
+import Heading from "@/components/content/Heading";
+import Link from "@/components/content/Link";
 
 import { Button, LinkButton } from "@/components/shared/form/Button";
 
-import { GiveAnHourProgress } from "@/components/show-and-tell/GiveAnHourProgress";
-import { QrCode } from "@/components/show-and-tell/QrCode";
 import { ShowAndTellEntry } from "@/components/show-and-tell/ShowAndTellEntry";
+import { QrCode } from "@/components/show-and-tell/QrCode";
+import { GiveAnHourProgress } from "@/components/show-and-tell/GiveAnHourProgress";
 
 import alveusLogo from "@/assets/logo.png";
-import showAndTellHeader from "@/assets/show-and-tell/header.png";
 import showAndTellPeepo from "@/assets/show-and-tell/peepo.png";
+import showAndTellHeader from "@/assets/show-and-tell/header.png";
 
 export type ShowAndTellPageProps = InferGetStaticPropsType<
   typeof getStaticProps

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -109,6 +109,8 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
   const [isPresentationView, setIsPresentationView] = useState(false);
   const presentationViewRootElementRef = useRef<HTMLDivElement | null>(null);
 
+  const [currentPostIndex, setCurrentPostIndex] = useState(0);
+
   // We use this ref to scroll to the entry when transitioning between presentation view and normal view
   // and when the next/prev buttons are clicked
   const currentEntryElementRef = useRef<HTMLElement | null>(null);
@@ -134,6 +136,9 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
     // Update the next/prev buttons
     setHasPrevEntry(currentPos > 0);
     setHasNextEntry(currentPos < entryElements.length - 1);
+
+    // Set the current post index
+    setCurrentPostIndex(currentPos + 1); // Add 1 to make it 1-based index
 
     // Only autoload if we're in presentation view, and if there's a next page
     if (!isPresentationView || !entries.hasNextPage) return;
@@ -497,7 +502,13 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
           )}
 
           <div className="sticky bottom-[20px] right-[20px] z-20 ml-auto flex w-fit flex-col gap-2">
-            {isPresentationView ? <p>X / {postsToShowCount}</p> : null}
+            {isPresentationView ? (
+              <p className="text-xl text-alveus-green">
+                {postsToShowCount - currentPostIndex <= 0
+                  ? "Caught up!"
+                  : `${postsToShowCount - currentPostIndex} / ${postsToShowCount} remaining`}
+              </p>
+            ) : null}
             <div className="flex flex-row gap-2">
               <Button
                 className="bg-white shadow-lg"

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -502,7 +502,7 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
           )}
 
           <div className="sticky bottom-[20px] right-[20px] z-20 ml-auto flex w-fit flex-col gap-2">
-            {isPresentationView ?? (
+            {isPresentationView && (
               <p className="text-xl text-alveus-green">
                 {postsToShowCount - currentPostIndex <= 0
                   ? "Caught up!"

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -1,49 +1,49 @@
+import type { InferGetStaticPropsType, NextPage } from "next";
+import Image from "next/image";
 import {
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
-  type WheelEvent,
   type KeyboardEventHandler,
+  type WheelEvent,
 } from "react";
-import type { InferGetStaticPropsType, NextPage } from "next";
-import Image from "next/image";
 import scrollIntoView from "smooth-scroll-into-view-if-needed";
 
-import { delay } from "@/utils/delay";
-import { trpc } from "@/utils/trpc";
 import {
   getPosts,
   getPostsCount,
   getUsersCount,
 } from "@/server/db/show-and-tell";
+import { delay } from "@/utils/delay";
+import { trpc } from "@/utils/trpc";
 
 import useOnToggleNativeFullscreen from "@/hooks/fullscreen";
 import useIntersectionObserver from "@/hooks/intersection";
 import useLocaleString from "@/hooks/locale";
 
-import IconLoading from "@/icons/IconLoading";
-import IconArrowUp from "@/icons/IconArrowUp";
 import IconArrowDown from "@/icons/IconArrowDown";
 import IconArrowsIn from "@/icons/IconArrowsIn";
 import IconArrowsOut from "@/icons/IconArrowsOut";
+import IconArrowUp from "@/icons/IconArrowUp";
+import IconLoading from "@/icons/IconLoading";
 import IconPencil from "@/icons/IconPencil";
 
-import Meta from "@/components/content/Meta";
-import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";
 import Link from "@/components/content/Link";
+import Meta from "@/components/content/Meta";
+import Section from "@/components/content/Section";
 
 import { Button, LinkButton } from "@/components/shared/form/Button";
 
-import { ShowAndTellEntry } from "@/components/show-and-tell/ShowAndTellEntry";
-import { QrCode } from "@/components/show-and-tell/QrCode";
 import { GiveAnHourProgress } from "@/components/show-and-tell/GiveAnHourProgress";
+import { QrCode } from "@/components/show-and-tell/QrCode";
+import { ShowAndTellEntry } from "@/components/show-and-tell/ShowAndTellEntry";
 
 import alveusLogo from "@/assets/logo.png";
-import showAndTellPeepo from "@/assets/show-and-tell/peepo.png";
 import showAndTellHeader from "@/assets/show-and-tell/header.png";
+import showAndTellPeepo from "@/assets/show-and-tell/peepo.png";
 
 export type ShowAndTellPageProps = InferGetStaticPropsType<
   typeof getStaticProps
@@ -483,9 +483,9 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
                   />
                 </div>
                 <p className="text-sm lg:text-base xl:text-lg">
-                  Has stream helped you become more environmental conscious?
+                  Has stream helped you become more environmentally conscious?
                   Please share with the community any of your conservation or
-                  wildlife related activities.
+                  wildlife-related activities.
                 </p>
                 <QrCode className="h-auto max-h-[20vh] w-full max-w-[12vw]" />
               </div>

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -14,6 +14,7 @@ import scrollIntoView from "smooth-scroll-into-view-if-needed";
 import {
   getPosts,
   getPostsCount,
+  getPostsToShow,
   getUsersCount,
 } from "@/server/db/show-and-tell";
 import { delay } from "@/utils/delay";
@@ -63,12 +64,14 @@ export const getStaticProps = async () => {
   }
   const totalPostsCount = await getPostsCount();
   const usersCount = await getUsersCount();
+  const postsToShowCount = await getPostsToShow();
 
   return {
     props: {
       entries,
       nextCursor,
       totalPostsCount,
+      postsToShowCount,
       usersCount,
     },
   };
@@ -84,6 +87,7 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
   entries: initialEntries,
   nextCursor,
   totalPostsCount,
+  postsToShowCount,
   usersCount,
 }) => {
   const entries = trpc.showAndTell.getEntries.useInfiniteQuery(
@@ -493,6 +497,7 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
           )}
 
           <div className="sticky bottom-[20px] right-[20px] z-20 ml-auto flex w-fit flex-col gap-2">
+            {isPresentationView ? <p>X / {postsToShowCount}</p> : null}
             <div className="flex flex-row gap-2">
               <Button
                 className="bg-white shadow-lg"

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -502,13 +502,13 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
           )}
 
           <div className="sticky bottom-[20px] right-[20px] z-20 ml-auto flex w-fit flex-col gap-2">
-            {isPresentationView ? (
+            {isPresentationView ?? (
               <p className="text-xl text-alveus-green">
                 {postsToShowCount - currentPostIndex <= 0
                   ? "Caught up!"
                   : `${postsToShowCount - currentPostIndex} / ${postsToShowCount} remaining`}
               </p>
-            ) : null}
+            )}
             <div className="flex flex-row gap-2">
               <Button
                 className="bg-white shadow-lg"

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -490,18 +490,9 @@ export async function deletePost(id: string, authorUserId?: string) {
 }
 
 export async function getPostsToShow() {
-  // Find the latest entry marked as seenOnStream=true
-  const latestSeenEntry = await prisma.showAndTellEntry.findFirst({
-    where: {
-      seenOnStream: true,
-    },
-    orderBy: [...postOrderBy],
-  });
-
-  // Calculate the number of entries since the latest seen entry
   const postsToShow = await prisma.showAndTellEntry.count({
     where: {
-      seenOnStream: false, // Only consider entries that have not been seen on stream
+      AND: [whereApproved, { seenOnStream: false }],
     },
   });
 

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -1,5 +1,5 @@
-import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 
 import { env } from "@/env";
 
@@ -9,13 +9,13 @@ import {
   MAX_VIDEOS,
 } from "@/data/show-and-tell";
 
+import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 import { prisma } from "@/server/db/client";
 import { checkAndFixUploadedImageFileStorageObject } from "@/server/utils/file-storage";
-import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 
+import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 import { getEntityStatus } from "@/utils/entity-helpers";
 import { notEmpty } from "@/utils/helpers";
-import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 
 export const withAttachments = {
   include: {

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -502,9 +502,6 @@ export async function getPostsToShow() {
   const postsToShow = await prisma.showAndTellEntry.count({
     where: {
       seenOnStream: false, // Only consider entries that have not been seen on stream
-      approvedAt: {
-        gte: latestSeenEntry?.seenOnStreamAt ?? new Date(0), // If no entry is seen, count all approved entries from the beginning
-      },
     },
   });
 


### PR DESCRIPTION
## Describe your changes

Resolves #669 - adds a counter that shows the number of remaining posts when in presenter view.

![image](https://github.com/user-attachments/assets/035835ea-0757-4b87-b43c-a370f7b12edd)

Implemented as (number of posts AFTER this post) / (total posts to show).

Could be implemented as `Post X of Y (Z remaining)` -  let me know if this is preferable.

I figured showing the remaining count instead of X of Y as #669 suggests allows the actually desired information to be conveyed in an easier way

## Notes for testing your change

N/A

## Potential Concerns

Weird sorting stuff - admin edits can make this behave strangely (i.e. editing after approved date/after shown on stream/etc), because of the way the query filters are implemented. I would consider removing the 
```ts
approvedAt: {
  gte: latestSeenEntry?.seenOnStreamAt ?? new Date(0),
},
```
filter from `postsToShow` if all posts will reliably be marked as seen on stream. This should avoid that weird behavior.