### PR TITLE
Add endpoint for extension ambassadors

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -34,7 +34,7 @@
     "format": "prisma format"
   },
   "dependencies": {
-    "@alveusgg/data": "github:alveusgg/data#0.46.0",
+    "@alveusgg/data": "github:alveusgg/data#0.48.0",
     "@aws-sdk/client-s3": "^3.709.0",
     "@aws-sdk/s3-request-presigner": "^3.709.0",
     "@bart-krakowski/get-week-info-polyfill": "^1.0.8",

--- a/apps/website/src/pages/api/stream/ambassadors.ts
+++ b/apps/website/src/pages/api/stream/ambassadors.ts
@@ -65,9 +65,11 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<AmbassadorsResponse | string>,
 ) {
+  // Response can be cached for 30 minutes
+  // And can be stale for 5 minutes while revalidating
   res.setHeader(
     "Cache-Control",
-    "max-age=60, s-maxage=60, stale-while-revalidate=300",
+    "max-age=1800, s-maxage=1800, stale-while-revalidate=300",
   );
   return res.json({ ambassadors });
 }

--- a/apps/website/src/pages/api/stream/ambassadors.ts
+++ b/apps/website/src/pages/api/stream/ambassadors.ts
@@ -71,5 +71,27 @@ export default async function handler(
     "Cache-Control",
     "max-age=1800, s-maxage=1800, stale-while-revalidate=300",
   );
+
+  // Allow localhost + *.ext-twitch.tv to access
+  res.setHeader("Vary", "Origin");
+  if (req.headers.origin && URL.canParse(req.headers.origin)) {
+    const url = new URL(req.headers.origin);
+    if (
+      url.hostname === "localhost" ||
+      url.hostname.endsWith(".ext-twitch.tv")
+    ) {
+      res.setHeader("Access-Control-Allow-Origin", req.headers.origin);
+    }
+  }
+
+  // Handle preflight requests
+  if (req.method === "OPTIONS") {
+    res.setHeader("Access-Control-Allow-Methods", "GET");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    res.setHeader("Access-Control-Max-Age", "86400");
+    return res.status(200).end();
+  }
+
+  // Return the actual data
   return res.json({ ambassadors });
 }

--- a/apps/website/src/pages/api/stream/ambassadors.ts
+++ b/apps/website/src/pages/api/stream/ambassadors.ts
@@ -1,0 +1,71 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import allAmbassadors from "@alveusgg/data/src/ambassadors/core";
+import {
+  isActiveAmbassadorEntry,
+  type ActiveAmbassador,
+} from "@alveusgg/data/src/ambassadors/filters";
+import {
+  getAmbassadorImages,
+  type AmbassadorImage,
+} from "@alveusgg/data/src/ambassadors/images";
+import { getClassification } from "@alveusgg/data/src/ambassadors/classification";
+import { getIUCNStatus } from "@alveusgg/data/src/iucn";
+
+import {
+  typeSafeObjectEntries,
+  typeSafeObjectFromEntries,
+} from "@/utils/helpers";
+import { createImageUrl } from "@/utils/image";
+
+// If these types change, the extension schema MUST be updated as well
+type Ambassador = Omit<ActiveAmbassador, "iucn" | "class"> & {
+  image: Omit<AmbassadorImage, "src"> & { src: string };
+  iucn: ActiveAmbassador["iucn"] & { title: string };
+  class: { name: ActiveAmbassador["class"]; title: string };
+};
+export type AmbassadorsResponse = {
+  ambassadors: Record<string, Ambassador>;
+};
+
+const ambassadors = typeSafeObjectFromEntries(
+  typeSafeObjectEntries(allAmbassadors)
+    .filter(isActiveAmbassadorEntry)
+    .map<[string, Ambassador]>(([key, val]) => {
+      const image = getAmbassadorImages(key)[0];
+
+      return [
+        key,
+        {
+          ...val,
+          image: {
+            ...image,
+            src: createImageUrl({
+              src: image.src.src,
+              width: 600,
+            }),
+          },
+          iucn: {
+            ...val.iucn,
+            title: getIUCNStatus(val.iucn.status),
+          },
+          class: {
+            name: val.class,
+            title: getClassification(val.class),
+          },
+        },
+      ];
+    }),
+);
+
+// API for extension
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<AmbassadorsResponse | string>,
+) {
+  res.setHeader(
+    "Cache-Control",
+    "max-age=60, s-maxage=60, stale-while-revalidate=300",
+  );
+  return res.json({ ambassadors });
+}

