### PR TITLE
Add Vercel track call to short links

### DIFF
--- a/apps/website/src/middleware.ts
+++ b/apps/website/src/middleware.ts
@@ -20,6 +20,8 @@ export async function middleware(req: NextRequest, event: NextFetchEvent) {
     event.waitUntil(
       callEndpoint<TrackClickSchema>("/api/short-links/track-click", {
         id: shortLink.id,
+        slug: shortLink.slug,
+        link: shortLink.link,
       }),
     );
     return NextResponse.redirect(shortLink.link);

--- a/apps/website/src/middleware.ts
+++ b/apps/website/src/middleware.ts
@@ -7,6 +7,22 @@ import { env } from "@/env";
 import { callEndpoint } from "@/server/utils/queue";
 import type { TrackClickSchema } from "@/pages/api/short-links/track-click";
 
+const headersToObject = (headers: Headers) =>
+  [...headers.entries()].reduce<Record<string, string | string[]>>(
+    (acc, [key, value]) => {
+      const existing = acc[key];
+      if (existing === undefined) return { ...acc, [key]: value };
+
+      return {
+        ...acc,
+        [key]: Array.isArray(existing)
+          ? [...existing, value]
+          : [existing, value],
+      };
+    },
+    {},
+  );
+
 export async function middleware(req: NextRequest, event: NextFetchEvent) {
   const res = await fetch(env.NEXT_PUBLIC_BASE_URL + "/api/short-links", {
     method: "POST",
@@ -22,6 +38,7 @@ export async function middleware(req: NextRequest, event: NextFetchEvent) {
         id: shortLink.id,
         slug: shortLink.slug,
         link: shortLink.link,
+        headers: headersToObject(req.headers),
       }),
     );
     return NextResponse.redirect(shortLink.link);

--- a/apps/website/src/pages/api/short-links/track-click.ts
+++ b/apps/website/src/pages/api/short-links/track-click.ts
@@ -8,20 +8,21 @@ const trackClickSchema = z.object({
   id: z.string().cuid(),
   slug: z.string(),
   link: z.string(),
+  headers: z.record(z.union([z.string(), z.array(z.string())])),
 });
 export type TrackClickSchema = z.infer<typeof trackClickSchema>;
 
 //API for short links tracking
 export default createTokenProtectedApiHandler(
   trackClickSchema,
-  async ({ id, slug, link }) => {
+  async ({ id, slug, link, headers }) => {
     try {
       await prisma.shortLinksTracking.upsert({
         where: { id },
         create: { id, clicks: 1 },
         update: { clicks: { increment: 1 } },
       });
-      await track("Short link clicked", { id, slug, link });
+      await track("Short link clicked", { slug, link }, { headers });
       return true;
     } catch (e) {
       console.error("Failed to track click", e);

--- a/apps/website/src/pages/api/short-links/track-click.ts
+++ b/apps/website/src/pages/api/short-links/track-click.ts
@@ -1,20 +1,27 @@
 import { z } from "zod";
+import { track } from "@vercel/analytics/server";
+
 import { prisma } from "@/server/db/client";
 import { createTokenProtectedApiHandler } from "@/server/utils/api";
 
-const trackClickSchema = z.object({ id: z.string().cuid() });
+const trackClickSchema = z.object({
+  id: z.string().cuid(),
+  slug: z.string(),
+  link: z.string(),
+});
 export type TrackClickSchema = z.infer<typeof trackClickSchema>;
 
 //API for short links tracking
 export default createTokenProtectedApiHandler(
   trackClickSchema,
-  async (options) => {
+  async ({ id, slug, link }) => {
     try {
       await prisma.shortLinksTracking.upsert({
-        where: { id: options.id },
-        create: { id: options.id, clicks: 1 },
+        where: { id },
+        create: { id, clicks: 1 },
         update: { clicks: { increment: 1 } },
       });
+      await track("Short link clicked", { id, slug, link });
       return true;
     } catch (e) {
       console.error("Failed to track click", e);


### PR DESCRIPTION
## Describe your changes

To give us better visibility into the clicks through the short link system, hook it into the Vercel analytics system that we have access to with the site.

Per https://github.com/vercel/analytics/issues/88, it looks like we can pass through the request headers to improve what data Vercel can show.

## Notes for testing your change

Vercel now tracks short link clicks as custom events.