### PR TITLE
Ensure pnpmfile is present in bot Dockerfile

### DIFF
--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 COPY package.json .
 COPY pnpm-lock.yaml .
 COPY pnpm-workspace.yaml .
+COPY .pnpmfile.cjs .
 COPY patches ./patches
 
 ## Copy chatbot files


### PR DESCRIPTION
## Describe your changes

Fast-follow to #868 for the bot deployment which is erroring on pnpmfileChecksum due to the pnpmfile not being present in the Dockerfile when the dependency installation is done.

## Notes for testing your change

I actually pushed this branch to preview, so a successful bot deployment should be observable.
