### PR TITLE
Improve Show and Tell location (centroids & shorter names)

### DIFF
--- a/apps/website/src/components/shared/form/MapPickerField.tsx
+++ b/apps/website/src/components/shared/form/MapPickerField.tsx
@@ -172,10 +172,10 @@ export const MapPickerField = ({
           ({
             result: {
               geometry: { coordinates },
-              place_name,
+              text,
             },
           }) => {
-            handleLocationSet(map, coordinates[1], coordinates[0], place_name);
+            handleLocationSet(map, coordinates[1], coordinates[0], text);
           },
         ),
       )

--- a/apps/website/src/utils/geolocation.ts
+++ b/apps/website/src/utils/geolocation.ts
@@ -110,7 +110,6 @@ const forwardGeocode = async (
     const url = new URL("https://nominatim.openstreetmap.org/search");
     url.searchParams.append("q", String(config.query));
     url.searchParams.append("format", "geojson");
-    url.searchParams.append("polygon_geoData", "1");
     url.searchParams.append("addressdetails", "1");
     url.searchParams.append("accept-language", "en-US,en");
 
@@ -121,14 +120,12 @@ const forwardGeocode = async (
       const point: CarmenGeojsonFeature = {
         id: feature.properties.placeid,
         type: "Feature",
-        geometry: {
-          type: "Point",
-          coordinates: [feature.bbox[0], feature.bbox[1]],
-        },
+        geometry: feature.geometry,
         properties: feature.properties,
         place_name: feature.properties.display_name,
         place_type: ["place"],
-        text: feature.properties.display_name,
+        text: createAddress(feature.properties.address),
+        bbox: feature.bbox,
       };
       features.push(point);
     }
@@ -175,7 +172,8 @@ const reverseGeocode = async (
           properties: feature.properties,
           place_name: feature.properties.display_name,
           place_type: ["place"],
-          text: feature.properties.display_name,
+          language: "en",
+          text: createAddress(feature.properties.address),
         };
         features.push(point);
       }


### PR DESCRIPTION
## Describe your changes

This will make the map search use a shorter name for locations consistent with the reverse geocode and use the centroid instead of south-east bounding box coordinate.

This also makes the map zoom to the bounding box when available.

See #796

## Notes for testing your change

Check every type of map input still works as expected: Select on map, search by text (point of interest, address, area/region).