### PR TITLE
Add Maya to Twitch schedule syncing

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -351,10 +351,25 @@ const config = {
       destination: "https://www.youtube.com/AlveusSanctuary/live",
       permanent: true,
     },
+    // TODO: Drive this from twitchChannels in @/data/calendar-events (store id + a default flag)
     {
       source: "/updates/ical",
       destination:
         "https://api.twitch.tv/helix/schedule/icalendar?broadcaster_id=636587384",
+      permanent: true,
+    },
+    // TODO: Drive this from twitchChannels in @/data/calendar-events (store id)
+    {
+      source: "/updates/ical/alveus",
+      destination:
+        "https://api.twitch.tv/helix/schedule/icalendar?broadcaster_id=636587384",
+      permanent: true,
+    },
+    // TODO: Drive this from twitchChannels in @/data/calendar-events (store id)
+    {
+      source: "/updates/ical/maya",
+      destination:
+        "https://api.twitch.tv/helix/schedule/icalendar?broadcaster_id=235835559",
       permanent: true,
     },
   ],

--- a/apps/website/src/components/calendar/Schedule.tsx
+++ b/apps/website/src/components/calendar/Schedule.tsx
@@ -31,8 +31,10 @@ const groupedCategories = standardCategories.reduce(
   {} as Record<string, { name: string; color: string }[]>,
 );
 
+// TODO: Drive this from twitchChannels in @/data/calendar-events (once the redirects themselves are driven from there)
 const webcalUrls: Record<string, string> = {
   Alveus: `${getShortBaseUrl().replace(/^((https?:)?\/\/)?/, "webcal://")}/updates/ical`,
+  Maya: `${getShortBaseUrl().replace(/^((https?:)?\/\/)?/, "webcal://")}/updates/ical/maya`,
 };
 
 export function Schedule() {

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -53,6 +53,12 @@ export const twitchChannels = {
       /^alveus\b/i.test(event.category) &&
       !/\b(yt|youtube)\b/i.test(event.category),
   },
+  maya: {
+    username: "Maya",
+    filter: (event: CalendarEvent) =>
+      /^maya\b/i.test(event.category) &&
+      !/\b(yt|youtube)\b/i.test(event.category),
+  },
 } as const satisfies Record<
   string,
   { username: string; filter: (event: CalendarEvent) => boolean }

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -46,10 +46,17 @@ export const frequentLinks: FrequentLink[] = [
   },
 ] as const;
 
