### PR TITLE
Drop shadow on leaves + misc fixes

### DIFF
--- a/apps/website/src/pages/about/alveus.tsx
+++ b/apps/website/src/pages/about/alveus.tsx
@@ -573,7 +573,7 @@ const AboutAlveusPage: NextPage = () => {
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -top-20 right-0 z-30 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -top-20 right-0 z-30 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none drop-shadow-md lg:block"
         />
 
         <Section className="text-center">
@@ -667,7 +667,7 @@ const AboutAlveusPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -top-32 left-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-bottom-48 2xl:max-w-48"
+          className="pointer-events-none absolute -top-32 left-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-bottom-48 2xl:max-w-48"
         />
 
         <Section>
@@ -709,7 +709,7 @@ const AboutAlveusPage: NextPage = () => {
         <Image
           src={leafLeftImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-24 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none drop-shadow-md lg:block"
         />
 
         <Transparency className="grow" />

--- a/apps/website/src/pages/about/maya.tsx
+++ b/apps/website/src/pages/about/maya.tsx
@@ -115,7 +115,7 @@ const AboutMayaPage: NextPage = () => {
         <Image
           src={leafRightImage1}
           alt=""
-          className="pointer-events-none absolute -top-8 right-0 z-10 hidden h-auto w-1/2 max-w-md select-none lg:block xl:max-w-lg"
+          className="pointer-events-none absolute -top-8 right-0 z-10 hidden h-auto w-1/2 max-w-md select-none drop-shadow-md lg:block xl:max-w-lg"
         />
 
         <Section dark className="py-24">
@@ -145,7 +145,7 @@ const AboutMayaPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-32 left-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-bottom-48 2xl:max-w-48"
+          className="pointer-events-none absolute -bottom-32 left-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-bottom-48 2xl:max-w-48"
         />
 
         <Section>
@@ -170,7 +170,7 @@ const AboutMayaPage: NextPage = () => {
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-24 right-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 right-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <Section
@@ -194,7 +194,7 @@ const AboutMayaPage: NextPage = () => {
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -bottom-20 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-20 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <Section className="grow">

--- a/apps/website/src/pages/about/staff.tsx
+++ b/apps/website/src/pages/about/staff.tsx
@@ -252,12 +252,12 @@ const AboutStaffPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -left-8 -top-52 z-10 hidden h-auto w-1/2 max-w-40 -rotate-45 select-none lg:block"
+          className="pointer-events-none absolute -left-8 -top-52 z-10 hidden h-auto w-1/2 max-w-40 -rotate-45 select-none drop-shadow-md lg:block"
         />
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-52 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-bottom-64 2xl:max-w-48"
+          className="pointer-events-none absolute -bottom-52 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-bottom-64 2xl:max-w-48"
         />
 
         <Section className="grow">

--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -93,7 +93,7 @@ const AboutTechPage: NextPage = () => {
         <Image
           src={leafRightImage1}
           alt=""
-          className="pointer-events-none absolute -top-8 right-0 z-30 hidden h-auto w-1/2 max-w-sm select-none lg:block xl:max-w-md"
+          className="pointer-events-none absolute -top-8 right-0 z-30 hidden h-auto w-1/2 max-w-sm select-none drop-shadow-md lg:block xl:max-w-md"
         />
 
         <Section dark className="py-24">
@@ -115,7 +115,7 @@ const AboutTechPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-32 right-0 z-10 hidden h-auto w-1/2 max-w-40 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-32 right-0 z-10 hidden h-auto w-1/2 max-w-40 -scale-x-100 select-none drop-shadow-md lg:block"
         />
 
         <Section>
@@ -306,7 +306,7 @@ const AboutTechPage: NextPage = () => {
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <Section className="grow">

--- a/apps/website/src/pages/about/tech/index.tsx
+++ b/apps/website/src/pages/about/tech/index.tsx
@@ -345,7 +345,7 @@ const AboutTechPage: NextPage = () => {
         <Image
           src={leafRightImage1}
           alt=""
-          className="pointer-events-none absolute -top-8 right-0 z-10 hidden h-auto w-1/2 max-w-sm select-none lg:block xl:max-w-md"
+          className="pointer-events-none absolute -top-8 right-0 z-10 hidden h-auto w-1/2 max-w-sm select-none drop-shadow-md lg:block xl:max-w-md"
         />
 
         <Section dark className="py-24">
@@ -365,7 +365,7 @@ const AboutTechPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-28 -left-8 z-10 hidden h-auto w-1/2 max-w-40 -rotate-45 select-none lg:block 2xl:max-w-48"
+          className="pointer-events-none absolute -bottom-28 -left-8 z-10 hidden h-auto w-1/2 max-w-40 -rotate-45 select-none drop-shadow-md lg:block 2xl:max-w-48"
         />
 
         <Section containerClassName="flex flex-wrap -mx-4">
@@ -396,7 +396,7 @@ const AboutTechPage: NextPage = () => {
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-24 right-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 right-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <Section dark>
@@ -426,7 +426,7 @@ const AboutTechPage: NextPage = () => {
         <Image
           src={leafLeftImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-20 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-20 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none drop-shadow-md lg:block"
         />
 
         <Section>
@@ -443,7 +443,7 @@ const AboutTechPage: NextPage = () => {
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <Section dark className="grow bg-alveus-green-800">

--- a/apps/website/src/pages/ambassadors/index.tsx
+++ b/apps/website/src/pages/ambassadors/index.tsx
@@ -209,12 +209,12 @@ const AmbassadorsPage: NextPage = () => {
         <Image
           src={leafRightImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-4 right-0 z-30 hidden h-auto w-1/2 max-w-xs select-none lg:block"
+          className="pointer-events-none absolute -bottom-4 right-0 z-30 hidden h-auto w-1/2 max-w-xs select-none drop-shadow-md lg:block"
         />
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-36 -left-16 z-30 hidden h-auto w-1/2 max-w-32 rotate-45 -scale-y-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-36 -left-16 z-30 hidden h-auto w-1/2 max-w-32 rotate-45 -scale-y-100 select-none drop-shadow-md lg:block"
         />
 
         <Section dark className="py-24">
@@ -239,12 +239,12 @@ const AmbassadorsPage: NextPage = () => {
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-60 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-bottom-64 2xl:max-w-48"
+          className="pointer-events-none absolute -bottom-60 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-bottom-64 2xl:max-w-48"
         />
         <Image
           src={leafLeftImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <Section className="grow pt-8">

--- a/apps/website/src/pages/ambassadors/index.tsx
+++ b/apps/website/src/pages/ambassadors/index.tsx
@@ -149,7 +149,7 @@ const AmbassadorItems = forwardRef<
     {name && (
       <Heading
         level={2}
-        className="mb-8 mt-16 scroll-mt-16 border-b-2 border-alveus-green-300/25 pb-2 text-4xl text-alveus-green-800"
+        className="mb-8 mt-16 scroll-mt-22 border-b-2 border-alveus-green-300/25 pb-2 text-4xl text-alveus-green-800"
         id={`${option}:${group}`}
         link
       >

--- a/apps/website/src/pages/animal-quest/[episodeName].tsx
+++ b/apps/website/src/pages/animal-quest/[episodeName].tsx
@@ -324,7 +324,7 @@ const AnimalQuestEpisodePage: NextPage<AnimalQuestEpisodePageProps> = ({
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-32 right-0 z-10 hidden h-auto w-1/2 max-w-40 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-32 right-0 z-10 hidden h-auto w-1/2 max-w-40 -scale-x-100 select-none drop-shadow-md lg:block"
         />
 
         <Section dark>
@@ -441,7 +441,7 @@ const AnimalQuestEpisodePage: NextPage<AnimalQuestEpisodePageProps> = ({
         <Image
           src={leafLeftImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-22 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-22 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <Section>
@@ -479,12 +479,12 @@ const AnimalQuestEpisodePage: NextPage<AnimalQuestEpisodePageProps> = ({
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -top-16 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -top-16 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none drop-shadow-md lg:block"
         />
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-56 left-0 z-10 hidden h-auto w-1/2 max-w-40 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-56 left-0 z-10 hidden h-auto w-1/2 max-w-40 -scale-x-100 select-none drop-shadow-md lg:block"
         />
 
         <Section className="grow">

--- a/apps/website/src/pages/animal-quest/index.tsx
+++ b/apps/website/src/pages/animal-quest/index.tsx
@@ -277,7 +277,7 @@ const AnimalQuestPage: NextPage = () => {
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -bottom-10 left-0 z-30 hidden h-auto w-1/2 max-w-36 rotate-[20deg] -scale-y-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-10 left-0 z-30 hidden h-auto w-1/2 max-w-36 rotate-[20deg] -scale-y-100 select-none drop-shadow-md lg:block"
         />
 
         <Section
@@ -313,12 +313,12 @@ const AnimalQuestPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-32 left-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-bottom-48 2xl:max-w-48"
+          className="pointer-events-none absolute -bottom-32 left-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-bottom-48 2xl:max-w-48"
         />
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-60 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-bottom-64 2xl:max-w-48"
+          className="pointer-events-none absolute -bottom-60 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-bottom-64 2xl:max-w-48"
         />
 
         <Section className="grow pt-8">

--- a/apps/website/src/pages/events/fall-carnival-2023/index.tsx
+++ b/apps/website/src/pages/events/fall-carnival-2023/index.tsx
@@ -96,7 +96,7 @@ const FallCarnival2023EventPage: NextPage = () => {
         <Image
           src={leafLeftImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <IntroSection />
@@ -185,12 +185,12 @@ const FallCarnival2023EventPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -left-8 top-32 z-10 hidden h-auto w-1/3 max-w-28 -rotate-45 select-none lg:block"
+          className="pointer-events-none absolute -left-8 top-32 z-10 hidden h-auto w-1/3 max-w-28 -rotate-45 select-none drop-shadow-md lg:block"
         />
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -top-60 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-bottom-64 2xl:max-w-48"
+          className="pointer-events-none absolute -top-60 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-bottom-64 2xl:max-w-48"
         />
 
         <Activities />

--- a/apps/website/src/pages/events/fall-carnival-2023/tickets/[userName].tsx
+++ b/apps/website/src/pages/events/fall-carnival-2023/tickets/[userName].tsx
@@ -94,7 +94,7 @@ const TicketPage: NextPage = () => {
         <Image
           src={leafLeftImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <IntroSection showLinkToClaimTicket />
@@ -142,12 +142,12 @@ const TicketPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -left-8 top-32 z-10 hidden h-auto w-1/3 max-w-28 -rotate-45 select-none lg:block"
+          className="pointer-events-none absolute -left-8 top-32 z-10 hidden h-auto w-1/3 max-w-28 -rotate-45 select-none drop-shadow-md lg:block"
         />
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -top-60 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-bottom-64 2xl:max-w-48"
+          className="pointer-events-none absolute -top-60 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-bottom-64 2xl:max-w-48"
         />
 
         <Activities />

--- a/apps/website/src/pages/events/index.tsx
+++ b/apps/website/src/pages/events/index.tsx
@@ -141,12 +141,12 @@ const EventsPage: NextPage = () => {
         <Image
           src={leafRightImage1}
           alt=""
-          className="pointer-events-none absolute -top-8 right-0 z-10 hidden h-auto w-1/2 max-w-sm select-none lg:block"
+          className="pointer-events-none absolute -top-8 right-0 z-10 hidden h-auto w-1/2 max-w-sm select-none drop-shadow-md lg:block"
         />
         <Image
           src={leafLeftImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <Section dark className="py-24">
@@ -166,12 +166,12 @@ const EventsPage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-32 -left-8 z-10 hidden h-auto w-1/2 max-w-40 -rotate-45 select-none lg:block 2xl:max-w-48"
+          className="pointer-events-none absolute -bottom-32 -left-8 z-10 hidden h-auto w-1/2 max-w-40 -rotate-45 select-none drop-shadow-md lg:block 2xl:max-w-48"
         />
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-60 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-bottom-64 2xl:max-w-48"
+          className="pointer-events-none absolute -bottom-60 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-bottom-64 2xl:max-w-48"
         />
 
         <Section className="grow">

--- a/apps/website/src/pages/found-animal.tsx
+++ b/apps/website/src/pages/found-animal.tsx
@@ -105,12 +105,12 @@ const FoundAnimalPage: NextPage = () => {
         <Image
           src={leafRightImage1}
           alt=""
-          className="pointer-events-none absolute -top-8 right-0 z-10 hidden h-auto w-1/2 max-w-72 select-none lg:block xl:hidden 2xl:block"
+          className="pointer-events-none absolute -top-8 right-0 z-10 hidden h-auto w-1/2 max-w-72 select-none drop-shadow-md lg:block xl:hidden 2xl:block"
         />
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-24 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block"
         />
 
         <Section
@@ -120,7 +120,7 @@ const FoundAnimalPage: NextPage = () => {
           <Image
             src={leafLeftImage1}
             alt=""
-            className="pointer-events-none absolute left-0 top-[40vh] -z-10 h-auto w-1/2 max-w-40 select-none"
+            className="pointer-events-none absolute left-0 top-[40vh] -z-10 h-auto w-1/2 max-w-40 select-none drop-shadow-md"
           />
 
           <div className="mx-auto flex h-[80vh] w-full max-w-lg shrink-0 flex-col overflow-hidden rounded-xl border border-alveus-green bg-alveus-tan/75 shadow-lg backdrop-blur xl:mx-0">

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -247,14 +247,14 @@ const Home: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
           <Image
             src={leafRightImage1}
             alt=""
-            className="absolute -right-32 h-auto max-h-full w-full"
+            className="absolute -right-32 h-auto max-h-full w-full drop-shadow-md"
           />
         </div>
 
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -bottom-20 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none lg:block"
+          className="pointer-events-none absolute -bottom-20 left-0 z-10 hidden h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:block"
         />
 
         <Section dark>
@@ -374,7 +374,7 @@ const Home: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
         <Image
           src={leafRightImage2}
           alt=""
-          className="pointer-events-none absolute -top-44 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-top-52 2xl:max-w-48"
+          className="pointer-events-none absolute -top-44 right-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-top-52 2xl:max-w-48"
         />
 
         <Section>
@@ -418,7 +418,7 @@ const Home: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-44 left-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block 2xl:-bottom-48 2xl:max-w-48"
+          className="pointer-events-none absolute -bottom-44 left-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block 2xl:-bottom-48 2xl:max-w-48"
         />
 
         <Section dark className="grow bg-alveus-green-900">

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -175,7 +175,7 @@ const GiveAnHourPage: NextPage = () => (
           <Image
             src={leafRightImage2}
             alt=""
-            className="pointer-events-none absolute -bottom-14 right-0 -z-10 h-auto w-1/2 max-w-48 select-none lg:-bottom-32 lg:-left-20 lg:right-auto lg:max-w-40"
+            className="pointer-events-none absolute -bottom-14 right-0 -z-10 h-auto w-1/2 max-w-48 select-none drop-shadow-md lg:-bottom-32 lg:-left-20 lg:right-auto lg:max-w-40"
           />
 
           <Card
@@ -225,7 +225,7 @@ const GiveAnHourPage: NextPage = () => (
           <Image
             src={leafLeftImage3}
             alt=""
-            className="pointer-events-none absolute -top-20 right-0 -z-10 h-auto w-1/2 max-w-48 -scale-100 select-none lg:-right-32 lg:max-w-40 lg:scale-x-100"
+            className="pointer-events-none absolute -top-20 right-0 -z-10 h-auto w-1/2 max-w-48 -scale-100 select-none drop-shadow-md lg:-right-32 lg:max-w-40 lg:scale-x-100"
           />
 
           <Card

--- a/apps/website/src/pages/updates.tsx
+++ b/apps/website/src/pages/updates.tsx
@@ -37,7 +37,7 @@ const UpdatesPage: NextPage = () => {
   return (
     <>
       <Meta
-        title="Updates"
+        title="Schedule & Updates"
         description="See upcoming streams in the schedule and stay updated with push notifications"
       />
 

--- a/apps/website/src/pages/voters-guide.tsx
+++ b/apps/website/src/pages/voters-guide.tsx
@@ -197,7 +197,7 @@ const VotePage: NextPage = () => {
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -top-20 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -top-20 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none drop-shadow-md lg:block"
         />
 
         <Section>
@@ -291,7 +291,7 @@ const VotePage: NextPage = () => {
         <Image
           src={leafLeftImage1}
           alt=""
-          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-40 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-40 select-none drop-shadow-md lg:block"
         />
 
         <Section dark>
@@ -380,7 +380,7 @@ const VotePage: NextPage = () => {
         <Image
           src={leafLeftImage2}
           alt=""
-          className="pointer-events-none absolute -bottom-24 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none lg:block"
+          className="pointer-events-none absolute -bottom-24 right-0 z-10 hidden h-auto w-1/2 max-w-48 -scale-x-100 select-none drop-shadow-md lg:block"
         />
 
         <Section dark className="grow bg-alveus-green-900">


### PR DESCRIPTION
## Describe your changes

Adds a subtle shadow to all the leaves on the site, making them stand out slightly more and be less flat.

Also includes two misc fixes for the ambassadors page where the scroll marign wasn't quite enough when the enclosures subnav wraps, and updating the updates page title to match the heading/nav link.

## Notes for testing your change

Shadow looks good on leaves.