### PR TITLE
Show & Tell: Fix current post author in presentation view

### DIFF
--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -576,9 +576,9 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
             </>
           )}
 
-          <div className="sticky bottom-[20px] right-[20px] z-20 ml-auto flex w-fit flex-col gap-2">
-            {currentPostAuthor && (
-              <p className="text-lg text-alveus-green-100">
+          <div className="sticky bottom-[20px] right-[20px] z-20 ml-auto flex w-fit select-none flex-col gap-2">
+            {isPresentationView && currentPostAuthor && (
+              <p className="max-w-40 text-lg text-alveus-green-300">
                 by {currentPostAuthor}
               </p>
             )}


### PR DESCRIPTION
## Describe your changes

Fixes the display of the current post author in presentation view I introduced in #795. It should not show on normal mode anymore and it should not make the buttons move when overflowing.

## Notes for testing your change

Open fullscreen / presentation mode, see the author shows bottom right above the buttons. Does not break with long usernames.
