### PR TITLE
Add Bluesky to socials

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -11,6 +11,7 @@ import { camelToKebab, sentenceToKebab } from "@/utils/string-case";
 import { typeSafeObjectEntries, typeSafeObjectKeys } from "@/utils/helpers";
 
 import { twitchChannels } from "@/data/calendar-events";
+import socials from "@/data/socials";
 
 import "@/env/index.js";
 
@@ -295,26 +296,11 @@ const config: NextConfig = {
       destination: "https://bio.link/alveussanctuary",
       permanent: true,
     },
-    {
-      source: "/instagram",
-      destination: "https://www.instagram.com/alveussanctuary",
+    ...typeSafeObjectEntries(socials).map(([key, { link }]) => ({
+      source: `/${key}`,
+      destination: link,
       permanent: true,
-    },
-    {
-      source: "/twitter",
-      destination: "https://twitter.com/AlveusSanctuary",
-      permanent: true,
-    },
-    {
-      source: "/youtube",
-      destination: "https://www.youtube.com/AlveusSanctuary",
-      permanent: true,
-    },
-    {
-      source: "/tiktok",
-      destination: "https://www.tiktok.com/@alveussanctuary",
-      permanent: true,
-    },
+    })),
     {
       source: "/vods",
       destination:
@@ -346,11 +332,6 @@ const config: NextConfig = {
       source: "/vods/connor-projects",
       destination:
         "https://youtube.com/playlist?list=PLtQafKoimfLdtIla7qiJCFYDd4qDZG6y-",
-      permanent: true,
-    },
-    {
-      source: "/twitch",
-      destination: "https://twitch.tv/alveussanctuary",
       permanent: true,
     },
     {

--- a/apps/website/src/components/layout/footer/Socials.tsx
+++ b/apps/website/src/components/layout/footer/Socials.tsx
@@ -106,7 +106,7 @@ const Socials = () => {
                   className={buttonClasses}
                   href={social.link}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noreferrer me"
                   title={social.title}
                 >
                   <social.icon size={24} />

--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -74,10 +74,11 @@ export function DesktopMenu() {
         <ul className="contents">
           {Object.entries(utilityNavStructure).map(([key, link]) => (
             <li key={key}>
+              {/* eslint-disable-next-line react/jsx-no-target-blank */}
               <a
                 className="block rounded-xl bg-transparent p-2 text-white transition-colors hover:bg-white hover:text-alveus-green"
                 target="_blank"
-                rel="noreferrer"
+                rel={link.rel}
                 href={link.link}
                 title={link.title}
               >

--- a/apps/website/src/components/shared/data/socials.tsx
+++ b/apps/website/src/components/shared/data/socials.tsx
@@ -5,6 +5,7 @@ import IconTikTok from "@/icons/IconTikTok";
 import IconTwitter from "@/icons/IconTwitter";
 import IconTwitch from "@/icons/IconTwitch";
 import IconYouTube from "@/icons/IconYouTube";
+import IconBluesky from "@/icons/IconBluesky";
 
 type SocialLink = {
   link: string;
@@ -27,6 +28,11 @@ const socials = {
     link: "https://twitter.com/AlveusSanctuary",
     title: "X (Twitter)",
     icon: IconTwitter,
+  },
+  bluesky: {
+    link: "https://bsky.app/profile/alveussanctuary.org",
+    title: "Bluesky",
+    icon: IconBluesky,
   },
   tiktok: {
     link: "https://www.tiktok.com/@alveussanctuary",

--- a/apps/website/src/components/shared/data/socials.tsx
+++ b/apps/website/src/components/shared/data/socials.tsx
@@ -7,43 +7,30 @@ import IconTwitch from "@/icons/IconTwitch";
 import IconYouTube from "@/icons/IconYouTube";
 import IconBluesky from "@/icons/IconBluesky";
 
-type SocialLink = {
-  link: string;
-  title: string;
-  icon: ComponentType;
-};
+import socials from "@/data/socials";
 
-const socials = {
-  twitch: {
-    link: "https://twitch.tv/alveussanctuary",
-    title: "Twitch.tv",
-    icon: IconTwitch,
-  },
-  instagram: {
-    link: "https://www.instagram.com/alveussanctuary",
-    title: "Instagram",
-    icon: IconInstagram,
-  },
-  twitter: {
-    link: "https://twitter.com/AlveusSanctuary",
-    title: "X (Twitter)",
-    icon: IconTwitter,
-  },
-  bluesky: {
-    link: "https://bsky.app/profile/alveussanctuary.org",
-    title: "Bluesky",
-    icon: IconBluesky,
-  },
-  tiktok: {
-    link: "https://www.tiktok.com/@alveussanctuary",
-    title: "TikTok",
-    icon: IconTikTok,
-  },
-  youtube: {
-    link: "https://www.youtube.com/c/AlveusSanctuary",
-    title: "YouTube",
-    icon: IconYouTube,
-  },
-} satisfies Record<string, SocialLink>;
+import {
+  typeSafeObjectEntries,
+  typeSafeObjectFromEntries,
+} from "@/utils/helpers";
 
-export default socials;
+const icons = {
+  twitch: IconTwitch,
+  instagram: IconInstagram,
+  twitter: IconTwitter,
+  bluesky: IconBluesky,
+  tiktok: IconTikTok,
+  youtube: IconYouTube,
+} as const satisfies Record<keyof typeof socials, ComponentType>;
+
+const links = typeSafeObjectFromEntries(
+  typeSafeObjectEntries(socials).map(([key, social]) => [
+    key,
+    {
+      ...social,
+      icon: icons[key],
+    },
+  ]),
+);
+
+export default links;

--- a/apps/website/src/data/navigation.ts
+++ b/apps/website/src/data/navigation.ts
@@ -1,5 +1,9 @@
 import IconAmazon from "@/icons/IconAmazon";
 import socials from "@/components/shared/data/socials";
+import {
+  typeSafeObjectEntries,
+  typeSafeObjectFromEntries,
+} from "@/utils/helpers";
 
 export type NavStructureLink = {
   title: string;
@@ -129,6 +133,15 @@ export const utilityNavStructure = {
     link: "/wishlist",
     title: "Amazon Wishlist",
     icon: IconAmazon,
+    rel: "noreferrer",
   },
-  ...socials,
+  ...typeSafeObjectFromEntries(
+    typeSafeObjectEntries(socials).map(([key, value]) => [
+      key,
+      {
+        ...value,
+        rel: "noreferrer me",
+      },
+    ]),
+  ),
 };

--- a/apps/website/src/data/socials.ts
+++ b/apps/website/src/data/socials.ts
@@ -25,7 +25,7 @@ const socials = {
     title: "TikTok",
   },
   youtube: {
-    link: "https://www.youtube.com/c/AlveusSanctuary",
+    link: "https://www.youtube.com/AlveusSanctuary",
     title: "YouTube",
   },
 } as const satisfies Record<string, SocialLink>;

--- a/apps/website/src/data/socials.ts
+++ b/apps/website/src/data/socials.ts
@@ -1,0 +1,33 @@
+type SocialLink = {
+  link: string;
+  title: string;
+};
+
+const socials = {
+  twitch: {
+    link: "https://twitch.tv/alveussanctuary",
+    title: "Twitch.tv",
+  },
+  instagram: {
+    link: "https://www.instagram.com/alveussanctuary",
+    title: "Instagram",
+  },
+  twitter: {
+    link: "https://twitter.com/AlveusSanctuary",
+    title: "X (Twitter)",
+  },
+  bluesky: {
+    link: "https://bsky.app/profile/alveussanctuary.org",
+    title: "Bluesky",
+  },
+  tiktok: {
+    link: "https://www.tiktok.com/@alveussanctuary",
+    title: "TikTok",
+  },
+  youtube: {
+    link: "https://www.youtube.com/c/AlveusSanctuary",
+    title: "YouTube",
+  },
+} as const satisfies Record<string, SocialLink>;
+
+export default socials;

--- a/apps/website/src/icons/IconBluesky.tsx
+++ b/apps/website/src/icons/IconBluesky.tsx
@@ -1,0 +1,13 @@
+import { BaseIcon, type IconProps } from "@/icons/BaseIcon";
+
+// This SVG code is derived from FontAwesome (https://fontawesome.com/icons/bluesky)
+export default function IconBluesky(props: IconProps) {
+  return (
+    <BaseIcon viewBox="0 0 512 512" {...props}>
+      <path
+        fill="currentColor"
+        d="M111.8 62.2C170.2 105.9 233 194.7 256 242.4c23-47.6 85.8-136.4 144.2-180.2c42.1-31.6 110.3-56 110.3 21.8c0 15.5-8.9 130.5-14.1 149.2C478.2 298 412 314.6 353.1 304.5c102.9 17.5 129.1 75.5 72.5 133.5c-107.4 110.2-154.3-27.6-166.3-62.9l0 0c-1.7-4.9-2.6-7.8-3.3-7.8s-1.6 3-3.3 7.8l0 0c-12 35.3-59 173.1-166.3 62.9c-56.5-58-30.4-116 72.5-133.5C100 314.6 33.8 298 15.7 233.1C10.4 214.4 1.5 99.4 1.5 83.9c0-77.8 68.2-53.4 110.3-21.8z"
+      />
+    </BaseIcon>
+  );
+}


### PR DESCRIPTION
## Describe your changes

Adds the Alveus Bluesky account to the social links in the nav + footer, and to the redirects.

## Notes for testing your change

Link for Bluesky goes to the correct place, all social redirects continue to work.