### PR TITLE
Update data (mark Chips Ahoy as retired)

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -34,7 +34,7 @@
     "format": "prisma format"
   },
   "dependencies": {
-    "@alveusgg/data": "github:alveusgg/data#0.48.0",
+    "@alveusgg/data": "github:alveusgg/data#0.49.0",
     "@aws-sdk/client-s3": "^3.709.0",
     "@aws-sdk/s3-request-presigner": "^3.709.0",
     "@bart-krakowski/get-week-info-polyfill": "^1.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
   apps/website:
     dependencies:
       '@alveusgg/data':
-        specifier: github:alveusgg/data#0.48.0
-        version: https://codeload.github.com/alveusgg/data/tar.gz/ee2c147d27aa650940957fe1af2fbca260eb8509(tailwindcss@3.4.16)(zod@3.24.1)
+        specifier: github:alveusgg/data#0.49.0
+        version: https://codeload.github.com/alveusgg/data/tar.gz/fe978afcaef402a58c26b0223263605b3676ad50(tailwindcss@3.4.16)(zod@3.24.1)
       '@aws-sdk/client-s3':
         specifier: ^3.709.0
         version: 3.709.0
@@ -403,9 +403,9 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@alveusgg/data@https://codeload.github.com/alveusgg/data/tar.gz/ee2c147d27aa650940957fe1af2fbca260eb8509':
-    resolution: {tarball: https://codeload.github.com/alveusgg/data/tar.gz/ee2c147d27aa650940957fe1af2fbca260eb8509}
-    version: 0.48.0
+  '@alveusgg/data@https://codeload.github.com/alveusgg/data/tar.gz/fe978afcaef402a58c26b0223263605b3676ad50':
+    resolution: {tarball: https://codeload.github.com/alveusgg/data/tar.gz/fe978afcaef402a58c26b0223263605b3676ad50}
+    version: 0.49.0
     peerDependencies:
       tailwindcss: ^3.0.0
       zod: ^3.0.0
@@ -6162,7 +6162,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@alveusgg/data@https://codeload.github.com/alveusgg/data/tar.gz/ee2c147d27aa650940957fe1af2fbca260eb8509(tailwindcss@3.4.16)(zod@3.24.1)':
+  '@alveusgg/data@https://codeload.github.com/alveusgg/data/tar.gz/fe978afcaef402a58c26b0223263605b3676ad50(tailwindcss@3.4.16)(zod@3.24.1)':
     dependencies:
       zod: 3.24.1
     optionalDependencies:


### PR DESCRIPTION
## Describe your changes

cc https://github.com/alveusgg/data/pull/89

## Notes for testing your change

Chips no longer present on ambassadors page
