### PR TITLE
Fix incorrect overflow-clip replacements

### DIFF
--- a/apps/website/src/components/content/Slideshow.tsx
+++ b/apps/website/src/components/content/Slideshow.tsx
@@ -119,7 +119,7 @@ const Slideshow = ({
       {images.map(({ src, alt }, idx) => (
         <div
           // eslint-disable-next-line tailwindcss/no-custom-classname
-          className={`absolute inset-0 z-0 text-clip opacity-0 slideshow-${id}-container`}
+          className={`absolute inset-0 z-0 overflow-clip opacity-0 slideshow-${id}-container`}
           key={
             typeof src === "string"
               ? src

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -283,7 +283,7 @@ const Home: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
       </div>
 
       <div className="relative">
-        <div className="pointer-events-none absolute -top-64 bottom-0 right-0 z-10 hidden h-auto w-1/2 max-w-sm select-none text-clip lg:block xl:max-w-md 2xl:max-w-lg">
+        <div className="pointer-events-none absolute -top-64 bottom-0 right-0 z-10 hidden h-auto w-1/2 max-w-sm select-none overflow-clip lg:block xl:max-w-md 2xl:max-w-lg">
           <Image
             src={leafRightImage1}
             alt=""

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "pnpm": {
     "patchedDependencies": {
-      "next@15.0.3": "patches/next@15.0.3.patch"
+      "next@15.0.3": "patches/next@15.0.3.patch",
+      "eslint-plugin-tailwindcss@3.17.5": "patches/eslint-plugin-tailwindcss@3.17.5.patch"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/patches/eslint-plugin-tailwindcss@3.17.5.patch
+++ b/patches/eslint-plugin-tailwindcss@3.17.5.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/rules/migration-from-tailwind-2.js b/lib/rules/migration-from-tailwind-2.js
+index 5de0f0f72dae06e27ce28e035f350320a1cc8ebb..01d3a2e05503464a4ef602bb4a5c5e38767f768d 100644
+--- a/lib/rules/migration-from-tailwind-2.js
++++ b/lib/rules/migration-from-tailwind-2.js
+@@ -168,9 +168,9 @@ module.exports = {
+           notNeeded.push(cls);
+           return false;
+         }
+-        let overflowRes = /^overflow\-(?<value>clip|ellipsis)$/i.exec(suffix);
++        let overflowRes = /^overflow\-(?<value>ellipsis)$/i.exec(suffix);
+         if (overflowRes && overflowRes.groups && overflowRes.groups.value) {
+-          outdated.push([cls, cls.replace(/overflow\-(clip|ellipsis)$/i, `text-${overflowRes.groups.value}`)]);
++          outdated.push([cls, cls.replace(/overflow\-(ellipsis)$/i, `text-${overflowRes.groups.value}`)]);
+         }
+         let growShrinkRes = /flex\-(?<prop>grow|shrink)(\-(?<value>${flexVal}))?/i.exec(suffix);
+         if (growShrinkRes && growShrinkRes.groups && growShrinkRes.groups.prop) {

--- a/patches/eslint-plugin-tailwindcss@3.17.5.patch
+++ b/patches/eslint-plugin-tailwindcss@3.17.5.patch
@@ -1,3 +1,4 @@
+# FIXME: https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/294
 diff --git a/lib/rules/migration-from-tailwind-2.js b/lib/rules/migration-from-tailwind-2.js
 index 5de0f0f72dae06e27ce28e035f350320a1cc8ebb..01d3a2e05503464a4ef602bb4a5c5e38767f768d 100644
 --- a/lib/rules/migration-from-tailwind-2.js

--- a/patches/next@15.0.3.patch
+++ b/patches/next@15.0.3.patch
@@ -1,3 +1,4 @@
+# FIXME: https://github.com/vercel/satori/issues/565 / https://github.com/vercel/next.js/issues/72940
 diff --git a/dist/compiled/@vercel/og/index.edge.js b/dist/compiled/@vercel/og/index.edge.js
 index 089354ce4b62dde0fed3482e028ffade3d34b750..8d9115fc53d7a6d0eadc503cbc9fe50b138172ab 100644
 --- a/dist/compiled/@vercel/og/index.edge.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,10 @@ settings:
 
 patchedDependencies:
   eslint-plugin-tailwindcss@3.17.5:
-    hash: 6p7xycybtm4qe4kjmz2abkycuq
+    hash: ffbd4ayk5rqu3ipt6gp4marery
     path: patches/eslint-plugin-tailwindcss@3.17.5.patch
   next@15.0.3:
-    hash: uaqwqsvig2nsfzybtsjtwbchce
+    hash: d57ahejkwqwc465a6f2woe2etq
     path: patches/next@15.0.3.patch
 
 importers:
@@ -115,7 +115,7 @@ importers:
         version: 1.7.0(maplibre-gl@4.7.1)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.10(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.10(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@next/env':
         specifier: ^15.0.3
         version: 15.0.3
@@ -139,7 +139,7 @@ importers:
         version: 11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@trpc/next':
         specifier: 11.0.0-rc.638
-        version: 11.0.0-rc.638(@tanstack/react-query@5.60.6(react@18.3.1))(@trpc/client@11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@trpc/react-query@11.0.0-rc.638(@tanstack/react-query@5.60.6(react@18.3.1))(@trpc/client@11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 11.0.0-rc.638(@tanstack/react-query@5.60.6(react@18.3.1))(@trpc/client@11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@trpc/react-query@11.0.0-rc.638(@tanstack/react-query@5.60.6(react@18.3.1))(@trpc/client@11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@trpc/react-query':
         specifier: 11.0.0-rc.638
         version: 11.0.0-rc.638(@tanstack/react-query@5.60.6(react@18.3.1))(@trpc/client@11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -148,7 +148,7 @@ importers:
         version: 11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vercel/analytics':
         specifier: ^1.4.0
-        version: 1.4.0(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 1.4.0(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       country-list:
         specifier: ^2.3.0
         version: 2.3.0
@@ -184,16 +184,16 @@ importers:
         version: 4.7.1
       next:
         specifier: ^15.0.3
-        version: 15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.10
-        version: 4.24.10(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.10(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.2.3(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       next-superjson:
         specifier: ^1.0.7
-        version: 1.0.7(@swc/helpers@0.5.13)(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(superjson@2.2.1)
+        version: 1.0.7(@swc/helpers@0.5.13)(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(superjson@2.2.1)
       oauth:
         specifier: ^0.10.0
         version: 0.10.0
@@ -353,7 +353,7 @@ importers:
         version: 5.0.0(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-tailwindcss:
         specifier: ^3.17.5
-        version: 3.17.5(patch_hash=6p7xycybtm4qe4kjmz2abkycuq)(tailwindcss@3.4.15)
+        version: 3.17.5(patch_hash=ffbd4ayk5rqu3ipt6gp4marery)(tailwindcss@3.4.15)
       file-type:
         specifier: ^19.6.0
         version: 19.6.0
@@ -7958,10 +7958,10 @@ snapshots:
       sort-object: 3.0.3
       tinyqueue: 3.0.0
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.10(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.10(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@prisma/client': 5.22.0(prisma@5.22.0)
-      next-auth: 4.24.10(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-auth: 4.24.10(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   '@next/env@13.5.6': {}
 
@@ -9483,11 +9483,11 @@ snapshots:
     dependencies:
       '@trpc/server': 11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@trpc/next@11.0.0-rc.638(@tanstack/react-query@5.60.6(react@18.3.1))(@trpc/client@11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@trpc/react-query@11.0.0-rc.638(@tanstack/react-query@5.60.6(react@18.3.1))(@trpc/client@11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@trpc/next@11.0.0-rc.638(@tanstack/react-query@5.60.6(react@18.3.1))(@trpc/client@11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@trpc/react-query@11.0.0-rc.638(@tanstack/react-query@5.60.6(react@18.3.1))(@trpc/client@11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@trpc/client': 11.0.0-rc.638(@trpc/server@11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@trpc/server': 11.0.0-rc.638(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      next: 15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -9507,7 +9507,7 @@ snapshots:
       '@types/aws-lambda': 8.10.145
       express: 4.21.1
       fastify: 5.1.0
-      next: 15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ws: 8.18.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -9937,9 +9937,9 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vercel/analytics@1.4.0(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/analytics@1.4.0(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   '@vitest/expect@2.1.5':
@@ -11179,7 +11179,7 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-tailwindcss@3.17.5(patch_hash=6p7xycybtm4qe4kjmz2abkycuq)(tailwindcss@3.4.15):
+  eslint-plugin-tailwindcss@3.17.5(patch_hash=ffbd4ayk5rqu3ipt6gp4marery)(tailwindcss@3.4.15):
     dependencies:
       fast-glob: 3.3.2
       postcss: 8.4.49
@@ -12515,13 +12515,13 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@4.24.10(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.10(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.23.9
       '@panva/hkdf': 1.1.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       oauth: 0.9.15
       openid-client: 5.6.4
       preact: 10.19.3
@@ -12530,31 +12530,31 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       uuid: 8.3.2
 
-  next-sitemap@4.2.3(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  next-sitemap@4.2.3(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.6
       fast-glob: 3.3.2
       minimist: 1.2.8
-      next: 15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  next-superjson-plugin@0.6.3(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(superjson@2.2.1):
+  next-superjson-plugin@0.6.3(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(superjson@2.2.1):
     dependencies:
       hoist-non-react-statics: 3.3.2
-      next: 15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       superjson: 2.2.1
 
-  next-superjson@1.0.7(@swc/helpers@0.5.13)(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(superjson@2.2.1):
+  next-superjson@1.0.7(@swc/helpers@0.5.13)(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(superjson@2.2.1):
     dependencies:
       '@swc/core': 1.4.17(@swc/helpers@0.5.13)
       '@swc/types': 0.1.12
-      next: 15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      next-superjson-plugin: 0.6.3(next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(superjson@2.2.1)
+      next: 15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-superjson-plugin: 0.6.3(next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(superjson@2.2.1)
     transitivePeerDependencies:
       - '@swc/helpers'
       - superjson
 
-  next@15.0.3(patch_hash=uaqwqsvig2nsfzybtsjtwbchce)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.0.3(patch_hash=d57ahejkwqwc465a6f2woe2etq)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 15.0.3
       '@swc/counter': 0.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  eslint-plugin-tailwindcss@3.17.5:
+    hash: 6p7xycybtm4qe4kjmz2abkycuq
+    path: patches/eslint-plugin-tailwindcss@3.17.5.patch
   next@15.0.3:
     hash: uaqwqsvig2nsfzybtsjtwbchce
     path: patches/next@15.0.3.patch
@@ -335,10 +338,10 @@ importers:
         version: 9.1.0(eslint@9.15.0(jiti@1.21.6))
       eslint-import-resolver-typescript:
         specifier: ^3.6.3
-        version: 3.6.3(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import-x@4.4.2(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6))
+        version: 3.6.3(eslint-plugin-import-x@4.4.2(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
+        version: 2.31.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-import-x:
         specifier: ^4.4.2
         version: 4.4.2(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
@@ -350,7 +353,7 @@ importers:
         version: 5.0.0(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-tailwindcss:
         specifier: ^3.17.5
-        version: 3.17.5(tailwindcss@3.4.15)
+        version: 3.17.5(patch_hash=6p7xycybtm4qe4kjmz2abkycuq)(tailwindcss@3.4.15)
       file-type:
         specifier: ^19.6.0
         version: 19.6.0
@@ -10956,19 +10959,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import-x@4.4.2(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6)):
+  eslint-import-resolver-typescript@3.6.3(eslint-plugin-import-x@4.4.2(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.15.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-import-x: 4.4.2(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -10976,14 +10979,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       eslint: 9.15.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import-x@4.4.2(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.3(eslint-plugin-import-x@4.4.2(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6))
     transitivePeerDependencies:
       - supports-color
 
@@ -11004,7 +11006,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6)):
+  eslint-plugin-import@2.31.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -11015,7 +11017,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.15.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -11026,8 +11028,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -11179,7 +11179,7 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-tailwindcss@3.17.5(tailwindcss@3.4.15):
+  eslint-plugin-tailwindcss@3.17.5(patch_hash=6p7xycybtm4qe4kjmz2abkycuq)(tailwindcss@3.4.15):
     dependencies:
       fast-glob: 3.3.2
       postcss: 8.4.49


### PR DESCRIPTION
## Describe your changes

Somehow missed that this happened in #852, sorry!

Turns out it is a bug in the ESLint Tailwind plugin (https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/294), so I've added a patch to fix it for now so we can still benefit from the other replacements the v2 -> v3 rule offers (I imagine I'm going to type `flex-grow` again in the future rather than just `grow`).

## Notes for testing your change

Homepage (and any other page) does not horizontally overflow.