### PR TITLE
Vercel doesn't respect the Vary header for caching

### DIFF
--- a/apps/website/src/pages/api/stream/ambassadors.ts
+++ b/apps/website/src/pages/api/stream/ambassadors.ts
@@ -72,17 +72,9 @@ export default async function handler(
     "max-age=1800, s-maxage=1800, stale-while-revalidate=300",
   );
 
-  // Allow localhost + *.ext-twitch.tv to access
-  res.setHeader("Vary", "Origin");
-  if (req.headers.origin && URL.canParse(req.headers.origin)) {
-    const url = new URL(req.headers.origin);
-    if (
-      url.hostname === "localhost" ||
-      url.hostname.endsWith(".ext-twitch.tv")
-    ) {
-      res.setHeader("Access-Control-Allow-Origin", req.headers.origin);
-    }
-  }
+  // Vercel doesn't respect Vary so we allow all origins to use this
+  // Ideally we'd just allow specifically localhost + *.ext-twitch.tv
+  res.setHeader("Access-Control-Allow-Origin", "*");
 
   // Handle preflight requests
   if (req.method === "OPTIONS") {


### PR DESCRIPTION
## Describe your changes

Sigh. Follow-up for #897.

## Notes for testing your change

CORS header is present with a wildcard always.