### PR TITLE
Add SubNav (ToC) to pages with long content

### DIFF
--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -1,0 +1,26 @@
+import IconChevronRight from "@/icons/IconChevronRight";
+import Link from "./Link";
+
+type SubNavProps = {
+  links: Record<string, string>;
+};
+
+const SubNav = ({ links }: SubNavProps) => (
+  <nav className="sticky left-0 top-0 z-20 mt-0 bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl">
+    <div className="container mx-auto flex flex-row items-center gap-2 p-1 px-2">
+      {Object.entries(links).map(([key, value]) => (
+        <Link
+          key={key}
+          href={value}
+          custom
+          className="flex items-center gap-1 rounded-full px-2 py-1 transition-colors hover:bg-alveus-green-200"
+        >
+          <IconChevronRight className="size-5" />
+          {key}
+        </Link>
+      ))}
+    </div>
+  </nav>
+);
+
+export default SubNav;

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -10,6 +10,27 @@ type SubNavProps = {
   className?: string;
 };
 
+const SubNavInner = ({ links, className }: SubNavProps) => (
+  <div
+    className={classes(
+      "container mx-auto flex flex-row flex-wrap items-center gap-2 px-2 py-1",
+      className,
+    )}
+  >
+    {links.map(({ name, href }) => (
+      <Link
+        key={name}
+        href={href}
+        custom
+        className="flex items-center gap-1 rounded-full px-2 py-1 transition-colors hover:bg-alveus-green-200"
+      >
+        <IconChevronRight className="size-5" />
+        {name}
+      </Link>
+    ))}
+  </div>
+);
+
 const SubNav = ({ links, className }: SubNavProps) => (
   <nav
     className={classes(
@@ -17,20 +38,7 @@ const SubNav = ({ links, className }: SubNavProps) => (
       className,
     )}
   >
-    <div className="container mx-auto flex flex-row flex-wrap items-center gap-2 px-2 py-1">
-      {links.map(({ name, href }) => (
-        <Link
-          key={name}
-          href={href}
-          custom
-          className="flex items-center gap-1 rounded-full px-2 py-1 transition-colors hover:bg-alveus-green-200"
-        >
-          <IconChevronRight className="size-5" />
-          {name}
-        </Link>
-      ))}
-    </div>
+    <SubNavInner links={links} className={"max-lg:hidden"} />
   </nav>
 );
-
 export default SubNav;

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -57,4 +57,5 @@ const SubNav = ({ links, className }: SubNavProps) => (
     </div>
   </nav>
 );
+
 export default SubNav;

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -45,7 +45,7 @@ const SubNav = ({ links, className }: SubNavProps) => (
         className="hidden flex-row flex-wrap items-center lg:flex"
       />
       <Disclosure as="div" className="flex flex-row items-start lg:hidden">
-        <DisclosurePanel className="text-gray-500">
+        <DisclosurePanel as={Fragment}>
           <SubNavInner links={links} className="flex flex-col" />
         </DisclosurePanel>
         <DisclosureButton className="ml-auto p-1.5">

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -1,4 +1,5 @@
 import IconChevronRight from "@/icons/IconChevronRight";
+import { classes } from "@/utils/classes";
 import Link from "./Link";
 
 type SubNavProps = {
@@ -6,10 +7,16 @@ type SubNavProps = {
     name: string;
     href: string;
   }[];
+  className?: string;
 };
 
-const SubNav = ({ links }: SubNavProps) => (
-  <nav className="sticky left-0 top-0 z-20 mt-0 bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl">
+const SubNav = ({ links, className }: SubNavProps) => (
+  <nav
+    className={classes(
+      "sticky left-0 top-0 mt-0 bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl",
+      className,
+    )}
+  >
     <div className="container mx-auto flex flex-row items-center gap-2 p-1 px-2">
       {links.map(({ name, href }) => (
         <Link

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -3,9 +3,11 @@ import {
   DisclosureButton,
   DisclosurePanel,
 } from "@headlessui/react";
-import IconChevronRight from "@/icons/IconChevronRight";
 import { classes } from "@/utils/classes";
+
+import IconChevronRight from "@/icons/IconChevronRight";
 import IconMenu from "@/icons/IconMenu";
+
 import Link from "./Link";
 
 type SubNavProps = {

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -2,21 +2,24 @@ import IconChevronRight from "@/icons/IconChevronRight";
 import Link from "./Link";
 
 type SubNavProps = {
-  links: Record<string, string>;
+  links: {
+    name: string;
+    href: string;
+  }[];
 };
 
 const SubNav = ({ links }: SubNavProps) => (
   <nav className="sticky left-0 top-0 z-20 mt-0 bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl">
     <div className="container mx-auto flex flex-row items-center gap-2 p-1 px-2">
-      {Object.entries(links).map(([key, value]) => (
+      {links.map(({ name, href }) => (
         <Link
-          key={key}
-          href={value}
+          key={name}
+          href={href}
           custom
           className="flex items-center gap-1 rounded-full px-2 py-1 transition-colors hover:bg-alveus-green-200"
         >
           <IconChevronRight className="size-5" />
-          {key}
+          {name}
         </Link>
       ))}
     </div>

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -17,7 +17,7 @@ const SubNav = ({ links, className }: SubNavProps) => (
       className,
     )}
   >
-    <div className="container mx-auto flex flex-row items-center gap-2 py-1 px-2">
+    <div className="container mx-auto flex flex-row items-center gap-2 px-2 py-1">
       {links.map(({ name, href }) => (
         <Link
           key={name}

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -17,7 +17,7 @@ const SubNav = ({ links, className }: SubNavProps) => (
       className,
     )}
   >
-    <div className="container mx-auto flex flex-row items-center gap-2 px-2 py-1">
+    <div className="container mx-auto flex flex-row flex-wrap items-center gap-2 px-2 py-1">
       {links.map(({ name, href }) => (
         <Link
           key={name}

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -17,7 +17,7 @@ const SubNav = ({ links, className }: SubNavProps) => (
       className,
     )}
   >
-    <div className="container mx-auto flex flex-row items-center gap-2 p-1 px-2">
+    <div className="container mx-auto flex flex-row items-center gap-2 py-1 px-2">
       {links.map(({ name, href }) => (
         <Link
           key={name}

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -13,7 +13,7 @@ type SubNavProps = {
 const SubNav = ({ links, className }: SubNavProps) => (
   <nav
     className={classes(
-      "sticky left-0 top-0 mt-0 bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl",
+      "sticky inset-x-0 top-0 mt-0 bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl",
       className,
     )}
   >

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -1,5 +1,11 @@
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+} from "@headlessui/react";
 import IconChevronRight from "@/icons/IconChevronRight";
 import { classes } from "@/utils/classes";
+import IconMenu from "@/icons/IconMenu";
 import Link from "./Link";
 
 type SubNavProps = {
@@ -12,10 +18,7 @@ type SubNavProps = {
 
 const SubNavInner = ({ links, className }: SubNavProps) => (
   <div
-    className={classes(
-      "container mx-auto flex flex-row flex-wrap items-center gap-2 px-2 py-1",
-      className,
-    )}
+    className={classes("flex flex-row flex-wrap items-center gap-2", className)}
   >
     {links.map(({ name, href }) => (
       <Link
@@ -38,7 +41,17 @@ const SubNav = ({ links, className }: SubNavProps) => (
       className,
     )}
   >
-    <SubNavInner links={links} className={"max-lg:hidden"} />
+    <div className="container mx-auto px-2 py-1">
+      <SubNavInner links={links} className={"max-lg:hidden"} />
+      <Disclosure as="div" className="flex flex-row items-start lg:hidden">
+        <DisclosurePanel className="text-gray-500">
+          <SubNavInner links={links} className={""} />
+        </DisclosurePanel>
+        <DisclosureButton className="ml-auto py-1.5">
+          <IconMenu />
+        </DisclosureButton>
+      </Disclosure>
+    </div>
   </nav>
 );
 export default SubNav;

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -42,7 +42,7 @@ const SubNav = ({ links, className }: SubNavProps) => (
     )}
   >
     <div className="container mx-auto px-2 py-1">
-      <SubNavInner links={links} className={"max-lg:hidden"} />
+      <SubNavInner links={links} className="max-lg:hidden" />
       <Disclosure as="div" className="flex flex-row items-start lg:hidden">
         <DisclosurePanel className="text-gray-500">
           <SubNavInner links={links} className={""} />

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -47,7 +47,7 @@ const SubNav = ({ links, className }: SubNavProps) => (
         <DisclosurePanel className="text-gray-500">
           <SubNavInner links={links} className={""} />
         </DisclosurePanel>
-        <DisclosureButton className="ml-auto py-1.5">
+        <DisclosureButton className="ml-auto p-1.5">
           <IconMenu />
         </DisclosureButton>
       </Disclosure>

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -1,8 +1,10 @@
+import { Fragment } from "react";
 import {
   Disclosure,
   DisclosureButton,
   DisclosurePanel,
 } from "@headlessui/react";
+
 import { classes } from "@/utils/classes";
 
 import IconChevronRight from "@/icons/IconChevronRight";

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -17,9 +17,7 @@ type SubNavProps = {
 };
 
 const SubNavInner = ({ links, className }: SubNavProps) => (
-  <div
-    className={classes("flex flex-row flex-wrap items-center gap-2", className)}
-  >
+  <div className={classes("gap-2", className)}>
     {links.map(({ name, href }) => (
       <Link
         key={name}
@@ -42,10 +40,13 @@ const SubNav = ({ links, className }: SubNavProps) => (
     )}
   >
     <div className="container mx-auto px-2 py-1">
-      <SubNavInner links={links} className="max-lg:hidden" />
+      <SubNavInner
+        links={links}
+        className="hidden flex-row flex-wrap items-center lg:flex"
+      />
       <Disclosure as="div" className="flex flex-row items-start lg:hidden">
         <DisclosurePanel className="text-gray-500">
-          <SubNavInner links={links} className={""} />
+          <SubNavInner links={links} className="flex flex-col" />
         </DisclosurePanel>
         <DisclosureButton className="ml-auto p-1.5">
           <IconMenu />

--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -13,7 +13,7 @@ type SubNavProps = {
 const SubNav = ({ links, className }: SubNavProps) => (
   <nav
     className={classes(
-      "sticky inset-x-0 top-0 mt-0 bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl",
+      "sticky inset-x-0 top-0 bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl",
       className,
     )}
   >

--- a/apps/website/src/components/content/Transparency.tsx
+++ b/apps/website/src/components/content/Transparency.tsx
@@ -21,7 +21,7 @@ const Transparency = ({ className }: TransparencyProps) => (
   >
     <div className="flex flex-col gap-4 md:flex-row-reverse md:items-center md:gap-10">
       <div>
-        <Heading id="transparency" level={2} link className="scroll-mt-12">
+        <Heading id="transparency" level={2} link className="scroll-mt-24">
           Platinum rated transparency
         </Heading>
 

--- a/apps/website/src/pages/about/alveus.tsx
+++ b/apps/website/src/pages/about/alveus.tsx
@@ -14,13 +14,23 @@ import Timeline from "@/components/content/Timeline";
 import { Lightbox, Preview } from "@/components/content/YouTube";
 import Maya from "@/components/content/Maya";
 import Box from "@/components/content/Box";
+import Transparency from "@/components/content/Transparency";
+import SubNav from "@/components/content/SubNav";
 
 import IconArrowRight from "@/icons/IconArrowRight";
 
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
 import leafLeftImage2 from "@/assets/floral/leaf-left-2.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
-import Transparency from "@/components/content/Transparency";
+
+const sectionLinks = {
+  "Twitch.tv": "#twitch",
+  Founding: "#maya",
+  "History ": "#history",
+  "Tour Part 1": "#tour-part-1",
+  "Tour Part 2": "#tour-part-2",
+  Transparency: "#transparency",
+};
 
 const sources = {
   twitchAdvertising: {
@@ -163,7 +173,7 @@ const history: [HistoryItems, ...(HistoryCTA | HistoryItems)[]] = [
     cta: (
       <div className="flex flex-wrap items-center gap-y-16">
         <div className="basis-full md:basis-1/2 md:px-4">
-          <Heading id="tour-part-1" level={3} className="italic">
+          <Heading id="tour-part-1" level={3} className="scroll-mt-52 italic">
             Alveus Tour Part 1
           </Heading>
 
@@ -293,7 +303,7 @@ const history: [HistoryItems, ...(HistoryCTA | HistoryItems)[]] = [
         </div>
 
         <div className="basis-full md:basis-1/2 md:px-4">
-          <Heading id="tour-part-2" level={3} className="italic">
+          <Heading id="tour-part-2" level={3} className="scroll-mt-52 italic">
             Alveus Tour Part 2
           </Heading>
 
@@ -557,15 +567,17 @@ const AboutAlveusPage: NextPage = () => {
         </div>
       </Section>
 
+      <SubNav links={sectionLinks} />
+
       <div className="relative">
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -top-20 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -top-20 right-0 z-30 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
         />
 
         <Section className="text-center">
-          <Heading id="twitch" level={2} link>
+          <Heading id="twitch" level={2} link className="scroll-mt-14">
             Why Twitch.tv
           </Heading>
 
@@ -635,7 +647,7 @@ const AboutAlveusPage: NextPage = () => {
           </div>
 
           <div className="basis-full md:basis-1/2 md:px-4">
-            <Heading id="maya" level={2} className="italic" link>
+            <Heading id="maya" level={2} className="scroll-mt-32 italic" link>
               Maya Higa founded Alveus in February 2021
             </Heading>
             <p>
@@ -662,7 +674,7 @@ const AboutAlveusPage: NextPage = () => {
           <Heading
             id="history"
             level={2}
-            className="mb-16 text-center text-5xl text-alveus-green"
+            className="mb-16 scroll-mt-14 text-center text-5xl text-alveus-green"
             link
           >
             Alveus&apos; History

--- a/apps/website/src/pages/about/alveus.tsx
+++ b/apps/website/src/pages/about/alveus.tsx
@@ -26,7 +26,7 @@ import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
 const sectionLinks = [
   { name: "Twitch.tv", href: "#twitch" },
   { name: "Founding", href: "#maya" },
-  { name: "History ", href: "#history" },
+  { name: "History", href: "#history" },
   { name: "Tour Part 1", href: "#tour-part-1" },
   { name: "Tour Part 2", href: "#tour-part-2" },
   { name: "Transparency", href: "#transparency" },

--- a/apps/website/src/pages/about/alveus.tsx
+++ b/apps/website/src/pages/about/alveus.tsx
@@ -567,7 +567,7 @@ const AboutAlveusPage: NextPage = () => {
         </div>
       </Section>
 
-      <SubNav links={sectionLinks} />
+      <SubNav links={sectionLinks} className="z-20" />
 
       <div className="relative">
         <Image

--- a/apps/website/src/pages/about/alveus.tsx
+++ b/apps/website/src/pages/about/alveus.tsx
@@ -23,14 +23,14 @@ import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
 import leafLeftImage2 from "@/assets/floral/leaf-left-2.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
 
-const sectionLinks = {
-  "Twitch.tv": "#twitch",
-  Founding: "#maya",
-  "History ": "#history",
-  "Tour Part 1": "#tour-part-1",
-  "Tour Part 2": "#tour-part-2",
-  Transparency: "#transparency",
-};
+const sectionLinks = [
+  { name: "Twitch.tv", href: "#twitch" },
+  { name: "Founding", href: "#maya" },
+  { name: "History ", href: "#history" },
+  { name: "Tour Part 1", href: "#tour-part-1" },
+  { name: "Tour Part 2", href: "#tour-part-2" },
+  { name: "Transparency", href: "#transparency" },
+];
 
 const sources = {
   twitchAdvertising: {

--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -19,13 +19,11 @@ import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";
 import Button from "@/components/content/Button";
 import Meta from "@/components/content/Meta";
-
-import IconChevronRight from "@/icons/IconChevronRight";
+import SubNav from "@/components/content/SubNav";
 
 import leafRightImage1 from "@/assets/floral/leaf-right-1.png";
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
-import SubNav from "@/components/content/SubNav";
 
 interface NamedCommand extends Command {
   name: string;

--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -111,7 +111,7 @@ const AboutTechPage: NextPage = () => {
         </Section>
       </div>
 
-      <SubNav links={sectionLinks} />
+      <SubNav links={sectionLinks} className="z-20" />
 
       <div className="relative">
         <Image

--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -75,7 +75,10 @@ const signature = (command: NamedCommand) => {
   return `${cmd} ${cmdArgs}`;
 };
 
-const sectionLinks = { Commands: "#commands", Presets: "#presets" };
+const sectionLinks = [
+  { name: "Commands", href: "#commands" },
+  { name: "Presets", href: "#presets" },
+];
 
 const AboutTechPage: NextPage = () => {
   return (

--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -25,6 +25,7 @@ import IconChevronRight from "@/icons/IconChevronRight";
 import leafRightImage1 from "@/assets/floral/leaf-right-1.png";
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
+import SubNav from "@/components/content/SubNav";
 
 interface NamedCommand extends Command {
   name: string;
@@ -74,10 +75,7 @@ const signature = (command: NamedCommand) => {
   return `${cmd} ${cmdArgs}`;
 };
 
-const sectionLinks = [
-  { name: "Commands", id: "commands" },
-  { name: "Presets", id: "presets" },
-] as const;
+const sectionLinks = { Commands: "#commands", Presets: "#presets" };
 
 const AboutTechPage: NextPage = () => {
   return (
@@ -110,21 +108,7 @@ const AboutTechPage: NextPage = () => {
         </Section>
       </div>
 
-      <nav className="sticky left-0 top-0 z-20 mt-0 bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl">
-        <div className="container mx-auto flex flex-row items-center gap-2 p-1 px-2">
-          {sectionLinks.map(({ name, id }) => (
-            <a
-              key={id}
-              className="flex items-center gap-1 rounded-full px-2 py-1 transition-colors hover:bg-alveus-green-200"
-              href={`#${id}`}
-            >
-              <IconChevronRight className="size-5" />
-
-              {name}
-            </a>
-          ))}
-        </div>
-      </nav>
+      <SubNav links={sectionLinks} />
 
       <div className="relative">
         <Image

--- a/apps/website/src/pages/ambassadors/index.tsx
+++ b/apps/website/src/pages/ambassadors/index.tsx
@@ -214,7 +214,7 @@ const AmbassadorsPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-36 -left-8 z-30 hidden h-auto w-1/2 max-w-32 rotate-45 -scale-y-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-36 -left-16 z-30 hidden h-auto w-1/2 max-w-32 rotate-45 -scale-y-100 select-none lg:block"
         />
 
         <Section dark className="py-24">

--- a/apps/website/src/pages/ambassadors/index.tsx
+++ b/apps/website/src/pages/ambassadors/index.tsx
@@ -33,6 +33,7 @@ import leafRightImage1 from "@/assets/floral/leaf-right-1.png";
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
 import leafRightImage2 from "@/assets/floral/leaf-right-2.png";
 import leafLeftImage2 from "@/assets/floral/leaf-left-2.png";
+import SubNav from "@/components/content/SubNav";
 
 // We don't want to show retired ambassadors on the page
 const activeAmbassadors = typeSafeObjectEntries(ambassadors).filter(
@@ -148,7 +149,7 @@ const AmbassadorItems = forwardRef<
     {name && (
       <Heading
         level={2}
-        className="mb-8 mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl text-alveus-green-800"
+        className="mb-8 mt-16 scroll-mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl text-alveus-green-800"
         id={`${option}:${group}`}
         link
       >
@@ -182,6 +183,18 @@ const AmbassadorsPage: NextPage = () => {
     initial: "all",
   });
 
+  const sectionLinks = useMemo(
+    () =>
+      result instanceof Map
+        ? [...result.entries()].map(([key, value]) => ({
+            name: value.name,
+            href: `#${option}:${key}`,
+          }))
+        : [],
+
+    [result, option],
+  );
+
   return (
     <>
       <Meta
@@ -196,12 +209,12 @@ const AmbassadorsPage: NextPage = () => {
         <Image
           src={leafRightImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-4 right-0 z-10 hidden h-auto w-1/2 max-w-xs select-none lg:block"
+          className="pointer-events-none absolute -bottom-4 right-0 z-30 hidden h-auto w-1/2 max-w-xs select-none lg:block"
         />
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-36 -left-8 z-10 hidden h-auto w-1/2 max-w-32 rotate-45 -scale-y-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-36 -left-8 z-30 hidden h-auto w-1/2 max-w-32 rotate-45 -scale-y-100 select-none lg:block"
         />
 
         <Section dark className="py-24">
@@ -216,7 +229,7 @@ const AmbassadorsPage: NextPage = () => {
           </div>
         </Section>
       </div>
-
+      <SubNav links={sectionLinks} className="z-20" />
       {/* Grow the last section to cover the page */}
       <div className="relative flex grow flex-col">
         <Image

--- a/apps/website/src/pages/ambassadors/index.tsx
+++ b/apps/website/src/pages/ambassadors/index.tsx
@@ -229,7 +229,9 @@ const AmbassadorsPage: NextPage = () => {
           </div>
         </Section>
       </div>
+
       <SubNav links={sectionLinks} className="z-20" />
+
       {/* Grow the last section to cover the page */}
       <div className="relative flex grow flex-col">
         <Image

--- a/apps/website/src/pages/ambassadors/index.tsx
+++ b/apps/website/src/pages/ambassadors/index.tsx
@@ -28,12 +28,12 @@ import Heading from "@/components/content/Heading";
 import Meta from "@/components/content/Meta";
 import Select from "@/components/content/Select";
 import Grouped, { type GroupedProps } from "@/components/content/Grouped";
+import SubNav from "@/components/content/SubNav";
 
 import leafRightImage1 from "@/assets/floral/leaf-right-1.png";
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
 import leafRightImage2 from "@/assets/floral/leaf-right-2.png";
 import leafLeftImage2 from "@/assets/floral/leaf-left-2.png";
-import SubNav from "@/components/content/SubNav";
 
 // We don't want to show retired ambassadors on the page
 const activeAmbassadors = typeSafeObjectEntries(ambassadors).filter(
@@ -230,7 +230,9 @@ const AmbassadorsPage: NextPage = () => {
         </Section>
       </div>
 
-      <SubNav links={sectionLinks} className="z-20" />
+      {sectionLinks.length !== 0 && (
+        <SubNav links={sectionLinks} className="z-20" />
+      )}
 
       {/* Grow the last section to cover the page */}
       <div className="relative flex grow flex-col">

--- a/apps/website/src/pages/animal-quest/index.tsx
+++ b/apps/website/src/pages/animal-quest/index.tsx
@@ -277,7 +277,7 @@ const AnimalQuestPage: NextPage = () => {
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -bottom-20 right-0 z-30 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-10 left-0 z-30 hidden h-auto w-1/2 max-w-36 rotate-[20deg] -scale-y-100 select-none lg:block"
         />
 
         <Section

--- a/apps/website/src/pages/animal-quest/index.tsx
+++ b/apps/website/src/pages/animal-quest/index.tsx
@@ -1,6 +1,6 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import { Fragment, forwardRef } from "react";
+import { useMemo, Fragment, forwardRef } from "react";
 
 import animalQuest, {
   type AnimalQuestWithEpisode,
@@ -36,6 +36,7 @@ import animalQuestFull from "@/assets/animal-quest/full.png";
 import leafRightImage2 from "@/assets/floral/leaf-right-2.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
+import SubNav from "@/components/content/SubNav";
 
 const animalQuestEpisodes: AnimalQuestWithEpisode[] = animalQuest
   .map((episode, idx) => ({
@@ -248,6 +249,18 @@ const AnimalQuestPage: NextPage = () => {
     initial: "all",
   });
 
+  const sectionLinks = useMemo(
+    () =>
+      result instanceof Map
+        ? [...result.entries()].map(([key, value]) => ({
+            name: value.name,
+            href: `#${option}:${key}`,
+          }))
+        : [],
+
+    [result, option],
+  );
+
   return (
     <>
       <Meta
@@ -263,7 +276,7 @@ const AnimalQuestPage: NextPage = () => {
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -bottom-20 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-20 right-0 z-30 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
         />
 
         <Section
@@ -289,7 +302,7 @@ const AnimalQuestPage: NextPage = () => {
           />
         </Section>
       </div>
-
+      <SubNav links={sectionLinks} className="z-20" />
       {/* Grow the last section to cover the page */}
       <div className="relative flex grow flex-col">
         <Image

--- a/apps/website/src/pages/animal-quest/index.tsx
+++ b/apps/website/src/pages/animal-quest/index.tsx
@@ -28,6 +28,8 @@ import Meta from "@/components/content/Meta";
 import Link from "@/components/content/Link";
 import Select from "@/components/content/Select";
 import Grouped, { type GroupedProps } from "@/components/content/Grouped";
+import SubNav from "@/components/content/SubNav";
+
 import IconYouTube from "@/icons/IconYouTube";
 
 import animalQuestLogo from "@/assets/animal-quest/logo.png";
@@ -36,7 +38,6 @@ import animalQuestFull from "@/assets/animal-quest/full.png";
 import leafRightImage2 from "@/assets/floral/leaf-right-2.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
-import SubNav from "@/components/content/SubNav";
 
 const animalQuestEpisodes: AnimalQuestWithEpisode[] = animalQuest
   .map((episode, idx) => ({
@@ -302,7 +303,11 @@ const AnimalQuestPage: NextPage = () => {
           />
         </Section>
       </div>
-      <SubNav links={sectionLinks} className="z-20" />
+
+      {sectionLinks.length !== 0 && (
+        <SubNav links={sectionLinks} className="z-20" />
+      )}
+
       {/* Grow the last section to cover the page */}
       <div className="relative flex grow flex-col">
         <Image

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -26,11 +26,11 @@ import Meta from "@/components/content/Meta";
 import Link from "@/components/content/Link";
 import { Lightbox, Preview } from "@/components/content/YouTube";
 import Grouped, { type GroupedProps } from "@/components/content/Grouped";
+import SubNav from "@/components/content/SubNav";
 
 import leafRightImage2 from "@/assets/floral/leaf-right-2.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
-import SubNav from "@/components/content/SubNav";
 
 type CreatorWithSlug = Creator & { slug: string };
 

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -368,7 +368,7 @@ const CollaborationsPage: NextPage = () => {
           <Creators className="mt-6" />
         </Section>
       </div>
-      <SubNav links={sectionLinks} />
+      <SubNav links={sectionLinks} className="z-20" />
 
       {/* Grow the last section to cover the page */}
       <div className="relative flex grow flex-col">

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -227,7 +227,7 @@ const CollaborationItems = forwardRef<
         <Heading
           level={-1}
           className={classes(
-            "text-alveus-green-800 mb-6 mt-8 scroll-mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl",
+            "mb-6 mt-8 scroll-mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl text-alveus-green-800",
             index === 0 && "sr-only-linkable",
           )}
           id={`${option}:${group}`}

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { type NextPage } from "next";
 import Image from "next/image";
 
@@ -23,6 +30,7 @@ import Grouped, { type GroupedProps } from "@/components/content/Grouped";
 import leafRightImage2 from "@/assets/floral/leaf-right-2.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
+import SubNav from "@/components/content/SubNav";
 
 type CreatorWithSlug = Creator & { slug: string };
 
@@ -219,7 +227,7 @@ const CollaborationItems = forwardRef<
         <Heading
           level={-1}
           className={classes(
-            "alveus-green-800 mb-6 mt-8 border-b-2 border-alveus-green-300/25 pb-2 text-4xl",
+            "alveus-green-800 mb-6 mt-8 scroll-mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl",
             index === 0 && "sr-only",
           )}
           id={`${option}:${group}`}
@@ -310,6 +318,15 @@ const CollaborationsPage: NextPage = () => {
     initial: "all",
   });
 
+  const sectionLinks = useMemo(
+    () =>
+      [...result.entries()].map(([key, value]) => ({
+        name: value.name,
+        href: `#${option}:${key}`,
+      })),
+    [result, option],
+  );
+
   return (
     <>
       <Meta
@@ -324,7 +341,7 @@ const CollaborationsPage: NextPage = () => {
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -bottom-16 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-16 right-0 z-30 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
         />
 
         <Section dark className="pb-12 pt-24">
@@ -348,10 +365,10 @@ const CollaborationsPage: NextPage = () => {
               together to learn about the importance of conservation.
             </p>
           </div>
-
           <Creators className="mt-6" />
         </Section>
       </div>
+      <SubNav links={sectionLinks} />
 
       {/* Grow the last section to cover the page */}
       <div className="relative flex grow flex-col">

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -368,6 +368,7 @@ const CollaborationsPage: NextPage = () => {
           <Creators className="mt-6" />
         </Section>
       </div>
+
       <SubNav links={sectionLinks} className="z-20" />
 
       {/* Grow the last section to cover the page */}

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -227,7 +227,7 @@ const CollaborationItems = forwardRef<
         <Heading
           level={-1}
           className={classes(
-            "alveus-green-800 mb-6 mt-8 scroll-mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl",
+            "text-alveus-green-800 mb-6 mt-8 scroll-mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl",
             index === 0 && "sr-only-linkable",
           )}
           id={`${option}:${group}`}

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -228,7 +228,7 @@ const CollaborationItems = forwardRef<
           level={-1}
           className={classes(
             "alveus-green-800 mb-6 mt-8 scroll-mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl",
-            index === 0 && "sr-only",
+            index === 0 && "sr-only-linkable",
           )}
           id={`${option}:${group}`}
           link

--- a/apps/website/src/styles/globals.css
+++ b/apps/website/src/styles/globals.css
@@ -24,6 +24,13 @@
     height: 0;
     display: none;
   }
+
+  .sr-only-linkable {
+    @apply sr-only relative m-0 -ml-px -mt-px overflow-clip;
+
+    font-size: 0;
+    line-height: 0;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Describe your changes

Resolves #699 by adding a navbar table of contents to:

- /ambassadors (when the headings are visible)
- /collaborations
- /animal-quest (when the headings are visible)
- /about/alveus

## Notes for testing your change

- Open website
- SubNav renders correctly for both desktop and mobile
