### PR TITLE
Remove invalid MIME type

### DIFF
--- a/apps/website/src/utils/files.ts
+++ b/apps/website/src/utils/files.ts
@@ -1,6 +1,5 @@
 export type ImageMimeType = (typeof imageMimeTypes)[number];
 export const imageMimeTypes = [
-  "image/jpg",
   "image/jpeg",
   "image/png",
   "image/gif",


### PR DESCRIPTION
Found out the convoluted way that a canvas converts an image to image/png when an unsupported MIME type is provided.

I'm not sure of everywhere these types are used or what knock-on effects this could have.