### PR TITLE
Allow overlay components to be hidden by query param

### DIFF
--- a/apps/website/src/components/overlay/Datetime.tsx
+++ b/apps/website/src/components/overlay/Datetime.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+import { DATETIME_ALVEUS_ZONE, formatDateTimeParts } from "@/utils/datetime";
+import { classes } from "@/utils/classes";
+
+const Datetime = ({
+  className,
+  children,
+}: {
+  className?: string;
+  children?: ReactNode;
+}) => {
+  // Get the current time and date
+  // Refresh every 250ms
+  const [time, setTime] = useState<{
+    time: string;
+    date: string;
+  }>();
+  const interval = useRef<NodeJS.Timeout>(null);
+  useEffect(() => {
+    const update = () => {
+      const date = new Date();
+      const parts = formatDateTimeParts(
+        date,
+        { style: "short", time: "seconds", timezone: true },
+        { zone: DATETIME_ALVEUS_ZONE },
+      );
+
+      // Get the hour -> second parts
+      const hourIdx = parts.findIndex((part) => part.type === "hour");
+      const secondIdx = parts.findIndex((part) => part.type === "second");
+      if (hourIdx === -1 || secondIdx === -1) return;
+      const timeParts = parts
+        .slice(hourIdx, secondIdx + 1)
+        .map((part) => part.value);
+
+      // Get the AM/PM part and the timezone
+      const dayPeriod = parts.find((part) => part.type === "dayPeriod");
+      if (dayPeriod) timeParts.push(" ", dayPeriod.value);
+      const timezone = parts.find((part) => part.type === "timeZoneName");
+      if (timezone) timeParts.push(" ", timezone.value);
+
+      // Get the date
+      const year = parts.find((part) => part.type === "year");
+      const month = parts.find((part) => part.type === "month");
+      const day = parts.find((part) => part.type === "day");
+      if (!year || !month || !day) return;
+
+      setTime({
+        time: timeParts.join(""),
+        date: [year, month, day]
+          .map((part) => part.value.padStart(2, "0"))
+          .join("-"),
+      });
+    };
+
+    update();
+    interval.current = setInterval(update, 250);
+    return () => clearInterval(interval.current ?? undefined);
+  }, []);
+
+  return (
+    <div
+      className={classes(
+        className,
+        "flex flex-col gap-1 font-mono font-medium text-white text-stroke-2",
+      )}
+    >
+      {time && (
+        <>
+          <p className="text-4xl">{time.time}</p>
+          <p className="text-4xl">{time.date}</p>
+        </>
+      )}
+
+      {children}
+    </div>
+  );
+};
+
+export default Datetime;

