### PR TITLE
Show & Tell: Add mod comments

### DIFF
--- a/apps/website/prisma/schema.prisma
+++ b/apps/website/prisma/schema.prisma
@@ -91,9 +91,9 @@ model Session {
 }
 
 model User {
-  id                 String             @id @default(cuid())
+  id                 String                  @id @default(cuid())
   name               String?
-  email              String?            @unique
+  email              String?                 @unique
   emailVerified      DateTime?
   image              String?
   accounts           Account[]
@@ -104,6 +104,7 @@ model User {
   bingoEntries       BingoEntry[]
   outgoingWebhooks   OutgoingWebhook[]
   showAndTellEntries ShowAndTellEntry[]
+  modComments        ShowAndTellModComment[]
   roles              UserRole[]
   virtualTickets     VirtualTicket[]
 
@@ -403,6 +404,7 @@ model ShowAndTellEntry {
   volunteeringMinutes Int?
 
   attachments ShowAndTellEntryAttachment[]
+  modComments ShowAndTellModComment[]
   user        User?                        @relation(fields: [userId], references: [id])
 
   @@index([userId], name: "ShowAndTellEntry_userId")
@@ -422,6 +424,22 @@ model ShowAndTellEntryAttachment {
   imageAttachment ImageAttachment? @relation(fields: [imageAttachmentId], references: [id], onDelete: Cascade)
 
   @@index([entryId], name: "ShowAndTellEntryAttachment_entryId")
+}
+
+model ShowAndTellModComment {
+  id         String   @id @default(cuid())
+  entryId    String
+  modId      String
+  comment    String
+  isInternal Boolean  @default(true)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  entry ShowAndTellEntry @relation(fields: [entryId], references: [id], onDelete: Cascade)
+  user  User?            @relation(fields: [modId], references: [id])
+
+  @@index([entryId], name: "ShowAndTellModComment_entryId")
+  @@index([modId], name: "ShowAndTellModComment_modId")
 }
 
 model FileStorageObject {

--- a/apps/website/src/components/shared/Tooltip.tsx
+++ b/apps/website/src/components/shared/Tooltip.tsx
@@ -1,0 +1,36 @@
+import { Transition } from "@headlessui/react";
+import type { ReactNode} from "react";
+import { Fragment, useState } from "react";
+
+export type TooltipProps = {
+  content: string;
+  children: ReactNode;
+};
+
+export function Tooltip({ content, children }: TooltipProps) {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  return (
+    <div
+      className="relative flex items-center"
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      {children}
+      <Transition
+        as={Fragment}
+        show={showTooltip}
+        enter="transition ease-out duration-200"
+        enterFrom="opacity-0 translate-y-1"
+        enterTo="opacity-100 translate-y-0"
+        leave="transition ease-in duration-150"
+        leaveFrom="opacity-100 translate-y-0"
+        leaveTo="opacity-0 translate-y-1"
+      >
+        <div className="absolute bottom-full mb-0 w-max rounded bg-alveus-green-900 p-2 text-xs text-alveus-tan shadow-lg">
+          {content}
+        </div>
+      </Transition>
+    </div>
+  );
+}

--- a/apps/website/src/components/shared/Tooltip.tsx
+++ b/apps/website/src/components/shared/Tooltip.tsx
@@ -1,5 +1,5 @@
 import { Transition } from "@headlessui/react";
-import type { ReactNode} from "react";
+import type { ReactNode } from "react";
 import { Fragment, useState } from "react";
 
 export type TooltipProps = {

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -32,6 +32,7 @@ import Link from "@/components/content/Link";
 import { ShowAndTellGallery } from "@/components/show-and-tell/gallery/ShowAndTellGallery";
 import { SeenOnStreamBadge } from "@/components/show-and-tell/SeenOnStreamBadge";
 
+import IconShield from "@/icons/IconShield";
 import IconWorld from "@/icons/IconWorld";
 import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
@@ -222,7 +223,10 @@ const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
               {content}
               {modComments &&
                 modComments.map((comment) => (
-                  <p key={comment.id}>[MOD] {comment.comment}</p>
+                  <p key={comment.id} className="italic text-alveus-green">
+                    {" "}
+                    <IconShield className="inline h-6 w-6" /> {comment.comment}
+                  </p>
                 ))}
             </ErrorBoundary>
           </div>

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -1,19 +1,3 @@
-import type {
-  FileStorageObject,
-  ImageAttachment,
-  ImageMetadata,
-  LinkAttachment,
-  ShowAndTellEntryAttachment,
-  ShowAndTellEntry as ShowAndTellEntryModel,
-} from "@prisma/client";
-import parse, {
-  domToReact,
-  Element,
-  Text,
-  type DOMNode,
-  type HTMLReactParserOptions,
-} from "html-react-parser";
-import Image from "next/image";
 import {
   forwardRef,
   Fragment,
@@ -22,22 +6,38 @@ import {
   useMemo,
   useRef,
 } from "react";
+import type {
+  FileStorageObject,
+  ImageAttachment,
+  ImageMetadata,
+  LinkAttachment,
+  ShowAndTellEntry as ShowAndTellEntryModel,
+  ShowAndTellEntryAttachment,
+} from "@prisma/client";
+import Image from "next/image";
+import parse, {
+  domToReact,
+  Element,
+  Text,
+  type DOMNode,
+  type HTMLReactParserOptions,
+} from "html-react-parser";
 import { ErrorBoundary } from "react-error-boundary";
 
-import { DATETIME_ALVEUS_ZONE, formatDateTime } from "@/utils/datetime";
-import { notEmpty } from "@/utils/helpers";
+import { trpc } from "@/utils/trpc";
+
 import { parseVideoUrl, videoPlatformConfigs } from "@/utils/video-urls";
+import { notEmpty } from "@/utils/helpers";
+import { DATETIME_ALVEUS_ZONE, formatDateTime } from "@/utils/datetime";
 
 import Link from "@/components/content/Link";
 import { ShowAndTellGallery } from "@/components/show-and-tell/gallery/ShowAndTellGallery";
 import { SeenOnStreamBadge } from "@/components/show-and-tell/SeenOnStreamBadge";
-
-import IconShield from "@/icons/IconShield";
-import IconWorld from "@/icons/IconWorld";
-import { classes } from "@/utils/classes";
-import { trpc } from "@/utils/trpc";
-
 import { Tooltip } from "@/components/shared/Tooltip";
+
+import IconWorld from "@/icons/IconWorld";
+import IconShield from "@/icons/IconShield";
+import { classes } from "@/utils/classes";
 
 export type ShowAndTellEntryWithAttachments = Pick<
   ShowAndTellEntryModel,

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -37,6 +37,8 @@ import IconWorld from "@/icons/IconWorld";
 import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
 
+import { Tooltip } from "@/components/shared/Tooltip";
+
 export type ShowAndTellEntryWithAttachments = Pick<
   ShowAndTellEntryModel,
   | "id"
@@ -223,10 +225,19 @@ const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
               {content}
               {modComments &&
                 modComments.map((comment) => (
-                  <p key={comment.id} className="italic text-alveus-green">
-                    {" "}
-                    <IconShield className="inline h-6 w-6" /> {comment.comment}
-                  </p>
+                  <Tooltip
+                    key={comment.id}
+                    content={`This is a verified mod comment, last updated ${formatDateTime(
+                      comment.updatedAt,
+                      { style: "short", time: "seconds" },
+                      { zone: DATETIME_ALVEUS_ZONE },
+                    )}`}
+                  >
+                    <p className="italic text-alveus-green">
+                      <IconShield className="inline h-6 w-6" />{" "}
+                      {comment.comment}
+                    </p>
+                  </Tooltip>
                 ))}
             </ErrorBoundary>
           </div>

--- a/apps/website/src/icons/IconEyeSlash.tsx
+++ b/apps/website/src/icons/IconEyeSlash.tsx
@@ -1,0 +1,18 @@
+import { BaseIcon, type IconProps } from "@/icons/BaseIcon";
+
+// This SVG code is derived from Heroicons (https://heroicons.com)
+// eye-slash-outline
+export default function IconEyeSlash(props: IconProps) {
+  return (
+    <BaseIcon viewBox="0 0 24 24" {...props}>
+      <path
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"
+      />
+    </BaseIcon>
+  );
+}

--- a/apps/website/src/icons/IconPaperAirplane.tsx
+++ b/apps/website/src/icons/IconPaperAirplane.tsx
@@ -1,0 +1,18 @@
+import { BaseIcon, type IconProps } from "@/icons/BaseIcon";
+
+// This SVG code is derived from Heroicons (https://heroicons.com)
+// paper-airplane-outline
+export default function IconPaperAirplane(props: IconProps) {
+  return (
+    <BaseIcon viewBox="0 0 24 24" {...props}>
+      <path
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5"
+      />
+    </BaseIcon>
+  );
+}

--- a/apps/website/src/icons/IconShield.tsx
+++ b/apps/website/src/icons/IconShield.tsx
@@ -1,0 +1,18 @@
+import { BaseIcon, type IconProps } from "@/icons/BaseIcon";
+
+// This SVG code is derived from Heroicons (https://heroicons.com)
+// shield-check-outline
+export default function IconShield(props: IconProps) {
+  return (
+    <BaseIcon viewBox="0 0 24 24" {...props}>
+      <path
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
+      />
+    </BaseIcon>
+  );
+}

--- a/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
+++ b/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
@@ -22,7 +22,10 @@ import {
 import { MessageBox } from "@/components/shared/MessageBox";
 import { ShowAndTellEntryForm } from "@/components/show-and-tell/ShowAndTellEntryForm";
 import IconCheckCircle from "@/icons/IconCheckCircle";
+import IconEye from "@/icons/IconEye";
+import IconEyeSlash from "@/icons/IconEyeSlash";
 import IconMinus from "@/icons/IconMinus";
+import IconPaperAirplane from "@/icons/IconPaperAirplane";
 import IconTrash from "@/icons/IconTrash";
 
 export async function getServerSideProps(context: NextPageContext) {
@@ -106,7 +109,7 @@ const AdminReviewShowAndTellPage: NextPage<
 
     addModCommentMutation.mutate({
       entryId: String(entryId),
-      modId, // Replace with actual mod ID
+      modId: String(modId),
       comment: newComment,
       isInternal: true,
     });
@@ -234,11 +237,20 @@ const AdminReviewShowAndTellPage: NextPage<
                         toggleCommentVisibility(comment.id, comment.isInternal)
                       }
                     >
-                      {comment.isInternal ? "Make public" : "Make private"}
+                      {comment.isInternal ? (
+                        <>
+                          <IconEye className="h-6 w-6" /> Make Public
+                        </>
+                      ) : (
+                        <>
+                          <IconEyeSlash className="h-6 w-6" /> Make Private
+                        </>
+                      )}
                     </Button>
                     <Button
                       size="small"
                       className={dangerButtonClasses}
+                      confirmationMessage="Please confirm deletion!"
                       onClick={() => deleteComment(comment.id)}
                     >
                       <IconTrash className="h-4 w-4" />
@@ -253,14 +265,17 @@ const AdminReviewShowAndTellPage: NextPage<
                   type="text"
                   name="comment"
                   placeholder="Add a comment..."
-                  className="flex-1 rounded-l border p-2"
+                  className="flex-1 rounded-l border p-2 text-black"
                   value={newComment}
                   onChange={(e) => setNewComment(e.target.value)}
                   required
                 />
-                <Button type="submit" className="rounded-r">
-                  Send
-                </Button>
+                <button
+                  type="submit"
+                  className="flex items-center justify-center rounded-r p-2 text-white"
+                >
+                  <IconPaperAirplane className="h-6 w-6" />
+                </button>
               </form>
             </Panel>
           </>

--- a/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
+++ b/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
@@ -1,32 +1,32 @@
-import type { InferGetStaticPropsType, NextPage, NextPageContext } from "next";
+import type { NextPage, NextPageContext, InferGetStaticPropsType } from "next";
+import { useState } from "react";
 import { getSession, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 
-import { useState } from "react";
-import { permissions } from "@/data/permissions";
-import { getAdminSSP } from "@/server/utils/admin";
-import { getEntityStatus } from "@/utils/entity-helpers";
 import { trpc } from "@/utils/trpc";
+import { getEntityStatus } from "@/utils/entity-helpers";
+import { getAdminSSP } from "@/server/utils/admin";
+import { permissions } from "@/data/permissions";
 
+import { MessageBox } from "@/components/shared/MessageBox";
+import { ShowAndTellEntryForm } from "@/components/show-and-tell/ShowAndTellEntryForm";
 import { AdminPageLayout } from "@/components/admin/AdminPageLayout";
 import { Headline } from "@/components/admin/Headline";
 import { Panel } from "@/components/admin/Panel";
-import DateTime from "@/components/content/DateTime";
-import Meta from "@/components/content/Meta";
 import {
   approveButtonClasses,
   Button,
   dangerButtonClasses,
   defaultButtonClasses,
 } from "@/components/shared/form/Button";
-import { MessageBox } from "@/components/shared/MessageBox";
-import { ShowAndTellEntryForm } from "@/components/show-and-tell/ShowAndTellEntryForm";
+import Meta from "@/components/content/Meta";
+import DateTime from "@/components/content/DateTime";
+import IconTrash from "@/icons/IconTrash";
+import IconMinus from "@/icons/IconMinus";
 import IconCheckCircle from "@/icons/IconCheckCircle";
 import IconEye from "@/icons/IconEye";
 import IconEyeSlash from "@/icons/IconEyeSlash";
-import IconMinus from "@/icons/IconMinus";
 import IconPaperAirplane from "@/icons/IconPaperAirplane";
-import IconTrash from "@/icons/IconTrash";
 
 export async function getServerSideProps(context: NextPageContext) {
   const session = await getSession(context);

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
 import { TRPCError } from "@trpc/server";
+import { z } from "zod";
 
 import { env } from "@/env";
 
@@ -9,13 +9,13 @@ import {
   MAX_VIDEOS,
 } from "@/data/show-and-tell";
 
-import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 import { prisma } from "@/server/db/client";
 import { checkAndFixUploadedImageFileStorageObject } from "@/server/utils/file-storage";
+import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 
-import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 import { getEntityStatus } from "@/utils/entity-helpers";
 import { notEmpty } from "@/utils/helpers";
+import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 
 export const withAttachments = {
   include: {
@@ -220,6 +220,11 @@ export async function getPostById(
     include: {
       ...withAttachments.include,
       user: true,
+      modComments: {
+        include: {
+          user: true,
+        },
+      },
     },
     where: {
       approvedAt:
@@ -487,4 +492,66 @@ export async function deletePost(id: string, authorUserId?: string) {
     }),
   ]);
   await revalidateCache(id);
+}
+
+export async function getPostsToShow() {
+  // Find the latest entry marked as seenOnStream=true
+  const latestSeenEntry = await prisma.showAndTellEntry.findFirst({
+    where: {
+      seenOnStream: true,
+    },
+    orderBy: [...postOrderBy],
+  });
+
+  // Calculate the number of entries since the latest seen entry
+  const postsToShow = await prisma.showAndTellEntry.count({
+    where: {
+      seenOnStream: false, // Only consider entries that have not been seen on stream
+    },
+  });
+
+  return postsToShow;
+}
+
+// Fetch all mod comments for a specific entry
+export async function getModCommentsForEntry(entryId: string) {
+  return await prisma.showAndTellModComment.findMany({
+    where: { entryId },
+    include: { user: true },
+  });
+}
+
+// Add a new mod comment
+export async function addModComment(
+  entryId: string,
+  modId: string,
+  comment: string,
+  isInternal: boolean,
+) {
+  return await prisma.showAndTellModComment.create({
+    data: {
+      entryId,
+      modId,
+      comment,
+      isInternal,
+    },
+  });
+}
+
+// Delete a mod comment
+export async function deleteModComment(commentId: string) {
+  return await prisma.showAndTellModComment.delete({
+    where: { id: commentId },
+  });
+}
+
+// Toggle comment visibility
+export async function toggleCommentVisibility(
+  commentId: string,
+  isInternal: boolean,
+) {
+  return await prisma.showAndTellModComment.update({
+    where: { id: commentId },
+    data: { isInternal: !isInternal },
+  });
 }

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -1,5 +1,5 @@
-import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 
 import { env } from "@/env";
 
@@ -9,13 +9,13 @@ import {
   MAX_VIDEOS,
 } from "@/data/show-and-tell";
 
+import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 import { prisma } from "@/server/db/client";
 import { checkAndFixUploadedImageFileStorageObject } from "@/server/utils/file-storage";
-import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 
+import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 import { getEntityStatus } from "@/utils/entity-helpers";
 import { notEmpty } from "@/utils/helpers";
-import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 
 export const withAttachments = {
   include: {

--- a/apps/website/src/server/trpc/router/admin/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/admin/show-and-tell.ts
@@ -1,26 +1,26 @@
-import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { permissions } from "@/data/permissions";
-import {
-  addModComment,
-  approvePost,
-  deleteModComment,
-  deletePost,
-  getAdminPosts,
-  getModCommentsForEntry,
-  getPostById,
-  markPostAsSeen,
-  removeApprovalFromPost,
-  showAndTellUpdateInputSchema,
-  toggleCommentVisibility,
-  unmarkPostAsSeen,
-  updatePost,
-} from "@/server/db/show-and-tell";
+import { TRPCError } from "@trpc/server";
 import {
   createCheckPermissionMiddleware,
   protectedProcedure,
   router,
 } from "@/server/trpc/trpc";
+import {
+  showAndTellUpdateInputSchema,
+  updatePost,
+  approvePost,
+  removeApprovalFromPost,
+  deletePost,
+  getPostById,
+  markPostAsSeen,
+  unmarkPostAsSeen,
+  getAdminPosts,
+  getModCommentsForEntry,
+  addModComment,
+  deleteModComment,
+  toggleCommentVisibility,
+} from "@/server/db/show-and-tell";
+import { permissions } from "@/data/permissions";
 import { deleteFileStorageObject } from "@/server/utils/file-storage";
 import { notEmpty } from "@/utils/helpers";
 

--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -1,16 +1,15 @@
-import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import {
+  createFileStorageUpload,
+  deleteFileStorageObject,
+} from "@/server/utils/file-storage";
 import {
   protectedProcedure,
   publicProcedure,
   router,
 } from "@/server/trpc/trpc";
-import {
-  createFileStorageUpload,
-  deleteFileStorageObject,
-} from "@/server/utils/file-storage";
 
-import { env } from "@/env";
 import {
   createPost,
   deletePost,
@@ -24,6 +23,7 @@ import {
   withAttachments,
 } from "@/server/db/show-and-tell";
 import { imageMimeTypes } from "@/utils/files";
+import { env } from "@/env";
 import { notEmpty } from "@/utils/helpers";
 
 const uploadPrefix = "show-and-tell/";


### PR DESCRIPTION
## Describe your changes

Resolves #716, resolves #717. Adds support for both public & private mod comments on Show & Tell posts.

![image](https://github.com/user-attachments/assets/9ab588ba-565e-4005-bfd7-09dcb4b78079)
![image](https://github.com/user-attachments/assets/4c893251-6391-4a9d-aeae-3cb23313169f)

## Todo
- [x] Add support for mod comments
- [x] Display mod comments in admin area
- [x] Display mod comments in frontend
- [x] Make it pretty