### PR TITLE
Implement calendar layout based on user locale

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -33,6 +33,7 @@
     "@alveusgg/data": "github:alveusgg/data#0.39.0",
     "@aws-sdk/client-s3": "^3.503.1",
     "@aws-sdk/s3-request-presigner": "^3.503.1",
+    "@bart-krakowski/get-week-info-polyfill": "^1.0.8",
     "@fontsource/pt-sans": "^5.0.8",
     "@headlessui/react": "^1.7.18",
     "@next-auth/prisma-adapter": "^1.0.7",
@@ -82,7 +83,6 @@
     "slugify": "^1.6.6",
     "smooth-scroll-into-view-if-needed": "^2.0.2",
     "superjson": "^2.2.1",
-    "weekstart": "^2.0.0",
     "xml2js": "^0.6.2",
     "zod": "^3.22.4"
   },

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -82,6 +82,7 @@
     "slugify": "^1.6.6",
     "smooth-scroll-into-view-if-needed": "^2.0.2",
     "superjson": "^2.2.1",
+    "weekstart": "^2.0.0",
     "xml2js": "^0.6.2",
     "zod": "^3.22.4"
   },

--- a/apps/website/src/components/calendar/Calendar.tsx
+++ b/apps/website/src/components/calendar/Calendar.tsx
@@ -8,9 +8,8 @@ import {
 
 import { Transition } from "@headlessui/react";
 import { DateTime } from "luxon";
-
-import { ListBucketInventoryConfigurationsOutputFilterSensitiveLog } from "@aws-sdk/client-s3";
 import { getWeekStartByLocale } from "weekstart/full";
+
 import { trpc } from "@/utils/trpc";
 import { classes } from "@/utils/classes";
 

--- a/apps/website/src/components/calendar/Calendar.tsx
+++ b/apps/website/src/components/calendar/Calendar.tsx
@@ -8,7 +8,7 @@ import {
 
 import { Transition } from "@headlessui/react";
 import { DateTime } from "luxon";
-import { getWeekStartByLocale } from "weekstart/full";
+import "@bart-krakowski/get-week-info-polyfill";
 
 import { trpc } from "@/utils/trpc";
 import { classes } from "@/utils/classes";
@@ -294,9 +294,13 @@ export function Calendar({
 
   if (!today || !selectedDateTime) return null;
 
-  // Get week start (0 = Sunday, 1 = Monday, etc) and adjust Sunday to 7
-  const locale = Intl.DateTimeFormat().resolvedOptions().locale;
-  const startDay = getWeekStartByLocale(locale) || 7; // Convert 0 to 7 for Sunday.
+  const locale = new Intl.Locale(
+    Intl.DateTimeFormat().resolvedOptions().locale,
+  );
+  // Get first day of the week based on Locale.
+  // Defaults to 7 if getWeekInfo is not supported.
+  // 1 = Monday, 7 = Sunday.
+  const startDay = locale.getWeekInfo?.()?.firstDay ?? 7;
   const startOffset = (7 + selectedDateTime.weekday - startDay) % 7; // Luxon uses 1-based days
   const weeks = Math.ceil((startOffset + daysInMonth!) / 7);
 

--- a/apps/website/src/components/calendar/Calendar.tsx
+++ b/apps/website/src/components/calendar/Calendar.tsx
@@ -7,8 +7,10 @@ import {
 } from "react";
 
 import { Transition } from "@headlessui/react";
-import { DateTime, Info } from "luxon";
+import { DateTime } from "luxon";
 
+import { ListBucketInventoryConfigurationsOutputFilterSensitiveLog } from "@aws-sdk/client-s3";
+import { getWeekStartByLocale } from "weekstart/full";
 import { trpc } from "@/utils/trpc";
 import { classes } from "@/utils/classes";
 
@@ -292,7 +294,10 @@ export function Calendar({
   );
 
   if (!today || !selectedDateTime) return null;
-  const startDay = Info.getStartOfWeek({ locale: DateTime.local().locale }); // 1 = Monday, 7 = Sunday
+
+  // Get week start (0 = Sunday, 1 = Monday, etc) and adjust Sunday to 7
+  const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+  const startDay = getWeekStartByLocale(locale) || 7; // Convert 0 to 7 for Sunday.
   const startOffset = (7 + selectedDateTime.weekday - startDay) % 7; // Luxon uses 1-based days
   const weeks = Math.ceil((startOffset + daysInMonth!) / 7);
 

--- a/apps/website/src/components/calendar/Calendar.tsx
+++ b/apps/website/src/components/calendar/Calendar.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 
 import { Transition } from "@headlessui/react";
-import { DateTime } from "luxon";
+import { DateTime, Info } from "luxon";
 
 import { trpc } from "@/utils/trpc";
 import { classes } from "@/utils/classes";
@@ -292,8 +292,7 @@ export function Calendar({
   );
 
   if (!today || !selectedDateTime) return null;
-
-  const startDay = 1; // 1 = Monday, 7 = Sunday
+  const startDay = Info.getStartOfWeek({ locale: DateTime.local().locale }); // 1 = Monday, 7 = Sunday
   const startOffset = (7 + selectedDateTime.weekday - startDay) % 7; // Luxon uses 1-based days
   const weeks = Math.ceil((startOffset + daysInMonth!) / 7);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.503.1
         version: 3.503.1
+      '@bart-krakowski/get-week-info-polyfill':
+        specifier: ^1.0.8
+        version: 1.0.8
       '@fontsource/pt-sans':
         specifier: ^5.0.8
         version: 5.0.8
@@ -239,9 +242,6 @@ importers:
       superjson:
         specifier: ^2.2.1
         version: 2.2.1
-      weekstart:
-        specifier: ^2.0.0
-        version: 2.0.0
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
@@ -1051,6 +1051,10 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
+
+  /@bart-krakowski/get-week-info-polyfill@1.0.8:
+    resolution: {integrity: sha512-Vkp5Skl44AkQ/w+pJ1XrCa5P5whvpK7Ix75KBoZXpGXOEp6CqLVkcAQaWfzY6+rF1R+2cwvJMkxkYF3M4B8HFw==}
+    dev: false
 
   /@corex/deepmerge@4.0.43:
     resolution: {integrity: sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==}
@@ -10114,10 +10118,6 @@ packages:
       - esbuild
       - uglify-js
     dev: true
-
-  /weekstart@2.0.0:
-    resolution: {integrity: sha512-HjYc14IQUwDcnGICuc8tVtqAd6EFpoAQMqgrqcNtWWZB+F1b7iTq44GzwM1qvnH4upFgbhJsaNHuK93NOFheSg==}
-    dev: false
 
   /whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       superjson:
         specifier: ^2.2.1
         version: 2.2.1
+      weekstart:
+        specifier: ^2.0.0
+        version: 2.0.0
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
@@ -10111,6 +10114,10 @@ packages:
       - esbuild
       - uglify-js
     dev: true
+
+  /weekstart@2.0.0:
+    resolution: {integrity: sha512-HjYc14IQUwDcnGICuc8tVtqAd6EFpoAQMqgrqcNtWWZB+F1b7iTq44GzwM1qvnH4upFgbhJsaNHuK93NOFheSg==}
+    dev: false
 
   /whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}


### PR DESCRIPTION
## Describe your changes

<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->
resolves #777 
The schedule calendar should now displays weeks based on the user’s locale starting day.

en-GB
![image](https://github.com/user-attachments/assets/08e07df3-66c9-478d-8eb3-fbbbf5f03fca)


en-US
![image](https://github.com/user-attachments/assets/a5c67f2c-1100-4521-ab11-008a3cf451a7)


...

## Notes for testing your change
Use Chrome DevTools to simulate different country locales and verify the calendar's starting day.

...
