### PR TITLE
Show & Tell: Add Accreditation Badge

### DIFF
--- a/apps/website/prisma/schema.prisma
+++ b/apps/website/prisma/schema.prisma
@@ -401,6 +401,7 @@ model ShowAndTellEntry {
   seenOnStreamAt      DateTime?
   seenOnStream        Boolean   @default(false)
   volunteeringMinutes Int?
+  azaZoo              Boolean   @default(false)
 
   attachments ShowAndTellEntryAttachment[]
   user        User?                        @relation(fields: [userId], references: [id])

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -1,3 +1,19 @@
+import type {
+  FileStorageObject,
+  ImageAttachment,
+  ImageMetadata,
+  LinkAttachment,
+  ShowAndTellEntryAttachment,
+  ShowAndTellEntry as ShowAndTellEntryModel,
+} from "@prisma/client";
+import parse, {
+  domToReact,
+  Element,
+  Text,
+  type DOMNode,
+  type HTMLReactParserOptions,
+} from "html-react-parser";
+import Image from "next/image";
 import {
   forwardRef,
   Fragment,
@@ -6,32 +22,17 @@ import {
   useMemo,
   useRef,
 } from "react";
-import type {
-  FileStorageObject,
-  ImageAttachment,
-  ImageMetadata,
-  LinkAttachment,
-  ShowAndTellEntry as ShowAndTellEntryModel,
-  ShowAndTellEntryAttachment,
-} from "@prisma/client";
-import Image from "next/image";
-import parse, {
-  domToReact,
-  Element,
-  Text,
-  type DOMNode,
-  type HTMLReactParserOptions,
-} from "html-react-parser";
 import { ErrorBoundary } from "react-error-boundary";
 
-import { parseVideoUrl, videoPlatformConfigs } from "@/utils/video-urls";
-import { notEmpty } from "@/utils/helpers";
 import { DATETIME_ALVEUS_ZONE, formatDateTime } from "@/utils/datetime";
+import { notEmpty } from "@/utils/helpers";
+import { parseVideoUrl, videoPlatformConfigs } from "@/utils/video-urls";
 
 import Link from "@/components/content/Link";
 import { ShowAndTellGallery } from "@/components/show-and-tell/gallery/ShowAndTellGallery";
 import { SeenOnStreamBadge } from "@/components/show-and-tell/SeenOnStreamBadge";
 
+import IconCheck from "@/icons/IconCheck";
 import IconWorld from "@/icons/IconWorld";
 import { classes } from "@/utils/classes";
 
@@ -46,6 +47,7 @@ export type ShowAndTellEntryWithAttachments = Pick<
   | "approvedAt"
   | "seenOnStream"
   | "volunteeringMinutes"
+  | "azaZoo"
 > & {
   attachments: Array<
     ShowAndTellEntryAttachment & {
@@ -144,7 +146,7 @@ const Header = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
           { style: "long" },
           { zone: DATETIME_ALVEUS_ZONE },
         )}
-        {entry.volunteeringMinutes ? (
+        {entry.volunteeringMinutes && (
           <>
             {` — `}
             <Link
@@ -176,7 +178,40 @@ const Header = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
               />
             </Link>
           </>
-        ) : null}
+        )}
+        {entry.azaZoo && (
+          <>
+            {` — `}
+            <Link
+              href="https://www.aza.org/about-us"
+              className={classes(
+                "inline-flex items-center gap-1 text-[#e0684b]",
+                isPresentationView
+                  ? "group text-nowrap rounded-full bg-alveus-tan-900/95 p-1 text-3xl shadow-lg transition-all hover:scale-102 hover:bg-alveus-tan-900 focus:bg-alveus-tan-900"
+                  : "hover:underline focus:underline",
+              )}
+              target="_blank"
+              custom
+            >
+              <strong
+                className={classes(
+                  "bg-[#e0684b] bg-clip-text font-bold text-transparent",
+                  isPresentationView
+                    ? "from-blue-500 pl-2 leading-none transition-colors group-hover:from-blue-400 group-hover:to-green-500"
+                    : "from-blue-800",
+                )}
+              >
+                Accredited Zoo
+              </strong>
+              <IconCheck
+                className={classes(
+                  "inline-block",
+                  isPresentationView ? "h-12 w-12" : "h-8 w-8",
+                )}
+              />
+            </Link>
+          </>
+        )}
       </p>
     </header>
   );

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -1,19 +1,3 @@
-import type {
-  FileStorageObject,
-  ImageAttachment,
-  ImageMetadata,
-  LinkAttachment,
-  ShowAndTellEntryAttachment,
-  ShowAndTellEntry as ShowAndTellEntryModel,
-} from "@prisma/client";
-import parse, {
-  domToReact,
-  Element,
-  Text,
-  type DOMNode,
-  type HTMLReactParserOptions,
-} from "html-react-parser";
-import Image from "next/image";
 import {
   forwardRef,
   Fragment,
@@ -22,18 +6,34 @@ import {
   useMemo,
   useRef,
 } from "react";
+import type {
+  FileStorageObject,
+  ImageAttachment,
+  ImageMetadata,
+  LinkAttachment,
+  ShowAndTellEntry as ShowAndTellEntryModel,
+  ShowAndTellEntryAttachment,
+} from "@prisma/client";
+import Image from "next/image";
+import parse, {
+  domToReact,
+  Element,
+  Text,
+  type DOMNode,
+  type HTMLReactParserOptions,
+} from "html-react-parser";
 import { ErrorBoundary } from "react-error-boundary";
 
-import { DATETIME_ALVEUS_ZONE, formatDateTime } from "@/utils/datetime";
-import { notEmpty } from "@/utils/helpers";
 import { parseVideoUrl, videoPlatformConfigs } from "@/utils/video-urls";
+import { notEmpty } from "@/utils/helpers";
+import { DATETIME_ALVEUS_ZONE, formatDateTime } from "@/utils/datetime";
 
 import Link from "@/components/content/Link";
 import { ShowAndTellGallery } from "@/components/show-and-tell/gallery/ShowAndTellGallery";
 import { SeenOnStreamBadge } from "@/components/show-and-tell/SeenOnStreamBadge";
 
-import IconCheck from "@/icons/IconCheck";
 import IconWorld from "@/icons/IconWorld";
+import IconCheck from "@/icons/IconCheck";
 import { classes } from "@/utils/classes";
 
 export type ShowAndTellEntryWithAttachments = Pick<

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -1,20 +1,20 @@
-import { type FormEvent, useMemo, useState } from "react";
 import { useRouter } from "next/router";
+import { type FormEvent, useMemo, useState } from "react";
 
 import type { ShowAndTellSubmitInput } from "@/server/db/show-and-tell";
 
 import {
+  getMaxTextLengthForCreatedAt,
   MAX_IMAGES,
   MAX_VIDEOS,
-  getMaxTextLengthForCreatedAt,
   resizeImageOptions,
 } from "@/data/show-and-tell";
 
 import { classes } from "@/utils/classes";
-import { trpc } from "@/utils/trpc";
-import { notEmpty } from "@/utils/helpers";
 import { getEntityStatus } from "@/utils/entity-helpers";
 import { type ImageMimeType, imageMimeTypes } from "@/utils/files";
+import { notEmpty } from "@/utils/helpers";
+import { trpc } from "@/utils/trpc";
 
 import IconLoading from "@/icons/IconLoading";
 import IconWarningTriangle from "@/icons/IconWarningTriangle";
@@ -22,23 +22,23 @@ import IconWarningTriangle from "@/icons/IconWarningTriangle";
 import useFileUpload from "@/hooks/files/upload";
 
 import type { ShowAndTellEntryWithAttachments } from "@/components/show-and-tell/ShowAndTellEntry";
+import Link from "../content/Link";
+import { Button } from "../shared/form/Button";
 import { Fieldset } from "../shared/form/Fieldset";
-import { TextField } from "../shared/form/TextField";
+import { ImageUploadAttachment } from "../shared/form/ImageUploadAttachment";
+import { NumberField } from "../shared/form/NumberField";
 import { RichTextField } from "../shared/form/RichTextField";
+import { TextAreaField } from "../shared/form/TextAreaField";
+import { TextField } from "../shared/form/TextField";
 import {
   UploadAttachmentsField,
   useUploadAttachmentsData,
 } from "../shared/form/UploadAttachmentsField";
-import { Button } from "../shared/form/Button";
-import { ImageUploadAttachment } from "../shared/form/ImageUploadAttachment";
-import { MessageBox } from "../shared/MessageBox";
-import { TextAreaField } from "../shared/form/TextAreaField";
-import { NumberField } from "../shared/form/NumberField";
 import {
   useVideoLinksData,
   VideoLinksField,
 } from "../shared/form/VideoLinksField";
-import Link from "../content/Link";
+import { MessageBox } from "../shared/MessageBox";
 
 type ShowAndTellEntryFormProps = {
   isAnonymous?: boolean;
@@ -101,6 +101,8 @@ export function ShowAndTellEntryForm({
     !!entry?.volunteeringMinutes,
   );
 
+  const [isAzaZoo, setIsAzaZoo] = useState(!!entry?.azaZoo);
+
   const imageAttachmentsData = useUploadAttachmentsData(
     useMemo(
       () =>
@@ -146,6 +148,7 @@ export function ShowAndTellEntryForm({
       imageAttachments: { create: [], update: {} },
       videoLinks: videoLinksData.videoUrls,
       volunteeringMinutes: wantsToTrackGiveAnHour && hours ? hours * 60 : null,
+      azaZoo: formData.get("azaZoo") === "on",
     };
 
     for (const fileReference of imageAttachmentsData.files) {
@@ -383,6 +386,37 @@ export function ShowAndTellEntryForm({
                 entry?.volunteeringMinutes ? entry.volunteeringMinutes / 60 : 1
               }
             />
+          </div>
+        </Fieldset>
+
+        <Fieldset legend="AZA Zoo">
+          <p>
+            Is this submission related to an accredited zoo? (i.e.{" "}
+            <Link
+              href="https://www.aza.org/find-a-zoo-or-aquarium"
+              target="_blank"
+            >
+              AZA
+            </Link>
+            ,{" "}
+            <Link href="https://www.eaza.net/#map_home" target="_blank">
+              EAZA
+            </Link>
+            ,{" "}
+            <Link href="https://caza.ca/plan-a-visit/" target="_blank">
+              CAZA
+            </Link>
+            , etc)
+          </p>
+          <div className="flex items-center gap-4">
+            <input
+              type="checkbox"
+              id="azaZoo"
+              name="azaZoo"
+              checked={isAzaZoo}
+              onChange={(e) => setIsAzaZoo(e.target.checked)}
+            />
+            <label htmlFor="azaZoo">Yes, it is an accredited zoo.</label>
           </div>
         </Fieldset>
 

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -1,20 +1,20 @@
-import { useRouter } from "next/router";
 import { type FormEvent, useMemo, useState } from "react";
+import { useRouter } from "next/router";
 
 import type { ShowAndTellSubmitInput } from "@/server/db/show-and-tell";
 
 import {
-  getMaxTextLengthForCreatedAt,
   MAX_IMAGES,
   MAX_VIDEOS,
+  getMaxTextLengthForCreatedAt,
   resizeImageOptions,
 } from "@/data/show-and-tell";
 
 import { classes } from "@/utils/classes";
+import { trpc } from "@/utils/trpc";
+import { notEmpty } from "@/utils/helpers";
 import { getEntityStatus } from "@/utils/entity-helpers";
 import { type ImageMimeType, imageMimeTypes } from "@/utils/files";
-import { notEmpty } from "@/utils/helpers";
-import { trpc } from "@/utils/trpc";
 
 import IconLoading from "@/icons/IconLoading";
 import IconWarningTriangle from "@/icons/IconWarningTriangle";
@@ -22,23 +22,23 @@ import IconWarningTriangle from "@/icons/IconWarningTriangle";
 import useFileUpload from "@/hooks/files/upload";
 
 import type { ShowAndTellEntryWithAttachments } from "@/components/show-and-tell/ShowAndTellEntry";
-import Link from "../content/Link";
-import { Button } from "../shared/form/Button";
 import { Fieldset } from "../shared/form/Fieldset";
-import { ImageUploadAttachment } from "../shared/form/ImageUploadAttachment";
-import { NumberField } from "../shared/form/NumberField";
-import { RichTextField } from "../shared/form/RichTextField";
-import { TextAreaField } from "../shared/form/TextAreaField";
 import { TextField } from "../shared/form/TextField";
+import { RichTextField } from "../shared/form/RichTextField";
 import {
   UploadAttachmentsField,
   useUploadAttachmentsData,
 } from "../shared/form/UploadAttachmentsField";
+import { Button } from "../shared/form/Button";
+import { ImageUploadAttachment } from "../shared/form/ImageUploadAttachment";
+import { MessageBox } from "../shared/MessageBox";
+import { TextAreaField } from "../shared/form/TextAreaField";
+import { NumberField } from "../shared/form/NumberField";
 import {
   useVideoLinksData,
   VideoLinksField,
 } from "../shared/form/VideoLinksField";
-import { MessageBox } from "../shared/MessageBox";
+import Link from "../content/Link";
 
 type ShowAndTellEntryFormProps = {
   isAnonymous?: boolean;

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -1,5 +1,5 @@
-import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 
 import { env } from "@/env";
 
@@ -9,13 +9,13 @@ import {
   MAX_VIDEOS,
 } from "@/data/show-and-tell";
 
+import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 import { prisma } from "@/server/db/client";
 import { checkAndFixUploadedImageFileStorageObject } from "@/server/utils/file-storage";
-import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 
+import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 import { getEntityStatus } from "@/utils/entity-helpers";
 import { notEmpty } from "@/utils/helpers";
-import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 
 export const withAttachments = {
   include: {

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
 import { TRPCError } from "@trpc/server";
+import { z } from "zod";
 
 import { env } from "@/env";
 
@@ -9,13 +9,13 @@ import {
   MAX_VIDEOS,
 } from "@/data/show-and-tell";
 
-import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 import { prisma } from "@/server/db/client";
 import { checkAndFixUploadedImageFileStorageObject } from "@/server/utils/file-storage";
+import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
 
-import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 import { getEntityStatus } from "@/utils/entity-helpers";
 import { notEmpty } from "@/utils/helpers";
+import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 
 export const withAttachments = {
   include: {
@@ -96,6 +96,7 @@ const showAndTellSharedInputSchema = z.object({
   imageAttachments: imageAttachmentsSchema,
   videoLinks: videoLinksSchema.max(MAX_VIDEOS),
   volunteeringMinutes: z.number().int().positive().nullable(),
+  azaZoo: z.boolean(),
 });
 
 export const showAndTellCreateInputSchema = showAndTellSharedInputSchema;
@@ -204,6 +205,7 @@ export async function createPost(
       title: input.title,
       text,
       volunteeringMinutes: input.volunteeringMinutes,
+      azaZoo: input.azaZoo,
       attachments: { create: [...newImages, ...newVideos] },
     },
   });
@@ -247,6 +249,7 @@ export async function getPosts({
       title: true,
       text: true,
       volunteeringMinutes: true,
+      azaZoo: true,
       seenOnStream: true,
       createdAt: true,
       updatedAt: true,
@@ -360,6 +363,7 @@ export async function updatePost(
         title: input.title,
         text,
         volunteeringMinutes: input.volunteeringMinutes,
+        azaZoo: input.azaZoo,
         updatedAt: now,
         approvedAt:
           keepApproved && wasApproved ? now : existingEntry.approvedAt,


### PR DESCRIPTION
## Describe your changes

Resolves #738. With more and more people submitting Show & Tells from zoos - this adds the option for people to mark their submission as an accredited zoo to display a badge.

For now, the badge links to the AZA about us page, but we could consider building our own page that's more generic, listing some of the larger accrediting bodies for zoos & aquariums, and why it's an important accreditation.

![image](https://github.com/user-attachments/assets/1f85b43a-b645-462d-b6b2-9d0c5ad9ee90)
![image](https://github.com/user-attachments/assets/a53bc8b7-d8ff-4034-a3d7-c029cd82da4a)

## Notes for testing your change

N/A
