### PR TITLE
Show & Tell: Show current post author in presentation view

### DIFF
--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -254,6 +254,7 @@ export const ShowAndTellEntry = forwardRef<
       }}
       ref={handleRef}
       data-show-and-tell-entry={entry.id}
+      data-show-and-tell-author={entry.displayName}
       tabIndex={-1}
     >
       {isPresentationView && featureImageUrl && (

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -133,6 +133,7 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
   const presentationViewRootElementRef = useRef<HTMLDivElement | null>(null);
 
   const [currentPostIndex, setCurrentPostIndex] = useState(0);
+  const [currentPostAuthor, setCurrentPostAuthor] = useState("");
 
   // We use this ref to scroll to the entry when transitioning between presentation view and normal view
   // and when the next/prev buttons are clicked
@@ -148,6 +149,11 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
   const checkPosition = useCallback(() => {
     const currentEntryElement = currentEntryElementRef.current;
     if (!currentEntryElement) return;
+
+    // Get author from the current entry (using a data attribute)
+    setCurrentPostAuthor(
+      currentEntryElement.getAttribute("data-show-and-tell-author") || "",
+    );
 
     // Get the current position of the current entry
     const allEntries =
@@ -571,6 +577,11 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
           )}
 
           <div className="sticky bottom-[20px] right-[20px] z-20 ml-auto flex w-fit flex-col gap-2">
+            {currentPostAuthor && (
+              <p className="text-lg text-alveus-green-100">
+                by {currentPostAuthor}
+              </p>
+            )}
             {isPresentationView && (
               <p className="text-xl text-alveus-green">
                 {postsToShowCount - currentPostIndex <= 0


### PR DESCRIPTION
## Describe your changes

Shows the author on the right side in presentation mode so the streamer can see it while showing pictures.

## Notes for testing your change

n/a