### PR TITLE
Fix ESLint + Prisma lint warnings

### DIFF
--- a/apps/website/prisma/schema.prisma
+++ b/apps/website/prisma/schema.prisma
@@ -2,8 +2,7 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["fullTextSearch"]
+  provider = "prisma-client-js"
 }
 
 datasource db {

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -180,7 +180,7 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
         ),
       },
     ],
-    [ambassador, enclosure],
+    [ambassador, species, enclosure],
   );
 
   const photoswipe = `photoswipe-${useId().replace(/\W/g, "")}`;


### PR DESCRIPTION
## Describe your changes

Fixes an ESLint hook warning + a Prisma warning relating to fullTextSearch (it is no longer in preview).

This does not fix the foreign key index warning from Prisma as a _bunch_ of the models are lacking these which I figured is either intentional or something that should be addressed in isolation.

## Notes for testing your change

Things still work :shrug: