### PR TITLE
Fix Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,19 @@ updates:
     versioning-strategy: increase
 
     # Update `dependencies` and `devDependencies` separately
+    # Create grouped PRs for minor/patch updates
+    # Major version updates will get individual PRs
     groups:
       production:
         dependency-type: production
+        update-types:
+          - patch
+          - minor
       development:
         dependency-type: development
+        update-types:
+          - patch
+          - minor
 
     # Manually update major versions of `@types/node` with the version specified within .nvmrc
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,7 @@ updates:
       time: "00:00"
 
   - package-ecosystem: npm
-    directories:
-      - /
-      - /apps/*
+    directory: /
     schedule:
       interval: weekly
       day: wednesday

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,47 @@
+// Ensure that any GitHub SSH dependencies are replaced with HTTPS tarballs
+// FIXME: https://github.com/dependabot/dependabot-core/issues/10124
+const afterAllResolved = (lockfile, context) => {
+  context.log(
+    "Patching lockfile to use HTTPS tarballs for GitHub dependencies",
+  );
+
+  for (const pkg in lockfile.packages) {
+    const match = pkg.match(
+      /^(.+)@git\+https:\/\/git@github\.com:(.+)\.git#(.+)$/,
+    );
+    if (!match) continue;
+
+    const data = lockfile.packages[pkg];
+    const tar = `https://codeload.github.com/${match[2]}/tar.gz/${match[3]}`;
+
+    delete lockfile.packages[pkg];
+    lockfile.packages[`${match[1]}@${tar}`] = {
+      ...data,
+      resolution: { tarball: tar },
+    };
+
+    context.log(`Replaced ${pkg} with ${match[1]}@${tar}`);
+  }
+
+  for (const pkg in lockfile.importers) {
+    const importer = lockfile.importers[pkg];
+    for (const dep in importer.dependencies)
+      importer.dependencies[dep] = importer.dependencies[dep].replace(
+        /^git\+https:\/\/git@github\.com:(.+)\.git#(.+)$/,
+        (_, repo, tag) => `https://codeload.github.com/${repo}/tar.gz/${tag}`,
+      );
+    for (const dep in importer.devDependencies)
+      importer.devDependencies[dep] = importer.devDependencies[dep].replace(
+        /^git\+https:\/\/git@github\.com:(.+)\.git#(.+)$/,
+        (_, repo, tag) => `https://codeload.github.com/${repo}/tar.gz/${tag}`,
+      );
+  }
+
+  return lockfile;
+};
+
+module.exports = {
+  hooks: {
+    afterAllResolved,
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+pnpmfileChecksum: q3k5ey2pj7rpz2q2umrynuvuse
+
 patchedDependencies:
   eslint-plugin-tailwindcss@3.17.5:
     hash: ffbd4ayk5rqu3ipt6gp4marery


### PR DESCRIPTION
## Describe your changes

After a _lot_ of testing over in https://github.com/MattIPv4/alveusgg/pulls, this config finally appears to be working.

Tl;dr Dependabot just needs the root of the pnpm workspace defined in `directory`/`directories`. And then, due to a pnpm/Dependabot bug we need to patch the lockfile after resolution to fix GitHub SSH dependencies being incorrectly resolved.

## Notes for testing your change

See test repo.