### PR TITLE
Make Discord notifications pretty

### DIFF
--- a/apps/website/src/data/notifications.ts
+++ b/apps/website/src/data/notifications.ts
@@ -59,11 +59,11 @@ export function getNotificationCategory(tag: string) {
 export const notificationLinkSuggestions = [
   {
     label: "TTV AlveusSanctuary",
-    url: "https://www.twitch.tv/AlveusSanctuary",
+    url: "https://twitch.tv/AlveusSanctuary",
   },
-  { label: "TTV Maya", url: "https://www.twitch.tv/maya" },
+  { label: "TTV Maya", url: "https://twitch.tv/maya" },
   { label: "YT AlveusSanctuary", url: "https://youtube.com/@AlveusSanctuary" },
-  { label: "YT Maya", url: "https://www.youtube.com/@mayahiga" },
+  { label: "YT Maya", url: "https://youtube.com/@mayahiga" },
   { label: "Website", url: "https://www.alveussanctuary.org/" },
   { label: "Twitter page", url: "https://twitter.com/AlveusSanctuary" },
 ] satisfies NotificationLinkSuggestion[];

--- a/apps/website/src/server/discord.ts
+++ b/apps/website/src/server/discord.ts
@@ -46,7 +46,7 @@ export async function triggerDiscordChannelWebhook({
 }) {
   const embed = {
     title: contentTitle || "Notification",
-    description: ((contentMessage || "") + (contentLink ? `\n[${contentLink.replace(/^https?:\/\//(www\.)?, "")}](${contentLink})` : "")).trim(),
+    description: ((contentMessage || "") + (contentLink ? `\n[${contentLink.replace(/^https?:\/\/(www\.)?/, "")}](${contentLink})` : "")).trim(),
     color: 0x636a60,
     url: contentLink,
     footer: {

--- a/apps/website/src/server/discord.ts
+++ b/apps/website/src/server/discord.ts
@@ -46,7 +46,7 @@ export async function triggerDiscordChannelWebhook({
 }) {
   const embed = {
     title: contentTitle || "Notification",
-    description: contentMessage || "",
+    description: ((contentMessage || "") + (contentLink ? `\n[${contentLink.replace(/^https?:\/\//(www\.)?, "")}](${contentLink})` : "")).trim(),
     color: 0x636a60,
     url: contentLink,
     footer: {

--- a/apps/website/src/server/discord.ts
+++ b/apps/website/src/server/discord.ts
@@ -44,12 +44,6 @@ export async function triggerDiscordChannelWebhook({
   expiresAt?: Date;
   toEveryone?: boolean;
 }) {
-  const linkRegex = /twitch\.tv\/(\w+)/;
-  const match = contentLink ? contentLink.match(linkRegex) : null;
-  const formattedLink = match
-    ? `[<:twitch:603947671941546025>/${match[1]}](${contentLink})`
-    : `[Click Here](${contentLink})`;
-
   const embed = {
     title: contentTitle || "Notification",
     description: contentMessage || "",

--- a/apps/website/src/server/discord.ts
+++ b/apps/website/src/server/discord.ts
@@ -46,7 +46,12 @@ export async function triggerDiscordChannelWebhook({
 }) {
   const embed = {
     title: contentTitle || "Notification",
-    description: ((contentMessage || "") + (contentLink ? `\n[${contentLink.replace(/^https?:\/\/(www\.)?/, "")}](${contentLink})` : "")).trim(),
+    description: (
+      (contentMessage || "") +
+      (contentLink
+        ? `\n[${contentLink.replace(/^https?:\/\/(www\.)?/, "")}](${contentLink})`
+        : "")
+    ).trim(),
     color: 0x636a60,
     url: contentLink,
     footer: {

--- a/apps/website/src/server/discord.ts
+++ b/apps/website/src/server/discord.ts
@@ -21,6 +21,7 @@ type DiscordWebhookNotificationBody = {
     thumbnail?: { url: string };
     image?: { url: string };
     author?: { name: string; url?: string; icon_url?: string };
+    timestamp?: Date;
   }>;
 };
 
@@ -52,20 +53,13 @@ export async function triggerDiscordChannelWebhook({
   const embed = {
     title: contentTitle || "Notification",
     description: contentMessage || "",
-    color: 0x636a60, // Custom color
-    fields: contentLink
-      ? [
-          {
-            name: "Link",
-            value: formattedLink,
-            inline: true,
-          },
-        ]
-      : [],
+    color: 0x636a60,
+    url: contentLink,
     footer: {
-      text: "Alveus Sanctuary • Notifications • alveus.gg/updates",
+      text: "alveus.gg/updates",
       icon_url: `${env.NEXT_PUBLIC_BASE_URL}/apple-touch-icon.png`,
     },
+    timestamp: new Date(Date.now()),
     image: {
       url: imageUrl || "",
     },
@@ -83,7 +77,7 @@ export async function triggerDiscordChannelWebhook({
 
   if (toEveryone) {
     body.allowed_mentions = { parse: ["everyone"] };
-    body.content = `@everyone ${contentLink}`;
+    body.content = `@everyone ${contentTitle}`;
   }
 
   const url = new URL(webhookUrl);

--- a/apps/website/src/server/discord.ts
+++ b/apps/website/src/server/discord.ts
@@ -1,52 +1,93 @@
 import { env } from "@/env";
-
 import { triggerOutgoingWebhook } from "@/server/outgoing-webhooks";
 
 export const OUTGOING_WEBHOOK_TYPE_DISCORD_CHANNEL = "discordChannel";
 
 type DiscordWebhookNotificationBody = {
-  // We dont use: files[], embeds, payload_json, attachments, flags, thread_name
   avatar_url: string;
   username: string;
-  content: string;
+  content?: string;
   tts: boolean;
   allowed_mentions: {
     parse?: Array<"everyone" | "roles" | "users">;
     users?: string[];
   };
+  embeds?: Array<{
+    title: string;
+    description: string;
+    color?: number;
+    fields?: Array<{ name: string; value: string; inline?: boolean }>;
+    footer?: { text: string; icon_url?: string };
+    thumbnail?: { url: string };
+    image?: { url: string };
+    author?: { name: string; url?: string; icon_url?: string };
+  }>;
 };
 
 export async function triggerDiscordChannelWebhook({
   webhookUrl,
-  content,
+  contentTitle,
+  contentMessage,
+  contentLink,
+  imageUrl,
   botName: username = env.DISCORD_BOT_NAME,
   expiresAt,
   toEveryone = false,
 }: {
   webhookUrl: string;
-  content: string;
+  contentTitle?: string;
+  contentMessage?: string;
+  contentLink?: string;
+  imageUrl?: string;
   botName?: string;
   expiresAt?: Date;
   toEveryone?: boolean;
 }) {
+  const linkRegex = /twitch\.tv\/(\w+)/;
+  const match = contentLink ? contentLink.match(linkRegex) : null;
+  const formattedLink = match
+    ? `[<:twitch:603947671941546025>/${match[1]}](${contentLink})`
+    : `[Click Here](${contentLink})`;
+
+  const embed = {
+    title: contentTitle || "Notification",
+    description: contentMessage || "",
+    color: 0x636a60, // Custom color
+    fields: contentLink
+      ? [
+          {
+            name: "Link",
+            value: formattedLink,
+            inline: true,
+          },
+        ]
+      : [],
+    footer: {
+      text: "Alveus Sanctuary • Notifications",
+      icon_url: `${env.NEXT_PUBLIC_BASE_URL}/apple-touch-icon.png`,
+    },
+    image: {
+      url: imageUrl || "",
+    },
+  };
+
   const body: DiscordWebhookNotificationBody = {
     username,
-    content,
     tts: false,
     avatar_url: `${env.NEXT_PUBLIC_BASE_URL}/apple-touch-icon.png`,
     allowed_mentions: {
       parse: [],
     },
+    embeds: [embed],
   };
 
   if (toEveryone) {
     body.allowed_mentions = { parse: ["everyone"] };
-    body.content = `@everyone ${content}`;
+    body.content = `@everyone ${contentLink}`;
   }
 
   const url = new URL(webhookUrl);
   url.searchParams.set("wait", "true");
-  //url.searchParams.set('thread_id', '1234567890');
 
   return triggerOutgoingWebhook({
     url: url.toString(),

--- a/apps/website/src/server/discord.ts
+++ b/apps/website/src/server/discord.ts
@@ -63,7 +63,7 @@ export async function triggerDiscordChannelWebhook({
         ]
       : [],
     footer: {
-      text: "Alveus Sanctuary • Notifications",
+      text: "Alveus Sanctuary • Notifications • alveus.gg/updates",
       icon_url: `${env.NEXT_PUBLIC_BASE_URL}/apple-touch-icon.png`,
     },
     image: {

--- a/apps/website/src/server/notifications.ts
+++ b/apps/website/src/server/notifications.ts
@@ -212,10 +212,10 @@ async function createDiscordNotifications({
   for (const webhookUrl of webhookUrls) {
     tasks.push(
       triggerDiscordChannelWebhook({
-        contentTitle: title || undefined,
-        contentMessage: message || undefined,
-        contentLink: linkUrl || undefined,
-        imageUrl: imageUrl || undefined,
+        contentTitle: title ?? undefined,
+        contentMessage: message,
+        contentLink: linkUrl ?? undefined,
+        imageUrl: imageUrl ?? undefined,
         webhookUrl,
         expiresAt,
         toEveryone,

--- a/apps/website/src/server/notifications.ts
+++ b/apps/website/src/server/notifications.ts
@@ -210,6 +210,11 @@ async function createDiscordNotifications({
 
   const tasks = [];
   for (const webhookUrl of webhookUrls) {
+    const relativeNotificationUrl = `/notifications/${id}`;
+    const link =
+      linkUrl ||
+      new URL(relativeNotificationUrl, env.NEXT_PUBLIC_BASE_URL).toString();
+
     tasks.push(
       triggerDiscordChannelWebhook({
         contentTitle: title ?? undefined,

--- a/apps/website/src/server/notifications.ts
+++ b/apps/website/src/server/notifications.ts
@@ -3,19 +3,19 @@ import type { Notification } from "@prisma/client";
 import { env } from "@/env";
 
 import {
-  pushBatchSize,
-  pushMaxAttempts,
-  pushRetryDelay,
-} from "@/data/env/push";
-import {
   defaultTag,
   defaultTitle,
   notificationCategories,
 } from "@/data/notifications";
+import {
+  pushBatchSize,
+  pushMaxAttempts,
+  pushRetryDelay,
+} from "@/data/env/push";
 
 import { prisma } from "@/server/db/client";
-import { triggerDiscordChannelWebhook } from "@/server/discord";
 import { callEndpoint } from "@/server/utils/queue";
+import { triggerDiscordChannelWebhook } from "@/server/discord";
 import { escapeLinksForDiscord } from "@/utils/escape-links-for-discord";
 
 import type { CreatePushesOptions } from "@/pages/api/notifications/batched-create-notification-pushes";


### PR DESCRIPTION
## Describe your changes

Make Discord webhook notifications prettier by using embeds! Supports the same content as before, but adds support for images for Discord notifications.

![image](https://github.com/user-attachments/assets/09b51d88-0f1b-44ae-af23-29b26ee43961)
![image](https://github.com/user-attachments/assets/0d3c6ddb-eee7-49fb-a036-9bf1a232e83c)

NOTE: A Twitch emote should be added to the Mayacord server (and the ID updated in this PR) - this is from one of my personal testing servers, and I'm not sure if Discord will reliably let the webhook use the emote - better to be safe and have the emote in the same server as the webhook.

## Notes for testing your change

Images will be broken on localhost (since Discord can't load your images) - test from staging or manually edit code to get images from somewhere else.