--- a/apps/website/src/components/overlay/Event.tsx
+++ b/apps/website/src/components/overlay/Event.tsx
@@ -1,0 +1,120 @@
+import Image from "next/image";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Transition } from "@headlessui/react";
+import { keepPreviousData } from "@tanstack/react-query";
+
+import { trpc } from "@/utils/trpc";
+import { DATETIME_ALVEUS_ZONE, formatDateTimeRelative } from "@/utils/datetime";
+import { classes } from "@/utils/classes";
+import { getFormattedTitle, twitchChannels } from "@/data/calendar-events";
+
+import logoImage from "@/assets/logo.png";
+
+const Event = ({ className }: { className?: string }) => {
+  // Set the range for upcoming events to the next 3 days
+  // Refresh every 60s
+  const [upcomingRange, setUpcomingRange] = useState<[Date, Date]>();
+  const upcomingRangeInterval = useRef<NodeJS.Timeout>(null);
+  useEffect(() => {
+    const updateRange = () => {
+      const now = new Date();
+      const next = new Date(now);
+      next.setDate(next.getDate() + 3);
+      setUpcomingRange([now, next]);
+    };
+
+    updateRange();
+    upcomingRangeInterval.current = setInterval(updateRange, 60 * 1000);
+    return () => clearInterval(upcomingRangeInterval.current ?? undefined);
+  }, []);
+
+  // Get the upcoming events and the first event ID
+  // Refresh when the range changes
+  const { data: events } = trpc.calendarEvents.getCalendarEvents.useQuery(
+    { start: upcomingRange?.[0], end: upcomingRange?.[1] },
+    { enabled: upcomingRange !== undefined, placeholderData: keepPreviousData },
+  );
+  const firstEventId = useMemo(
+    () => events?.find(twitchChannels.alveus.filter)?.id,
+    [events],
+  );
+
+  // If we have an upcoming event, swap socials with it
+  // Swap every 60s
+  const [visibleEventId, setVisibleEventId] = useState<string>();
+  const eventInterval = useRef<NodeJS.Timeout>(null);
+  useEffect(() => {
+    if (!firstEventId) {
+      setVisibleEventId(undefined);
+      return;
+    }
+
+    const swapEvent = () =>
+      setVisibleEventId((prev) => (prev ? undefined : firstEventId));
+    swapEvent();
+    eventInterval.current = setInterval(swapEvent, 60 * 1000);
+    return () => clearInterval(eventInterval.current ?? undefined);
+  }, [firstEventId]);
+  const event = useMemo(
+    () =>
+      visibleEventId && events?.find((event) => event.id === visibleEventId),
+    [visibleEventId, events],
+  );
+
+  return (
+    <>
+      <Transition show={event !== undefined}>
+        <div
+          className={classes(
+            className,
+            "text-stroke font-bold text-white transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300",
+          )}
+        >
+          <p>Upcoming:</p>
+
+          {event && (
+            <>
+              <p className="text-xl">
+                {getFormattedTitle(event, twitchChannels.alveus.username, 30)}
+              </p>
+              <p className="text-xl">
+                {formatDateTimeRelative(
+                  event.startAt,
+                  {
+                    style: "long",
+                    time: event.hasTime ? "minutes" : undefined,
+                    timezone: event.hasTime,
+                  },
+                  { zone: DATETIME_ALVEUS_ZONE },
+                )}
+              </p>
+            </>
+          )}
+        </div>
+      </Transition>
+
+      <Transition show={event === undefined}>
+        <div
+          className={classes(
+            className,
+            "flex items-center gap-2 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300",
+          )}
+        >
+          <Image
+            src={logoImage}
+            alt=""
+            height={64}
+            className="h-16 w-auto opacity-75 brightness-150 contrast-125 drop-shadow grayscale"
+          />
+
+          <div className="text-stroke text-xl font-bold text-white">
+            <p>alveussanctuary.org</p>
+            <p>@alveussanctuary</p>
+          </div>
+        </div>
+      </Transition>
+    </>
+  );
+};
+
+export default Event;

