### PR TITLE
Add monthly scheduled regular calendar events

### DIFF
--- a/apps/website/src/data/scheduled-tasks.ts
+++ b/apps/website/src/data/scheduled-tasks.ts
@@ -23,7 +23,7 @@ const scheduledTasksConfigSchema = z.object({
   tasks: z.array(
     z.object({
       id: z.string(),
-      task: z.function().returns(z.promise(z.void())),
+      task: z.function().args(z.date()).returns(z.promise(z.void())),
       label: z.string(),
       interval: durationSchema,
       startDateTime: z.date(),
@@ -64,7 +64,7 @@ const config: ScheduledTasksConfig = {
     },
     {
       id: "calendarEvents.regular",
-      task: () => createRegularCalendarEvents(),
+      task: (date) => createRegularCalendarEvents(date),
       label: "Calendar events: Create Regular Events",
       startDateTime: new Date(2024, 7, 21, 0, 8, 0),
       interval: { months: 1 },

--- a/apps/website/src/data/scheduled-tasks.ts
+++ b/apps/website/src/data/scheduled-tasks.ts
@@ -5,6 +5,7 @@ import { retryPendingNotificationPushes } from "@/server/notifications";
 import { cleanupExpiredNotificationPushes } from "@/server/db/notifications";
 import { retryOutgoingWebhooks } from "@/server/outgoing-webhooks";
 import { OUTGOING_WEBHOOK_TYPE_DISCORD_CHANNEL } from "@/server/discord";
+import { createRegularCalendarEvents } from "@/server/db/calendar-events";
 
 export type ScheduledTasksConfig = z.infer<typeof scheduledTasksConfigSchema>;
 
@@ -60,6 +61,13 @@ const config: ScheduledTasksConfig = {
       label: "Outgoing webhooks: Retry Discord Channel Webhooks",
       startDateTime: new Date(2023, 2, 3, 0, 8, 0),
       interval: { seconds: 30 },
+    },
+    {
+      id: "calendarEvents.regular",
+      task: () => createRegularCalendarEvents(),
+      label: "Calendar events: Create Regular Events",
+      startDateTime: new Date(2024, 7, 21, 0, 8, 0),
+      interval: { months: 1 },
     },
   ],
 };

--- a/apps/website/src/server/db/calendar-events.ts
+++ b/apps/website/src/server/db/calendar-events.ts
@@ -60,7 +60,7 @@ export async function getCalendarEvents({
   });
 }
 
-export async function createRegularCalendarEvents() {
+export async function createRegularCalendarEvents(date: Date) {
   const animalCareChats = {
     title: "Animal Care Chats",
     description:
@@ -115,7 +115,7 @@ export async function createRegularCalendarEvents() {
   ] as Omit<CalendarEventSchema, "startAt" | "hasTime">[][];
 
   // Walk through each day of the next month and create any events
-  const nextMonth = DateTime.now()
+  const nextMonth = DateTime.fromJSDate(date)
     .plus({ months: 1 })
     .setZone(DATETIME_ALVEUS_ZONE)
     .set({ day: 1, hour: 12, minute: 0, second: 0, millisecond: 0 });


### PR DESCRIPTION
## Describe your changes

Once a month on the 21st, create all the regular calendar events that happen each week for the following month.

## Notes for testing your change

If running locally, you may want to swap `interval: { months: 1 },` to `interval: { minutes: 1 },`, and add the following before the final `for` loop that creates the events:

```ts
  await prisma.calendarEvent.deleteMany({
    where: {
      startAt: {
        gte: nextMonth.toJSDate(),
        lt: nextMonth.plus({ months: 1 }).toJSDate(),
      },
    },
  });
```