### PR TITLE
Validate + refresh Twitch auth tokens for accounts

### DIFF
--- a/apps/website/prisma/schema.prisma
+++ b/apps/website/prisma/schema.prisma
@@ -67,6 +67,7 @@ model Account {
   refresh_token     String? @db.Text
   access_token      String? @db.Text
   expires_at        Int?
+  verified_at       Int?
   token_type        String?
   scope             String?
   id_token          String? @db.Text

--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -6,6 +6,7 @@ import {
   cloneElement,
   forwardRef,
   Fragment,
+  useEffect,
   type ReactElement,
 } from "react";
 
@@ -65,6 +66,11 @@ export function DesktopMenu() {
     user &&
     (user.isSuperUser ||
       checkRolesGivePermission(user.roles, permissions.viewDashboard));
+
+  // If we have an invalid session (such as a deleted Twitch account), sign out
+  useEffect(() => {
+    if (sessionData?.error) signOut();
+  }, [sessionData?.error]);
 
   return (
     <div className="hidden flex-grow flex-col gap-2 lg:flex">

--- a/apps/website/src/data/scheduled-tasks.ts
+++ b/apps/website/src/data/scheduled-tasks.ts
@@ -4,6 +4,7 @@ import { cleanupExpiredNotificationPushes } from "@/server/db/notifications";
 import { retryOutgoingWebhooks } from "@/server/outgoing-webhooks";
 import { OUTGOING_WEBHOOK_TYPE_DISCORD_CHANNEL } from "@/server/discord";
 import { createRegularCalendarEvents } from "@/server/db/calendar-events";
+import { refreshTwitchChannels } from "@/server/db/twitch-channels";
 
 export type ScheduledTasksConfig = {
   tasks: {
@@ -60,6 +61,13 @@ export const scheduledTasks: ScheduledTasksConfig = {
       label: "Calendar events: Create Regular Events",
       startDateTime: new Date(2024, 7, 21, 0, 8, 0),
       interval: { months: 1 },
+    },
+    {
+      id: "auth.refreshTwitchChannels",
+      task: () => refreshTwitchChannels(),
+      label: "Auth: Refresh Twitch channels access",
+      startDateTime: new Date(2024, 9, 30, 0, 0, 0),
+      interval: { minutes: 30 },
     },
   ],
 };

--- a/apps/website/src/pages/api/auth/[...nextauth].ts
+++ b/apps/website/src/pages/api/auth/[...nextauth].ts
@@ -33,27 +33,37 @@ type ProfileData = {
 export const authOptions: NextAuthOptions = {
   callbacks: {
     session: async function ({ session, user }) {
-      // Check the user's access token is valid, refresh if not
+      // If we're over an hour since we last verified the Twitch token, check it
       const token = await prisma.account.findFirst({
         where: { userId: user.id, provider: "twitch" },
-        select: { id: true, access_token: true, refresh_token: true },
+        select: {
+          id: true,
+          access_token: true,
+          refresh_token: true,
+          verified_at: true,
+        },
       });
       if (token?.access_token && token?.refresh_token) {
-        try {
-          await refreshAccessToken(
-            "twitch",
-            env.TWITCH_CLIENT_ID,
-            env.TWITCH_CLIENT_SECRET,
-            token.id,
-            token.access_token,
-            token.refresh_token,
-          );
-        } catch (err) {
-          if (!(err instanceof ExpiredAccessTokenError)) console.error(err);
-          return {
-            expires: new Date(0).toISOString(),
-            error: "Twitch auth expired",
-          };
+        if (
+          !token.verified_at ||
+          token.verified_at < Math.floor(Date.now() / 1000) - 60 * 60
+        ) {
+          try {
+            await refreshAccessToken(
+              "twitch",
+              env.TWITCH_CLIENT_ID,
+              env.TWITCH_CLIENT_SECRET,
+              token.id,
+              token.access_token,
+              token.refresh_token,
+            );
+          } catch (err) {
+            if (!(err instanceof ExpiredAccessTokenError)) console.error(err);
+            return {
+              expires: new Date(0).toISOString(),
+              error: "Twitch auth expired",
+            };
+          }
         }
       }
 
@@ -98,6 +108,7 @@ export const authOptions: NextAuthOptions = {
             data: {
               access_token: account.access_token,
               expires_at: account.expires_at,
+              verified_at: Math.floor(Date.now() / 1000),
               id_token: account.id_token,
               refresh_token: account.refresh_token,
               session_state: account.session_state,

--- a/apps/website/src/server/db/twitch-channels.ts
+++ b/apps/website/src/server/db/twitch-channels.ts
@@ -1,4 +1,6 @@
+import { env } from "@/env";
 import { prisma } from "@/server/db/client";
+import { refreshAccessToken } from "@/server/utils/oauth2";
 
 export async function getTwitchChannels() {
   return prisma.twitchChannel.findMany({
@@ -49,4 +51,47 @@ export async function deleteTwitchChannel(channelId: string) {
   return prisma.twitchChannel.delete({
     where: { channelId },
   });
+}
+
+export async function refreshTwitchChannels() {
+  const channels = await getTwitchChannels();
+  const accounts = channels
+    .map((channel) => [channel.broadcasterAccount, channel.moderatorAccount])
+    .flat();
+
+  const seen = new Set<string>();
+  for (const account of accounts) {
+    // Handle a channel not having a linked account
+    if (!account) continue;
+
+    // Handle a tied account not having tokens for some reason
+    if (!account.access_token || !account.refresh_token) {
+      console.log(
+        `Skipping refresh for ${account.id} - missing access token or refresh token`,
+      );
+      continue;
+    }
+
+    // Handle the same account being tied to multiple channels
+    if (seen.has(account.id)) continue;
+    seen.add(account.id);
+
+    await refreshAccessToken(
+      "twitch",
+      env.TWITCH_CLIENT_ID,
+      env.TWITCH_CLIENT_SECRET,
+      account.id,
+      account.access_token,
+      account.refresh_token,
+      // Force the refresh if we're within 1hr of expiry
+      !!(
+        account.expires_at && account.expires_at - Date.now() / 1000 < 60 * 60
+      ),
+    ).catch((err) => {
+      console.error(
+        `Error refreshing access token for account ${account.id}:`,
+        err,
+      );
+    });
+  }
 }

--- a/apps/website/src/server/utils/oauth2.ts
+++ b/apps/website/src/server/utils/oauth2.ts
@@ -79,6 +79,8 @@ export async function refreshAccessToken(
     access_token?: string;
     refresh_token?: string;
     expires_at?: number;
+    scope?: string;
+    token_type?: string;
   }>((resolve) => {
     oauth2.getOAuthAccessToken(
       refreshToken,
@@ -87,7 +89,16 @@ export async function refreshAccessToken(
         const expires_at = results?.expires_in
           ? Math.floor(Date.now() / 1000) + results.expires_in
           : undefined;
-        resolve({ error, access_token, refresh_token, expires_at });
+        const scope = results?.scope?.join(" ");
+        const token_type = results?.token_type;
+        resolve({
+          error,
+          access_token,
+          refresh_token,
+          expires_at,
+          scope,
+          token_type,
+        });
       },
     );
   });
@@ -102,6 +113,8 @@ export async function refreshAccessToken(
       access_token: res.access_token,
       refresh_token: res.refresh_token,
       expires_at: res.expires_at,
+      scope: res.scope,
+      token_type: res.token_type,
     },
   });
   return res.access_token;

--- a/apps/website/src/types/next-auth.d.ts
+++ b/apps/website/src/types/next-auth.d.ts
@@ -10,5 +10,6 @@ declare module "next-auth" {
       roles: string[];
       isSuperUser: boolean;
     } & DefaultSession["user"];
+    error?: string;
   }
 }


### PR DESCRIPTION
## Describe your changes

Should resolve #450 as we are continually validating and attempting to refresh the Twitch token. If the token is expired for any reason and we fail to refresh, we'll force the session to be signed out.

In preparation for #782, this also adds a cron job that more proactively refreshes the Twitch tokens for configured accounts in the DB -- if we're getting near the expiry we'll attempt a refresh, and if not, we'll run the same validate/refresh check as with sessions.

## Notes for testing your change

Authenticate website locally. While authenticated, in a new tab, access your Twitch settings and disconnect the OAuth app. Observe signed out of website.

Configure a Twitch channel and link your account to it in the admin UI. Wait for the expiry to get within 1hr, or update the timestamp in the DB to be within 1hr of now. Hit the cron endpoint with auth. Observe token refreshed and expiry time updated in admin UI.