### PR TITLE
Increase "schedule" messaging for /updates

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -160,6 +160,16 @@ const config = {
       permanent: true,
     },
     {
+      source: "/schedule",
+      destination: "/updates",
+      permanent: true,
+    },
+    {
+      source: "/calendar",
+      destination: "/updates",
+      permanent: true,
+    },
+    {
       source: "/aq/:path*",
       destination: "/animal-quest/:path*",
       permanent: false,

--- a/apps/website/src/data/navigation.ts
+++ b/apps/website/src/data/navigation.ts
@@ -43,13 +43,13 @@ export const mainNavStructure: NavStructure = {
         title: "Collaborations",
         link: "/collaborations",
       },
-      events: {
-        title: "Events",
-        link: "/events",
-      },
       updates: {
-        title: "Updates",
+        title: "Schedule & Updates",
         link: "/updates",
+      },
+      events: {
+        title: "Fundraising Events",
+        link: "/events",
       },
     },
   },

--- a/apps/website/src/pages/updates.tsx
+++ b/apps/website/src/pages/updates.tsx
@@ -19,7 +19,10 @@ const notificationTags = ["stream"];
 const UpdatesPage: NextPage = () => {
   return (
     <>
-      <Meta title="Updates" description="Announcements and Updates" />
+      <Meta
+        title="Updates"
+        description="See upcoming streams in the schedule and stay updated with push notifications"
+      />
 
       {/* Nav background */}
       <div className="-mt-40 hidden h-40 bg-alveus-green-900 lg:block" />
@@ -30,7 +33,7 @@ const UpdatesPage: NextPage = () => {
         containerClassName="flex flex-wrap items-center justify-between lg:flex-nowrap gap-x-16"
       >
         <div className="w-full flex-grow py-8 lg:max-w-2/3">
-          <Heading>Announcements and Updates</Heading>
+          <Heading>Schedule and Updates</Heading>
 
           <p className="mt-6">
             Stay updated using one of our announcement channels:


### PR DESCRIPTION
## Describe your changes

Adds some shortlinks and updates the messaging on the site to create some more visibility into the /updates page containing the schedule for streams.

## Notes for testing your change

Links + wording make sense.