--- a/apps/website/src/pages/api/stream/ambassadors.ts
+++ b/apps/website/src/pages/api/stream/ambassadors.ts
@@ -12,6 +12,8 @@ import {
 import { getClassification } from "@alveusgg/data/src/ambassadors/classification";
 import { getIUCNStatus } from "@alveusgg/data/src/iucn";
 
+import { env } from "@/env";
+
 import {
   typeSafeObjectEntries,
   typeSafeObjectFromEntries,
@@ -40,10 +42,10 @@ const ambassadors = typeSafeObjectFromEntries(
           ...val,
           image: {
             ...image,
-            src: createImageUrl({
+            src: `${env.NEXT_PUBLIC_BASE_URL}${createImageUrl({
               src: image.src.src,
               width: 600,
-            }),
+            })}`,
           },
           iucn: {
             ...val.iucn,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
   apps/website:
     dependencies:
       '@alveusgg/data':
-        specifier: github:alveusgg/data#0.46.0
-        version: https://codeload.github.com/alveusgg/data/tar.gz/c6d032d680fa2156947e4f87926e8eaeb5ca0b28
+        specifier: github:alveusgg/data#0.48.0
+        version: https://codeload.github.com/alveusgg/data/tar.gz/ee2c147d27aa650940957fe1af2fbca260eb8509(tailwindcss@3.4.16)(zod@3.24.1)
       '@aws-sdk/client-s3':
         specifier: ^3.709.0
         version: 3.709.0
@@ -337,7 +337,7 @@ importers:
         version: 3.7.0(eslint-plugin-import-x@4.5.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-import-x:
         specifier: ^4.5.0
         version: 4.5.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)
@@ -403,9 +403,15 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@alveusgg/data@https://codeload.github.com/alveusgg/data/tar.gz/c6d032d680fa2156947e4f87926e8eaeb5ca0b28':
-    resolution: {tarball: https://codeload.github.com/alveusgg/data/tar.gz/c6d032d680fa2156947e4f87926e8eaeb5ca0b28}
-    version: 0.46.0
+  '@alveusgg/data@https://codeload.github.com/alveusgg/data/tar.gz/ee2c147d27aa650940957fe1af2fbca260eb8509':
+    resolution: {tarball: https://codeload.github.com/alveusgg/data/tar.gz/ee2c147d27aa650940957fe1af2fbca260eb8509}
+    version: 0.48.0
+    peerDependencies:
+      tailwindcss: ^3.0.0
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      tailwindcss:
+        optional: true
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -6156,7 +6162,11 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@alveusgg/data@https://codeload.github.com/alveusgg/data/tar.gz/c6d032d680fa2156947e4f87926e8eaeb5ca0b28': {}
+  '@alveusgg/data@https://codeload.github.com/alveusgg/data/tar.gz/ee2c147d27aa650940957fe1af2fbca260eb8509(tailwindcss@3.4.16)(zod@3.24.1)':
+    dependencies:
+      zod: 3.24.1
+    optionalDependencies:
+      tailwindcss: 3.4.16
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -10278,15 +10288,16 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-import-x: 4.5.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)
       eslint: 9.16.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import-x@4.5.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6))
@@ -10311,7 +10322,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.31.0(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -10322,7 +10333,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.16.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -10333,6 +10344,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
## Describe your changes

In support of the work on the extension to allow it to fetch ambassador data in real-time from the website, removing the need for cumbersome slow releases whenever a change in ambassador data is needed.

## Notes for testing your change

Endpoint returns ambassador data including relationships, with cache header + CORS.