-// Used for the overlay + Twitch sync, showing all Alveus events that aren't YT videos
-export const isAlveusEvent = (event: CalendarEvent) =>
-  /\balveus\b/i.test(event.category) &&
-  !/\b(yt|youtube)\b/i.test(event.category);
+export const twitchChannels = {
+  alveus: {
+    username: "AlveusSanctuary",
+    filter: (event: CalendarEvent) =>
+      /^alveus\b/i.test(event.category) &&
+      !/\b(yt|youtube)\b/i.test(event.category),
+  },
+} as const satisfies Record<
+  string,
+  { username: string; filter: (event: CalendarEvent) => boolean }
+>;
 
 const truncate = (value: string, max: number) => {
   if (value.length <= max) return value;
@@ -62,10 +69,14 @@ const truncate = (value: string, max: number) => {
   return value.slice(0, max - 3) + "…";
 };
 
-// Used for the overlay + Twitch sync, showing the title + link (if not Alveus Twitch)
-export const getFormattedTitle = (event: CalendarEvent, length?: number) => {
+// Used for the overlay + Twitch sync, showing the title + link (if not the Twitch channel)
+export const getFormattedTitle = (
+  event: CalendarEvent,
+  channel: string,
+  length?: number,
+) => {
   const title = length ? truncate(event.title, length) : event.title;
-  return /twitch.tv\/alveussanctuary/i.test(event.link)
+  return new RegExp(`twitch\\.tv\\/${channel}`, "i").test(event.link)
     ? title
     : `${title} @ ${event.link.toLowerCase().replace(/^(https?:)?\/\/(www\.)?/, "")}`;
 };

--- a/apps/website/src/data/scheduled-tasks.ts
+++ b/apps/website/src/data/scheduled-tasks.ts
@@ -66,9 +66,9 @@ export const scheduledTasks: ScheduledTasksConfig = {
       interval: { months: 1 },
     },
     {
-      id: "calendarEvents.twitch",
-      task: () => syncTwitchSchedule(),
-      label: "Calendar events: Sync Twitch Schedule",
+      id: "calendarEvents.twitch.alveus",
+      task: () => syncTwitchSchedule("alveus"),
+      label: "Calendar events: Sync Twitch Schedule (Alveus)",
       startDateTime: new Date(2024, 9, 30, 0, 0, 0),
       interval: { minutes: 10 },
     },

--- a/apps/website/src/data/scheduled-tasks.ts
+++ b/apps/website/src/data/scheduled-tasks.ts
@@ -1,13 +1,18 @@
 import { cleanupFileStorage } from "@/server/file-storage/cleanup";
 import { retryPendingNotificationPushes } from "@/server/notifications";
-import { cleanupExpiredNotificationPushes } from "@/server/db/notifications";
 import { retryOutgoingWebhooks } from "@/server/outgoing-webhooks";
 import { OUTGOING_WEBHOOK_TYPE_DISCORD_CHANNEL } from "@/server/discord";
+
 import {
   createRegularCalendarEvents,
   syncTwitchSchedule,
 } from "@/server/db/calendar-events";
 import { refreshTwitchChannels } from "@/server/db/twitch-channels";
+import { cleanupExpiredNotificationPushes } from "@/server/db/notifications";
+
+import { typeSafeObjectKeys } from "@/utils/helpers";
+
+import { twitchChannels } from "@/data/calendar-events";
 
 export type ScheduledTasksConfig = {
   tasks: {
@@ -65,13 +70,13 @@ export const scheduledTasks: ScheduledTasksConfig = {
       startDateTime: new Date(2024, 7, 21, 0, 8, 0),
       interval: { months: 1 },
     },
-    {
-      id: "calendarEvents.twitch.alveus",
-      task: () => syncTwitchSchedule("alveus"),
-      label: "Calendar events: Sync Twitch Schedule (Alveus)",
+    ...typeSafeObjectKeys(twitchChannels).map((channel) => ({
+      id: `calendarEvents.twitch.${channel}`,
+      task: () => syncTwitchSchedule(channel),
+      label: `Calendar events: Sync Twitch Schedule (${channel})`,
       startDateTime: new Date(2024, 9, 30, 0, 0, 0),
       interval: { minutes: 10 },
-    },
+    })),
     {
       id: "auth.refreshTwitchChannels",
       task: () => refreshTwitchChannels(),

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -10,7 +10,7 @@ import {
   formatDateTimeParts,
   formatDateTimeRelative,
 } from "@/utils/datetime";
-import { getFormattedTitle, isAlveusEvent } from "@/data/calendar-events";
+import { getFormattedTitle, twitchChannels } from "@/data/calendar-events";
 
 import logoImage from "@/assets/logo.png";
 
@@ -129,7 +129,10 @@ const OverlayPage: NextPage = () => {
     { start: upcomingRange?.[0], end: upcomingRange?.[1] },
     { enabled: upcomingRange !== undefined, placeholderData: keepPreviousData },
   );
-  const firstEventId = useMemo(() => events?.find(isAlveusEvent)?.id, [events]);
+  const firstEventId = useMemo(
+    () => events?.find(twitchChannels.alveus.filter)?.id,
+    [events],
+  );
 
   // If we have an upcoming event, swap socials with it
   // Swap every 60s
@@ -175,7 +178,9 @@ const OverlayPage: NextPage = () => {
 
           {event && (
             <>
-              <p className="text-xl">{getFormattedTitle(event, 30)}</p>
+              <p className="text-xl">
+                {getFormattedTitle(event, twitchChannels.alveus.username, 30)}
+              </p>
               <p className="text-xl">
                 {formatDateTimeRelative(
                   event.startAt,


### PR DESCRIPTION
## Describe your changes

Resolves #834 by abstracting the Twitch syncing logic into an object constant where any channel can be defined, and adds Maya's channel to said object.

The TODO comments in this PR are to be left in for future work -- I think once we're on Next.js 15 we can use TS for the Next.js config, which'll allow us to import the twitchChannels data from source.

## Notes for testing your change

- Add Alveus + Maya events to the calendar
- Have the alveussanctuary channel defined in /admin/twitch and linked to the AlveusGG account
- Do not have the maya channel linked
- Run the cron task
- Observe only Alveus events synced to AlveusGG Twitch
- Have the maya channel defined in /admin/twitch and linked to the AlveusGG account
- Do not have the alveussanctuary channel linked
- Run the cron task
- Observe only Maya events synced to AlveusGG Twitch
