### PR TITLE
Handle sub-dependencies in pnpm GitHub deps workaround

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -7,7 +7,7 @@ const afterAllResolved = (lockfile, context) => {
 
   for (const pkg in lockfile.packages) {
     const match = pkg.match(
-      /^(.+)@git\+https:\/\/git@github\.com:(.+)\.git#(.+)$/,
+      /^(.+)@git\+https:\/\/git@github\.com:(.+)\.git#([0-9a-f]+)(\(.+\))?$/,
     );
     if (!match) continue;
 
@@ -15,12 +15,12 @@ const afterAllResolved = (lockfile, context) => {
     const tar = `https://codeload.github.com/${match[2]}/tar.gz/${match[3]}`;
 
     delete lockfile.packages[pkg];
-    lockfile.packages[`${match[1]}@${tar}`] = {
+    lockfile.packages[`${match[1]}@${tar}${match[4]}`] = {
       ...data,
       resolution: { tarball: tar },
     };
 
-    context.log(`Replaced ${pkg} with ${match[1]}@${tar}`);
+    context.log(`Replaced ${pkg} with ${match[1]}@${tar}${match[4]}`);
   }
 
   for (const pkg in lockfile.importers) {

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -15,12 +15,12 @@ const afterAllResolved = (lockfile, context) => {
     const tar = `https://codeload.github.com/${match[2]}/tar.gz/${match[3]}`;
 
     delete lockfile.packages[pkg];
-    lockfile.packages[`${match[1]}@${tar}${match[4]}`] = {
+    lockfile.packages[`${match[1]}@${tar}${match[4] ?? ""}`] = {
       ...data,
       resolution: { tarball: tar },
     };
 
-    context.log(`Replaced ${pkg} with ${match[1]}@${tar}${match[4]}`);
+    context.log(`Replaced ${pkg} with ${match[1]}@${tar}${match[4] ?? ""}`);
   }
 
   for (const pkg in lockfile.importers) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: wtq2iv2r2ygbtlnhhjvlb2roda
+pnpmfileChecksum: urn4mmnpyjudaqso7jbqi45omq
 
 patchedDependencies:
   eslint-plugin-tailwindcss@3.17.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: q3k5ey2pj7rpz2q2umrynuvuse
+pnpmfileChecksum: wtq2iv2r2ygbtlnhhjvlb2roda
 
 patchedDependencies:
   eslint-plugin-tailwindcss@3.17.5:
@@ -337,7 +337,7 @@ importers:
         version: 3.7.0(eslint-plugin-import-x@4.5.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-import-x:
         specifier: ^4.5.0
         version: 4.5.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)
@@ -10288,16 +10288,15 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-import-x: 4.5.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)
       eslint: 9.16.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import-x@4.5.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6))
@@ -10322,7 +10321,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6)):
+  eslint-plugin-import@2.31.0(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -10333,7 +10332,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.16.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -10344,8 +10343,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
## Describe your changes

Should fix the issue seen in #904 + #903 + #902 where the replacement we're doing in the lockfile didn't account for how pnpm lists sub-dependency versions as part of the parent package.

Unsure why there is a diff in the lockfile beyond the hash change -- I just run `pnpm install --fix-lockfile` locally to bump the hash.

## Notes for testing your change

I tested this over in my fork: https://github.com/MattIPv4/alveusgg/pull/22
