### PR TITLE
Use videos playlist for YouTube feeds to exclude shorts

### DIFF
--- a/apps/website/src/components/content/YouTubeCarousel.tsx
+++ b/apps/website/src/components/content/YouTubeCarousel.tsx
@@ -1,17 +1,15 @@
 import { useState, useEffect } from "react";
-import { Lightbox, Preview } from "@/components/content/YouTube";
-import Heading from "@/components/content/Heading";
+
+import type { YouTubeVideo } from "@/server/utils/youtube-api";
+
 import { formatDateTime } from "@/utils/datetime";
 import { classes } from "@/utils/classes";
 
-type Video = {
-  videoId: string;
-  title: string;
-  published: Date;
-};
+import { Lightbox, Preview } from "@/components/content/YouTube";
+import Heading from "@/components/content/Heading";
 
 type YouTubeCarouselProps = {
-  videos: Video[];
+  videos: YouTubeVideo[];
   dark?: boolean;
 };
 
@@ -20,7 +18,7 @@ const YouTubeCarousel = ({ videos, dark }: YouTubeCarouselProps) => {
 
   useEffect(() => {
     const hash = window.location.hash.slice(1);
-    if (videos.some((video) => video.videoId === hash)) setOpen(hash);
+    if (videos.some((video) => video.id === hash)) setOpen(hash);
   }, [videos]);
 
   return (
@@ -35,22 +33,22 @@ const YouTubeCarousel = ({ videos, dark }: YouTubeCarouselProps) => {
           <div className="flex w-full flex-wrap justify-around">
             {videos.map((video) => (
               <div
-                key={video.videoId}
+                key={video.id}
                 className="mx-auto flex basis-full flex-col items-center justify-start p-2 md:basis-1/2 lg:basis-1/4"
               >
                 <Trigger
-                  videoId={video.videoId}
+                  videoId={video.id}
                   caption={`${video.title}: ${formatDateTime(video.published, {
                     style: "long",
                   })}`}
-                  triggerId={video.videoId}
+                  triggerId={video.id}
                   className="w-full max-w-2xl"
                 >
-                  <Preview videoId={video.videoId} />
+                  <Preview videoId={video.id} />
                 </Trigger>
                 <Heading
                   level={2}
-                  id={video.videoId}
+                  id={video.id}
                   className="text-center text-2xl"
                 >
                   {video.title}

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import type { GetStaticProps, NextPage, InferGetStaticPropsType } from "next";
+import type { NextPage, InferGetStaticPropsType } from "next";
 import Link from "next/link";
 import Image from "next/image";
 import { useEffect, useState } from "react";
@@ -143,7 +143,7 @@ const getTwitchEmbed = (
   return url.toString();
 };
 
-export const getStaticProps: GetStaticProps = async () => {
+export const getStaticProps = async () => {
   const channels = [
     // Alveus Sanctuary
     "UCbJ-1yM55NHrR1GS9hhPuvg",

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -7,8 +7,8 @@ import ambassadors from "@alveusgg/data/src/ambassadors/core";
 import { getAmbassadorImages } from "@alveusgg/data/src/ambassadors/images";
 import animalQuestEpisodes from "@alveusgg/data/src/animal-quest";
 
-import { parseStringPromise } from "xml2js";
-import { z } from "zod";
+import { fetchYouTubeVideos } from "@/server/utils/youtube-api";
+
 import { typeSafeObjectEntries } from "@/utils/helpers";
 import { camelToKebab } from "@/utils/string-case";
 import usePrefersReducedMotion from "@/hooks/motion";
@@ -143,61 +143,21 @@ const getTwitchEmbed = (
   return url.toString();
 };
 
-// Define the schema for the expected structure of the feed entries
-const VideoSchema = z.object({
-  videoId: z.string(),
-  title: z.string(),
-  published: z.date(),
-});
-
-type Video = z.infer<typeof VideoSchema>;
-
-// Define the schema for the entire feed
-const FeedSchema = z.object({
-  feed: z.object({
-    entry: z.array(
-      z.object({
-        "yt:videoId": z.array(z.string()).nonempty(),
-        title: z.array(z.string()).nonempty(),
-        published: z.array(z.string()).nonempty(),
-      }),
-    ),
-  }),
-});
-
-const fetchYouTubeFeed = async (channelId: string): Promise<Video[]> => {
-  const url = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch YouTube feed: ${response.statusText}`);
-  }
-
-  const xml = await response.text();
-  const json = await parseStringPromise(xml);
-  const parsedFeed = FeedSchema.parse(json);
-
-  return parsedFeed.feed.entry
-    .map((entry) => ({
-      videoId: entry["yt:videoId"][0],
-      title: entry.title[0],
-      published: new Date(entry.published[0]),
-    }))
-    .filter((video) => !video.title.includes("#shorts")) // exclude shorts
-    .map((video) => VideoSchema.parse(video));
-};
-
 export const getStaticProps: GetStaticProps = async () => {
-  const channelIds = ["UCbJ-1yM55NHrR1GS9hhPuvg", "UCfisf6HxiQr8_4mctNBm9cQ"];
-  const videosArrays = await Promise.all(
-    channelIds.map((channelId) => fetchYouTubeFeed(channelId)),
+  const channels = [
+    // Alveus Sanctuary
+    "UCbJ-1yM55NHrR1GS9hhPuvg",
+    // Alveus Sanctuary Highlights
+    "UCfisf6HxiQr8_4mctNBm9cQ",
+  ];
+  const latestVideos = await Promise.all(
+    channels.map((channelId) => fetchYouTubeVideos(channelId)),
+  ).then((feeds) =>
+    feeds
+      .flat()
+      .sort((a, b) => b.published.getTime() - a.published.getTime())
+      .slice(0, 4),
   );
-
-  // Combine videos from all channels and sort by published date
-  const combinedVideos = videosArrays
-    .flat()
-    .sort((a, b) => b.published.getTime() - a.published.getTime());
-  const latestVideos = combinedVideos.slice(0, 4);
 
   return {
     props: {

--- a/apps/website/src/server/utils/youtube-api.ts
+++ b/apps/website/src/server/utils/youtube-api.ts
@@ -1,0 +1,56 @@
+import { parseStringPromise } from "xml2js";
+import { z } from "zod";
+
+const FeedSchema = z.object({
+  feed: z.object({
+    entry: z.array(
+      z.object({
+        "yt:videoId": z.array(z.string()).nonempty(),
+        title: z.array(z.string()).nonempty(),
+        published: z.array(z.string()).nonempty(),
+      }),
+    ),
+  }),
+});
+
+export const fetchYouTubeFeed = async (
+  type: "channel" | "playlist",
+  id: string,
+) => {
+  const url = `https://www.youtube.com/feeds/videos.xml?${type}_id=${id}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch YouTube feed: ${response.statusText}`);
+  }
+
+  const xml = await response.text();
+  const json = await parseStringPromise(xml);
+  console.log(json);
+  return FeedSchema.parse(json).feed.entry;
+};
+
+export interface YouTubeVideo {
+  id: string;
+  title: string;
+  published: Date;
+}
+
+export const fetchYouTubeVideos = async (
+  channelId: string,
+): Promise<YouTubeVideo[]> => {
+  if (!channelId.startsWith("UC"))
+    throw new Error("Invalid YouTube channel ID");
+
+  // Get the built-in videos playlist for the channel
+  // This contains only long-form videos, not shorts or live streams (or VoDs)
+  // See https://stackoverflow.com/a/76602819 for other playlist prefixes
+  return fetchYouTubeFeed("playlist", channelId.replace(/^UC/, "UULF")).then(
+    (feed) =>
+      feed.map((entry) => ({
+        id: entry["yt:videoId"][0],
+        title: entry.title[0],
+        published: new Date(entry.published[0]),
+      })),
+  );
+};


### PR DESCRIPTION
## Describe your changes

A few of the recent shorts uploaded to the Alveus YouTube videos do not contain the `#shorts` tag that we had been relying on to filter them out.

After a bunch of digging, it turns out you can use a channel id to generate assorted playlist IDs, including a playlist that only contains a channel's long-form videos without shorts.

As a fun side benefit of this, this will also ensure we don't show the live cam feed (or a VoD) from the main YouTube channel.

## Notes for testing your change

YouTube feed on the homepage is showing recent videos from both channels, without any shorts or live streams.