### PR TITLE
Fix event category filtering for stream overlay

### DIFF
--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -124,12 +124,10 @@ const OverlayPage: NextPage = () => {
   );
   const firstEventId = useMemo(
     () =>
-      events?.find((event) =>
-        [
-          "alveus regular stream",
-          "alveus special stream",
-          "collaboration stream",
-        ].includes(event.category.toLowerCase()),
+      events?.find(
+        (event) =>
+          /\balveus\b/i.test(event.category) &&
+          !/\b(yt|youtube)\b/i.test(event.category),
       )?.id,
     [events],
   );


### PR DESCRIPTION
## Describe your changes

Side effect of #807, collabs were no longer showing on the overlay. Made the logic more generic to show everything that is in an alveus category, except for YT videos.

## Notes for testing your change

Events show as expected on the overlay.