### PR TITLE
Update show and tell image/video attachments to be clickable

### DIFF
--- a/apps/website/src/components/shared/form/ImageUploadAttachment.tsx
+++ b/apps/website/src/components/shared/form/ImageUploadAttachment.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ReactNode, MouseEvent } from "react";
 
 import { classes } from "@/utils/classes";
 
@@ -66,18 +66,32 @@ export function ImageUploadAttachment({
   fileReference,
   children = "",
   showRemoveButton = true,
+  onClick,
 }: {
   removeFileReference: (id: string) => void;
   fileReference: FileReference;
   children?: ReactNode | ReactNode[];
   showRemoveButton?: boolean;
+  onClick?: (e: MouseEvent<HTMLAnchorElement>) => void;
 }) {
+  const src =
+    fileReference.status === "saved" || fileReference.status === "upload.done"
+      ? fileReference.url
+      : "dataURL" in fileReference
+        ? fileReference.dataURL
+        : undefined;
+
   return (
     <div className="flex flex-row gap-5 rounded-lg bg-white p-2 px-4 shadow-lg">
       <div className="py-2">
-        <div className="relative size-32 overflow-hidden rounded-lg bg-gray-200">
+        <a
+          href={src}
+          className="relative block size-32 overflow-hidden rounded-lg bg-gray-200"
+          title="Click to view image"
+          onClick={onClick}
+        >
           <ImageUploadFilePreview fileReference={fileReference} />
-        </div>
+        </a>
 
         {showRemoveButton && (
           <div className="p-2">

--- a/apps/website/src/components/shared/form/VideoLinksField.tsx
+++ b/apps/website/src/components/shared/form/VideoLinksField.tsx
@@ -119,7 +119,14 @@ export function VideoLinksField({
                   className="size-5"
                   platform={parseVideoUrl(url)?.platform}
                 />
-                <span className="min-w-0 flex-1 truncate text-left">{url}</span>
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="min-w-0 flex-1 truncate text-left text-blue-500 hover:underline"
+                >
+                  {url}
+                </a>
                 <Button
                   size="small"
                   width="auto"

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -1,10 +1,5 @@
-import type {
-  MouseEvent,
-  type FormEvent,
-  useCallback,
-  useMemo,
-  useState
-} from "react";
+import { useCallback, useMemo, useState } from "react";
+import type { FormEvent , MouseEvent } from "react";
 import { useRouter } from "next/router";
 import Image from "next/image";
 import type { ShowAndTellEntry } from "@prisma/client";


### PR DESCRIPTION
## Describe your changes

<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->

resolves issue https://github.com/alveusgg/alveusgg/issues/565.
- Clicking on a image attachment will display the image in a dialog
- Video attachments are now clickable hyperlinks instead of just text

## Notes for testing your change
I tested the changes locally.
<img width="1440" alt="Screenshot 2024-12-22 at 17 32 23" src="https://github.com/user-attachments/assets/28c720c6-5e0f-446a-9393-38e0fc696701" />