--- a/apps/website/src/components/overlay/Timecode.tsx
+++ b/apps/website/src/components/overlay/Timecode.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from "react";
+
+import { classes } from "@/utils/classes";
+
+const Timecode = ({ className }: { className?: string }) => {
+  // Get the current minutes/seconds as a binary code
+  // Refresh every 250ms
+  const [bits, setBits] = useState<string[]>();
+  const interval = useRef<NodeJS.Timeout>(null);
+  useEffect(() => {
+    const update = () => {
+      const date = new Date();
+      const minutes = date.getMinutes();
+      const seconds = date.getSeconds();
+
+      setBits((minutes * 60 + seconds).toString(2).padStart(12, "0").split(""));
+    };
+
+    update();
+    interval.current = setInterval(update, 250);
+    return () => clearInterval(interval.current ?? undefined);
+  }, []);
+
+  return (
+    <div className={classes(className, "grid grid-cols-12")}>
+      {bits?.map((bit, idx) => (
+        <div
+          key={`${bit}-${idx}`}
+          className={classes(
+            "size-1",
+            bit === "0" ? "bg-gray-400" : "bg-alveus-tan-800",
+          )}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default Timecode;

--- a/apps/website/src/components/overlay/Weather.tsx
+++ b/apps/website/src/components/overlay/Weather.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from "react";
+
+import { type WeatherResponse } from "@/pages/api/stream/weather";
+
+const Weather = () => {
+  // Get the current weather
+  // Refresh every 60s
+  const [weather, setWeather] = useState<WeatherResponse>();
+  const interval = useRef<NodeJS.Timeout>(null);
+  useEffect(() => {
+    const refresh = async () => {
+      const response = await fetch("/api/stream/weather");
+      if (response.ok) {
+        const data = await response.json();
+        setWeather(data);
+      }
+    };
+
+    refresh();
+    interval.current = setInterval(refresh, 60 * 1000);
+    return () => clearInterval(interval.current ?? undefined);
+  }, []);
+
+  // Remove the weather data if older than 10m
+  const stale = useRef<NodeJS.Timeout>(null);
+  useEffect(() => {
+    if (!weather) return;
+
+    stale.current = setTimeout(() => setWeather(undefined), 10 * 60 * 1000);
+    return () => clearTimeout(stale.current ?? undefined);
+  }, [weather]);
+
+  return (
+    weather && (
+      <p className="text-3xl">
+        {weather.temperature.fahrenheit}°F{" "}
+        <span className="text-xl">({weather.temperature.celsius}°C)</span>
+      </p>
+    )
+  );
+};
+
+export default Weather;

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -4,8 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { DATETIME_ALVEUS_ZONE, formatDateTimeParts } from "@/utils/datetime";
 
 import Event from "@/components/overlay/Event";
-
-import { type WeatherResponse } from "../api/stream/weather";
+import Weather from "@/components/overlay/Weather";
 
 const colors = ["#7E7E7E", "#4E3029"];
 
@@ -69,34 +68,6 @@ const OverlayPage: NextPage = () => {
     return () => clearInterval(timeInterval.current ?? undefined);
   }, []);
 
-  // Get the current weather
-  // Refresh every 60s
-  const [weather, setWeather] = useState<WeatherResponse>();
-  const weatherInterval = useRef<NodeJS.Timeout>(null);
-  useEffect(() => {
-    const fetchWeather = async () => {
-      const response = await fetch("/api/stream/weather");
-      if (response.ok) {
-        const data = await response.json();
-        setWeather(data);
-      }
-    };
-
-    fetchWeather();
-    weatherInterval.current = setInterval(fetchWeather, 60 * 1000);
-    return () => clearInterval(weatherInterval.current ?? undefined);
-  }, []);
-
-  // Remove the weather data if older than 10m
-  const weatherStaleTimer = useRef<NodeJS.Timeout>(null);
-  useEffect(() => {
-    if (!weather) return;
-
-    const updateWeather = () => setWeather(undefined);
-    weatherStaleTimer.current = setTimeout(updateWeather, 10 * 60 * 1000);
-    return () => clearTimeout(weatherStaleTimer.current ?? undefined);
-  }, [weather]);
-
   // This can be a client-side only page
   if (!time) return null;
 
@@ -105,12 +76,8 @@ const OverlayPage: NextPage = () => {
       <div className="absolute right-2 top-2 flex flex-col gap-1 text-right font-mono font-medium text-white text-stroke-2">
         <p className="text-4xl">{time.time}</p>
         <p className="text-4xl">{time.date}</p>
-        {weather && (
-          <p className="text-3xl">
-            {weather.temperature.fahrenheit}°F{" "}
-            <span className="text-xl">({weather.temperature.celsius}°C)</span>
-          </p>
-        )}
+
+        <Weather />
       </div>
 
       <Event className="absolute bottom-2 left-2" />

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -5,8 +5,7 @@ import { DATETIME_ALVEUS_ZONE, formatDateTimeParts } from "@/utils/datetime";
 
 import Event from "@/components/overlay/Event";
 import Weather from "@/components/overlay/Weather";
-
-const colors = ["#7E7E7E", "#4E3029"];
+import Timecode from "@/components/overlay/Timecode";
 
 const OverlayPage: NextPage = () => {
   // Get the current time and date
@@ -14,7 +13,6 @@ const OverlayPage: NextPage = () => {
   const [time, setTime] = useState<{
     time: string;
     date: string;
-    code: string[];
   }>();
   const timeInterval = useRef<NodeJS.Timeout>(null);
   useEffect(() => {
@@ -46,16 +44,7 @@ const OverlayPage: NextPage = () => {
       const day = parts.find((part) => part.type === "day");
       if (!year || !month || !day) return;
 
-      const minutes = date.getMinutes();
-      const seconds = date.getSeconds();
-
-      const code = (minutes * 60 + seconds)
-        .toString(2)
-        .padStart(12, "0")
-        .split("");
-
       setTime({
-        code,
         time: timeParts.join(""),
         date: [year, month, day]
           .map((part) => part.value.padStart(2, "0"))
@@ -82,17 +71,7 @@ const OverlayPage: NextPage = () => {
 
       <Event className="absolute bottom-2 left-2" />
 
-      <div className="absolute bottom-0 right-0 grid grid-cols-12">
-        {time.code.map((bit, idx) => (
-          <div
-            key={`${bit}-${idx}`}
-            style={{
-              backgroundColor: bit === "0" ? colors[0] : colors[1],
-            }}
-            className="size-1"
-          />
-        ))}
-      </div>
+      <Timecode className="absolute bottom-0 right-0" />
     </div>
   );
 };

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -1,73 +1,16 @@
 import { type NextPage } from "next";
-import { useEffect, useRef, useState } from "react";
-
-import { DATETIME_ALVEUS_ZONE, formatDateTimeParts } from "@/utils/datetime";
 
 import Event from "@/components/overlay/Event";
 import Weather from "@/components/overlay/Weather";
 import Timecode from "@/components/overlay/Timecode";
+import Datetime from "@/components/overlay/Datetime";
 
 const OverlayPage: NextPage = () => {
-  // Get the current time and date
-  // Refresh every 250ms
-  const [time, setTime] = useState<{
-    time: string;
-    date: string;
-  }>();
-  const timeInterval = useRef<NodeJS.Timeout>(null);
-  useEffect(() => {
-    const updateTime = () => {
-      const date = new Date();
-      const parts = formatDateTimeParts(
-        date,
-        { style: "short", time: "seconds", timezone: true },
-        { zone: DATETIME_ALVEUS_ZONE },
-      );
-
-      // Get the hour -> second parts
-      const hourIdx = parts.findIndex((part) => part.type === "hour");
-      const secondIdx = parts.findIndex((part) => part.type === "second");
-      if (hourIdx === -1 || secondIdx === -1) return;
-      const timeParts = parts
-        .slice(hourIdx, secondIdx + 1)
-        .map((part) => part.value);
-
-      // Get the AM/PM part and the timezone
-      const dayPeriod = parts.find((part) => part.type === "dayPeriod");
-      if (dayPeriod) timeParts.push(" ", dayPeriod.value);
-      const timezone = parts.find((part) => part.type === "timeZoneName");
-      if (timezone) timeParts.push(" ", timezone.value);
-
-      // Get the date
-      const year = parts.find((part) => part.type === "year");
-      const month = parts.find((part) => part.type === "month");
-      const day = parts.find((part) => part.type === "day");
-      if (!year || !month || !day) return;
-
-      setTime({
-        time: timeParts.join(""),
-        date: [year, month, day]
-          .map((part) => part.value.padStart(2, "0"))
-          .join("-"),
-      });
-    };
-
-    updateTime();
-    timeInterval.current = setInterval(updateTime, 250);
-    return () => clearInterval(timeInterval.current ?? undefined);
-  }, []);
-
-  // This can be a client-side only page
-  if (!time) return null;
-
   return (
     <div className="h-screen w-full">
-      <div className="absolute right-2 top-2 flex flex-col gap-1 text-right font-mono font-medium text-white text-stroke-2">
-        <p className="text-4xl">{time.time}</p>
-        <p className="text-4xl">{time.date}</p>
-
+      <Datetime className="absolute right-2 top-2 text-right">
         <Weather />
-      </div>
+      </Datetime>
 
       <Event className="absolute bottom-2 left-2" />
 

--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -1,4 +1,6 @@
 import { type NextPage } from "next";
+import { useRouter } from "next/router";
+import { useMemo } from "react";
 
 import Event from "@/components/overlay/Event";
 import Weather from "@/components/overlay/Weather";
@@ -6,15 +8,33 @@ import Timecode from "@/components/overlay/Timecode";
 import Datetime from "@/components/overlay/Datetime";
 
 const OverlayPage: NextPage = () => {
+  // Allow the hide query parameter to hide components
+  const { query } = useRouter();
+  const hide = useMemo(
+    () =>
+      new Set(
+        query.hide
+          ? Array.isArray(query.hide)
+            ? query.hide
+            : [query.hide]
+          : [],
+      ),
+    [query.hide],
+  );
+
   return (
     <div className="h-screen w-full">
-      <Datetime className="absolute right-2 top-2 text-right">
-        <Weather />
-      </Datetime>
+      {!hide.has("datetime") && (
+        <Datetime className="absolute right-2 top-2 text-right">
+          {!hide.has("weather") && <Weather />}
+        </Datetime>
+      )}
 
-      <Event className="absolute bottom-2 left-2" />
+      {!hide.has("event") && <Event className="absolute bottom-2 left-2" />}
 
-      <Timecode className="absolute bottom-0 right-0" />
+      {!hide.has("timecode") && (
+        <Timecode className="absolute bottom-0 right-0" />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Describe your changes

Allows for components in the stream overlay, such as the event/social promo, to be hidden via a query parameter.

## Notes for testing your change

By default, all components of the overlay continue to render as expected. Using the `hide=` query parameter, one or more components can be hidden (e.g. `?hide=event` or `?hide=timecode&hide=datetime`).
