### PR TITLE
Add VoDs shortlink for TwitchCon 2024

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -306,6 +306,11 @@ const config = {
       permanent: true,
     },
     {
+      source: "/vods/twitchcon-2024",
+      destination: "https://youtube.com/watch?v=b-d1h-dKEeU",
+      permanent: true,
+    },
+    {
       source: "/vods/non-releasable",
       destination: "https://youtube.com/watch?v=3UZjgUMuYeM",
       permanent: true,


### PR DESCRIPTION
## Describe your changes

Adds a shortlink for the 2024 panel at TwitchCon, like the 2023 link.

## Notes for testing your change

YouTube link is correct.
