### PR TITLE
Fix scheduled tasks getting stuck or not running properly

### DIFF
--- a/apps/website/src/server/scheduler.ts
+++ b/apps/website/src/server/scheduler.ts
@@ -18,7 +18,13 @@ async function executeTask(
       task: taskConfig.id,
     },
   });
-  await taskConfig.task(nextExecutionTime.toJSDate());
+
+  try {
+    await taskConfig.task(nextExecutionTime.toJSDate());
+  } catch (exception) {
+    console.error(`Error executing task ${taskConfig.id}`, exception);
+  }
+
   const finishTime = new Date();
   await prisma.taskExecutionEvent.update({
     where: { id: event.id },


### PR DESCRIPTION
## Describe your changes

This fixes two problems:
- The two retry tasks (webhooks and notifications) failed because the conditions for the exponentially delayed retry were broke. The array of delays was not filled, because it was using the `Array.map()` method on a sparse array. Instead this now fills the array before mapping over it.
- When tasks failed with an exception, they never were tagged as finished, getting the task stuck. This will both catch exceptions and allow stuck tasks to be run after some time (5 minutes).

Resolves #765

## Notes for testing your change

This is a hard one to test. In a fresh db you should see that the tasks run through and do not leave an unfinished `TaskExecutionEvent` entry.
