### PR TITLE
Fix PopoverButton clipping with anchor positioning

### DIFF
--- a/apps/website/src/components/shared/AddEventButton.tsx
+++ b/apps/website/src/components/shared/AddEventButton.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import { PopoverButton as PopeoverButtonHeadless } from "@headlessui/react";
+import { PopoverButton as PopoverButtonHeadless } from "@headlessui/react";
 
 import { env } from "@/env";
 
@@ -103,7 +103,7 @@ export function AddEventButton({ event }: AddEventButtonProps) {
       }
     >
       <div className="flex gap-2">
-        <PopeoverButtonHeadless as={Fragment}>
+        <PopoverButtonHeadless as={Fragment}>
           <Button
             width="auto"
             size="small"
@@ -113,8 +113,8 @@ export function AddEventButton({ event }: AddEventButtonProps) {
             <IconGoogleCalendar className="mr-2 size-5" />
             Google
           </Button>
-        </PopeoverButtonHeadless>
-        <PopeoverButtonHeadless as={Fragment}>
+        </PopoverButtonHeadless>
+        <PopoverButtonHeadless as={Fragment}>
           <Button
             width="auto"
             size="small"
@@ -124,7 +124,7 @@ export function AddEventButton({ event }: AddEventButtonProps) {
             <IconOutlook className="mr-2 size-5" />
             Apple/Outlook
           </Button>
-        </PopeoverButtonHeadless>
+        </PopoverButtonHeadless>
       </div>
     </PopoverButton>
   );

--- a/apps/website/src/components/shared/PopoverButton.tsx
+++ b/apps/website/src/components/shared/PopoverButton.tsx
@@ -1,7 +1,7 @@
 import { Fragment, type MouseEventHandler, type ReactNode } from "react";
 import {
   Popover,
-  PopoverButton as PopeoverButtonHeadless,
+  PopoverButton as PopoverButtonHeadless,
   PopoverPanel,
 } from "@headlessui/react";
 import { Button, defaultButtonClasses } from "@/components/shared/form/Button";
@@ -19,7 +19,7 @@ export function PopoverButton({
     <Popover className="relative">
       {({ open }) => (
         <>
-          <PopeoverButtonHeadless as={Fragment}>
+          <PopoverButtonHeadless as={Fragment}>
             <Button
               width="auto"
               size="small"
@@ -32,7 +32,7 @@ export function PopoverButton({
             >
               {label}
             </Button>
-          </PopeoverButtonHeadless>
+          </PopoverButtonHeadless>
 
           <PopoverPanel
             className="z-20 mt-0.5 rounded bg-gray-800 p-2 text-white shadow-xl"

--- a/apps/website/src/components/shared/PopoverButton.tsx
+++ b/apps/website/src/components/shared/PopoverButton.tsx
@@ -16,34 +16,32 @@ export function PopoverButton({
   onClick?: MouseEventHandler;
 }) {
   return (
-    <div className="relative">
-      <Popover>
-        {({ open }) => (
-          <>
-            <PopeoverButtonHeadless as={Fragment}>
-              <Button
-                width="auto"
-                size="small"
-                onClick={onClick}
-                className={
-                  open
-                    ? defaultButtonClasses
-                    : "bg-gray-700/10 hover:bg-gray-700/20"
-                }
-              >
-                {label}
-              </Button>
-            </PopeoverButtonHeadless>
-
-            <PopoverPanel
-              className="absolute right-0 z-20 mt-0.5 rounded bg-gray-800 p-2 text-white shadow-xl"
-              modal={false}
+    <Popover className="relative">
+      {({ open }) => (
+        <>
+          <PopeoverButtonHeadless as={Fragment}>
+            <Button
+              width="auto"
+              size="small"
+              onClick={onClick}
+              className={
+                open
+                  ? defaultButtonClasses
+                  : "bg-gray-700/10 hover:bg-gray-700/20"
+              }
             >
-              {children}
-            </PopoverPanel>
-          </>
-        )}
-      </Popover>
-    </div>
+              {label}
+            </Button>
+          </PopeoverButtonHeadless>
+
+          <PopoverPanel
+            className="absolute right-0 z-20 mt-0.5 rounded bg-gray-800 p-2 text-white shadow-xl"
+            modal={false}
+          >
+            {children}
+          </PopoverPanel>
+        </>
+      )}
+    </Popover>
   );
 }

--- a/apps/website/src/components/shared/PopoverButton.tsx
+++ b/apps/website/src/components/shared/PopoverButton.tsx
@@ -35,7 +35,8 @@ export function PopoverButton({
           </PopeoverButtonHeadless>
 
           <PopoverPanel
-            className="absolute right-0 z-20 mt-0.5 rounded bg-gray-800 p-2 text-white shadow-xl"
+            className="z-20 mt-0.5 rounded bg-gray-800 p-2 text-white shadow-xl"
+            anchor="bottom end"
             modal={false}
           >
             {children}

--- a/apps/website/src/components/shared/form/Button.tsx
+++ b/apps/website/src/components/shared/form/Button.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { type ReactNode, type ButtonHTMLAttributes } from "react";
+import { type ReactNode, type ButtonHTMLAttributes, forwardRef } from "react";
 import type { LinkProps } from "next/link";
 import Link from "next/link";
 
@@ -59,35 +59,42 @@ export function LinkButton({
   );
 }
 
-export function Button({
-  children,
-  type = "button",
-  size = "default",
-  width = "full",
-  className = defaultButtonClasses,
-  confirmationMessage,
-  ...props
-}: ButtonProps) {
-  const buttonProps = { ...props };
-  if (confirmationMessage) {
-    buttonProps.onClick = (e) => {
-      if (confirm(confirmationMessage)) {
-        props.onClick?.(e);
-      } else {
-        e.preventDefault();
-      }
-    };
-  }
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      children,
+      type = "button",
+      size = "default",
+      width = "full",
+      className = defaultButtonClasses,
+      confirmationMessage,
+      ...props
+    },
+    ref,
+  ) => {
+    const buttonProps = { ...props };
+    if (confirmationMessage) {
+      buttonProps.onClick = (e) => {
+        if (confirm(confirmationMessage)) {
+          props.onClick?.(e);
+        } else {
+          e.preventDefault();
+        }
+      };
+    }
 
-  return (
-    <button
-      type={type}
-      className={`${baseClasses} ${getWidthClasses(width)} ${getSizeClasses(
-        size,
-      )} ${className}`}
-      {...buttonProps}
-    >
-      {children}
-    </button>
-  );
-}
+    return (
+      <button
+        type={type}
+        ref={ref}
+        className={`${baseClasses} ${getWidthClasses(width)} ${getSizeClasses(
+          size,
+        )} ${className}`}
+        {...buttonProps}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+Button.displayName = "Button";


### PR DESCRIPTION
## Describe your changes

Resolves #822 by relying on modern anchor positioning instead of absolute positioning

Applies to all usages of popover button, not just the announcement share button

## Notes for testing your change

- Pull branch down locally
- Run website
- Create test announcement
- Check share button works in Firefox (Uses fallback js positioning)
- Check share button works in Chrome (Uses anchor positioning)
