### PR TITLE
Add autoscroll to collaborations slider

### DIFF
--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -43,9 +43,24 @@ const Creators = ({ className }: { className?: string }) => {
   const drag = useDragScroll();
   const containerRef = useRef<HTMLUListElement>(null);
   const [isHovered, setIsHovered] = useState(false);
+  const [supportsHover, setSupportsHover] = useState(false);
 
   useEffect(() => {
-    if (containerRef.current) {
+    const mediaQuery = window.matchMedia("(hover: hover)");
+    setSupportsHover(mediaQuery.matches);
+
+    const handleHoverChange = (event: MediaQueryListEvent) => {
+      setSupportsHover(event.matches);
+    };
+
+    mediaQuery.addEventListener("change", handleHoverChange);
+    return () => {
+      mediaQuery.removeEventListener("change", handleHoverChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (containerRef.current && supportsHover) {
       const container = containerRef.current;
 
       const handleScroll = () => {
@@ -68,7 +83,7 @@ const Creators = ({ className }: { className?: string }) => {
         container.removeEventListener("scroll", handleScroll);
       };
     }
-  }, [isHovered]);
+  }, [isHovered, supportsHover]);
 
   return (
     <div className={classes("flex justify-center", className)}>

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import { type NextPage } from "next";
 import Image from "next/image";
 
@@ -41,6 +41,37 @@ const creators = collaborations
 
 const Creators = ({ className }: { className?: string }) => {
   const drag = useDragScroll();
+  const containerRef = useRef<HTMLUListElement>(null);
+  const [isHovered, setIsHovered] = useState(false);
+  const [creatorList, setCreatorList] = useState([...creators]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (container) {
+      const handleScroll = () => {
+        const maxScrollLeft = container.scrollWidth - container.clientWidth;
+
+        if (container.scrollLeft >= maxScrollLeft) {
+          setCreatorList((prevList) => [...prevList, ...creators]);
+        }
+      };
+
+      const intervalId = setInterval(() => {
+        if (!isHovered) {
+          container.scrollLeft += 1;
+          handleScroll();
+        }
+      }, 30);
+
+      container.addEventListener("scroll", handleScroll);
+
+      return () => {
+        clearInterval(intervalId);
+        container.removeEventListener("scroll", handleScroll);
+      };
+    }
+  }, [isHovered]);
 
   return (
     <div className={classes("flex justify-center", className)}>
@@ -48,9 +79,15 @@ const Creators = ({ className }: { className?: string }) => {
         <ul
           className="scrollbar-none group/creators flex max-w-full cursor-grab flex-row gap-y-4 overflow-x-auto pb-2 pl-12 pr-8 pt-6"
           onMouseDown={drag}
+          ref={containerRef}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
         >
-          {creators.map(({ name, image, slug }, idx) => (
-            <li key={slug} style={{ zIndex: creators.length - idx }}>
+          {creatorList.map(({ name, image, slug }, idx) => (
+            <li
+              key={`${slug}-${idx}`}
+              style={{ zIndex: creators.length - (idx % creators.length) }}
+            >
               <Link
                 href={`#${slug}`}
                 title={name}

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -43,17 +43,14 @@ const Creators = ({ className }: { className?: string }) => {
   const drag = useDragScroll();
   const containerRef = useRef<HTMLUListElement>(null);
   const [isHovered, setIsHovered] = useState(false);
-  const [creatorList, setCreatorList] = useState([...creators]);
 
   useEffect(() => {
-    const container = containerRef.current;
+    if (containerRef.current) {
+      const container = containerRef.current;
 
-    if (container) {
       const handleScroll = () => {
-        const maxScrollLeft = container.scrollWidth - container.clientWidth;
-
-        if (container.scrollLeft >= maxScrollLeft) {
-          setCreatorList((prevList) => [...prevList, ...creators]);
+        if (container.scrollLeft >= container.scrollWidth / 2) {
+          container.scrollLeft = 0;
         }
       };
 
@@ -83,7 +80,7 @@ const Creators = ({ className }: { className?: string }) => {
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
         >
-          {creatorList.map(({ name, image, slug }, idx) => (
+          {[...creators, ...creators].map(({ name, image, slug }, idx) => (
             <li
               key={`${slug}-${idx}`}
               style={{ zIndex: creators.length - (idx % creators.length) }}


### PR DESCRIPTION
## Describe your changes

Resolves #648. Adds slow autoscrolling to the slider of collaborators to help indicate that there is more content if you scroll.

As Matt requested, this does not add arrows or additional UI elements, but sticks to simply adding a slow autoscroll of that slider.

The scroll should infinitely loop. Scrolling does get interrupted when you reach the end of 2 cycles, as the scroll position is reset. I implemented a different solution prior to this one that did allow infinite scrolling with no interruption or minor jumps, but it will theoretically infinitely loop repeating the slider, which seems not ideal haha. Autoscroll is paused on hover.

![image](https://i.aca30.com/wUXU3/xiKOPUBo47.gif/raw)

## Notes for testing your change

N/A