### PR TITLE
Add config for weekly dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+      time: 00:00
+
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /apps/*
+    schedule:
+      interval: weekly
+      day: wednesday
+      time: 00:00
+
+    # Ensure the new version is stored in `package.json`
+    versioning-strategy: increase
+
+    # Update `dependencies` and `devDependencies` separately
+    groups:
+      production:
+        dependency-type: production
+      development:
+        dependency-type: development
+
+    # Manually update major versions of `@types/node` with the version specified within .nvmrc
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## Describe your changes

Each Wednesday at midnight UTC, will create the following PRs (if needed):

- Update versions of any GitHub Actions being used
- Update the versions of any development dependencies being used
- Update the versions of any production dependencies being used

## Notes for testing your change

Syntax is all valid per https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file, and defines the policy as described above.