### PR TITLE
Fix removing description from existing calendar event

### DIFF
--- a/apps/website/src/components/admin/calendar-events/CalendarEventForm.tsx
+++ b/apps/website/src/components/admin/calendar-events/CalendarEventForm.tsx
@@ -77,13 +77,11 @@ export function CalendarEventForm({
       const mutationData: CalendarEventSchema = {
         title: String(formData.get("title")),
         category: String(formData.get("category")),
+        description: String(formData.get("description")) || null,
         link,
         startAt,
         hasTime,
       };
-
-      if (formData.get("description"))
-        mutationData.description = String(formData.get("description"));
 
       if (action === "edit") {
         if (!calendarEvent) return;

--- a/apps/website/src/server/apis/discord.ts
+++ b/apps/website/src/server/apis/discord.ts
@@ -43,7 +43,7 @@ export async function createScheduledGuildEvent(
   end: Date,
   title: string,
   location: string,
-  description?: string,
+  description: string | null,
 ) {
   const response = await fetch(
     `https://discord.com/api/v10/guilds/${guildId}/scheduled-events`,

--- a/apps/website/src/server/db/calendar-events.ts
+++ b/apps/website/src/server/db/calendar-events.ts
@@ -21,7 +21,7 @@ import { getFormattedTitle, twitchChannels } from "@/data/calendar-events";
 export const calendarEventSchema = z.object({
   title: z.string().min(1),
   category: z.string().min(1),
-  description: z.string().min(1).optional(),
+  description: z.string().min(1).nullable(),
   link: z.string().url(),
   startAt: z.date(),
   hasTime: z.boolean().default(true),
@@ -302,19 +302,19 @@ export async function syncDiscordEvents(guildId: string) {
   const create: {
     title: string;
     link: string;
-    description?: string;
+    description: string | null;
     startAt: Date;
   }[] = [];
   for (const event of events) {
     // Look for a matching event in the Discord API
     const title = getFormattedTitle(event);
-    const description = event.description || undefined;
+    const description = event.description;
     const date = event.startAt.toISOString().replace(/\.\d+Z$/, "+00:00");
     const idx = existing.findIndex(
       (e) =>
         e.name === title &&
         e.entity_metadata.location === event.link &&
-        (e.description || undefined) === description &&
+        e.description === description &&
         e.scheduled_start_time === date,
     );
 


### PR DESCRIPTION
## Describe your changes

Ensures that the description for a calendar event is always passed to the backend so that a description can be removed for an event that already has one set.

## Notes for testing your change

- Create a calendar event without a description
- Edit calendar event to have a description
- Refresh to confirm description set
- Edit calendar event to remove description
- Refresh to confirm description removed
