### PR TITLE
Do not error when sending pushes fails

### DIFF
--- a/apps/website/src/pages/api/notifications/send-push.ts
+++ b/apps/website/src/pages/api/notifications/send-push.ts
@@ -149,26 +149,21 @@ export default createTokenProtectedApiHandler(
       console.error("Failed to send push notification", e);
     }
 
-    const done = delivered || expired;
-    await updateNotificationPushStatus(
-      done
-        ? {
-            processingStatus: "DONE",
-            notificationId: options.notificationId,
-            subscriptionId: options.subscriptionId,
-            deliveredAt: delivered ? now : undefined,
-          }
-        : {
-            processingStatus:
-              options.attempt && options.attempt >= pushMaxAttempts
-                ? "DONE"
-                : "PENDING",
-            notificationId: options.notificationId,
-            subscriptionId: options.subscriptionId,
-            failedAt: now,
-          },
-    );
+    const status =
+      delivered ||
+      expired ||
+      (options.attempt && options.attempt >= pushMaxAttempts)
+        ? "DONE"
+        : "PENDING";
 
-    return delivered;
+    await updateNotificationPushStatus({
+      processingStatus: status,
+      notificationId: options.notificationId,
+      subscriptionId: options.subscriptionId,
+      deliveredAt: delivered ? now : undefined,
+      failedAt: delivered ? undefined : now,
+    });
+
+    return true;
   },
 );


### PR DESCRIPTION
## Describe your changes

Instead of returning a 500 error the send API endpoint will now respond with 200 even if the push was not delivered, so the queue does not retry the send action in addition to the internal retry system. We suspect that might have led to too many push requests to the vendors (apple, google, microsoft etc.).

## Notes for testing your change

Test notification pushes still work.