### PR TITLE
Allow for Twitch schedule segments to be nullable

### DIFF
--- a/apps/website/src/components/content/WatchLive.tsx
+++ b/apps/website/src/components/content/WatchLive.tsx
@@ -1,12 +1,5 @@
-import { Fragment } from "react";
 import Link from "next/link";
-import {
-  Menu,
-  MenuButton,
-  MenuItems,
-  MenuItem,
-  Transition,
-} from "@headlessui/react";
+import { Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/react";
 
 import IconChevronDown from "@/icons/IconChevronDown";
 

--- a/apps/website/src/server/db/calendar-events.ts
+++ b/apps/website/src/server/db/calendar-events.ts
@@ -186,11 +186,9 @@ async function getTwitchSchedule(
       start,
       cursor,
     );
-    // no segments found
-    if (response === null) {
-      break;
-    }
-    segments.push(...response.data.segments);
+    if (response === null) break;
+
+    segments.push(...(response.data.segments || []));
 
     cursor = response.pagination.cursor;
     if (!cursor) break;


### PR DESCRIPTION
## Describe your changes

Fixes an issue we've observed in production where `data.segments` can be `null` when fetching the channel's schedule (this is happening when the event count perfectly lines up with the page size).

## Notes for testing your change

Alveus seems to be hitting this currently in production, so you can override line 229 of `apps/website/src/server/db/calendar-events.ts` (the `getTwitchSchedule` call) to pass the Alveus channel ID specifically (`636587384`), and then observe this happening with some additional logging or by reverting the schema change in this PR.