### PR TITLE
Use title case for calendar category groupings

### DIFF
--- a/apps/website/src/components/calendar/Schedule.tsx
+++ b/apps/website/src/components/calendar/Schedule.tsx
@@ -6,6 +6,7 @@ import { standardCategories, twitchChannels } from "@/data/calendar-events";
 import { classes } from "@/utils/classes";
 import { getShortBaseUrl } from "@/utils/short-url";
 import { typeSafeObjectEntries } from "@/utils/helpers";
+import { sentenceToTitle } from "@/utils/string-case";
 
 import Link from "@/components/content/Link";
 import {
@@ -91,7 +92,9 @@ export function Schedule() {
       {typeSafeObjectEntries(groupedCategories).map(([group, categories]) => (
         <div key={group}>
           <div className="mb-1 flex flex-wrap items-end justify-end gap-2">
-            <h4 className="mr-auto text-lg font-bold">{group}</h4>
+            <h4 className="mr-auto text-lg font-bold">
+              {sentenceToTitle(group)}
+            </h4>
 
             {webcalUrls[group] && (
               <>

--- a/apps/website/src/utils/string-case.ts
+++ b/apps/website/src/utils/string-case.ts
@@ -6,3 +6,6 @@ export const kebabToCamel = (str: string) =>
 
 export const sentenceToKebab = (str: string) =>
   str.replace(/\s+/g, "-").toLowerCase();
+
+export const sentenceToTitle = (str: string) =>
+  str.replace(/\b\w/g, (g) => g.toUpperCase());


### PR DESCRIPTION
## Describe your changes

While working on another PR I noticed that the calendar categories were not in title case
This pr fixes that

## Notes for testing your change

- Pull branch locally
- Run website
- Check calendar categories have correct casing