### PR TITLE
Make collab event category specific to Alveus

### DIFF
--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -6,10 +6,13 @@ type StandardCategory = {
 export const standardCategories: StandardCategory[] = [
   { name: "Alveus Regular Stream", color: "bg-yellow-400 hover:bg-yellow-600" },
   { name: "Alveus Special Stream", color: "bg-green-300 hover:bg-green-500" },
+  {
+    name: "Alveus Collaboration Stream",
+    color: "bg-blue-300 hover:bg-blue-500",
+  },
   { name: "Alveus YouTube Video", color: "bg-red-300 hover:bg-red-500" },
   { name: "Maya Regular Stream", color: "bg-gray-200 hover:bg-gray-400" },
   { name: "Maya YouTube Video", color: "bg-red-200 hover:bg-red-400" },
-  { name: "Collaboration Stream", color: "bg-blue-300 hover:bg-blue-500" },
 ] as const;
 
 export const getStandardCategoryColor = (category: string) =>

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -11,7 +11,7 @@ export const standardCategories: StandardCategory[] = [
     color: "bg-blue-300 hover:bg-blue-500",
   },
   { name: "Alveus YouTube Video", color: "bg-red-300 hover:bg-red-500" },
-  { name: "Maya Regular Stream", color: "bg-gray-200 hover:bg-gray-400" },
+  { name: "Maya Stream", color: "bg-gray-200 hover:bg-gray-400" },
   { name: "Maya YouTube Video", color: "bg-red-200 hover:bg-red-400" },
 ] as const;
 


### PR DESCRIPTION
## Describe your changes

In preparation for #782, disambiguate the event categories so it is clear which ones should be synced to the Alveus Twitch schedule.

This will need a migration run against prod, smth along the lines of (please check this):

```sql
UPDATE CalendarEvent SET category = "Alveus Collaboration Stream" WHERE category = "Collaboration Stream";
UPDATE CalendarEvent SET category = "Maya Stream" WHERE category = "Maya Regular Stream";
```

## Notes for testing your change

Categories can still be selected/set correctly.
