### PR TITLE
Random Twitch clips stream overlay

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -378,7 +378,7 @@ const config: NextConfig = {
                 ["development", "preview"].includes(process.env.VERCEL_ENV) &&
                 "https://vercel.live/",
               // Twitch embeds:
-              "https://embed.twitch.tv/ https://player.twitch.tv/ https://www.twitch.tv/",
+              "https://embed.twitch.tv/ https://player.twitch.tv/ https://clips.twitch.tv/ https://www.twitch.tv/",
               // YouTube embeds:
               "https://www.youtube-nocookie.com/",
               // Streamable embeds:

--- a/apps/website/src/pages/stream/clips.tsx
+++ b/apps/website/src/pages/stream/clips.tsx
@@ -200,34 +200,36 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
   );
 
   return (
-    <div className="flex h-screen w-full p-8">
+    <div className="flex h-screen w-full items-center justify-center p-8">
       {clip && (
-        <div className="relative my-auto aspect-video h-auto w-full">
-          <div className="absolute -inset-2 -z-10 rounded-xl bg-alveus-green shadow-lg" />
+        <div className="flex aspect-video h-full max-w-full items-center justify-center">
+          <div className="relative flex aspect-video w-full items-center justify-center">
+            <div className="absolute -inset-2 -z-10 rounded-xl bg-alveus-green shadow-lg" />
 
-          <Transition show={details}>
-            <div className="absolute left-2 top-2 rounded-lg bg-black/25 px-4 py-2 text-white backdrop-blur transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300">
-              <h1 className="text-4xl">
-                {clip.title}
-                <span className="ml-1 text-2xl">
-                  {" "}
-                  (
-                  {new Date(clip.created).toLocaleDateString(undefined, {
-                    dateStyle: "long",
-                  })}
-                  )
-                </span>
-              </h1>
-              <p className="text-xl">Clipped by {clip.creator}</p>
-            </div>
-          </Transition>
+            <Transition show={details}>
+              <div className="absolute left-2 top-2 rounded-lg bg-black/25 px-4 py-2 text-white backdrop-blur transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300">
+                <h1 className="text-4xl">
+                  {clip.title}
+                  <span className="ml-1 text-2xl">
+                    {" "}
+                    (
+                    {new Date(clip.created).toLocaleDateString(undefined, {
+                      dateStyle: "long",
+                    })}
+                    )
+                  </span>
+                </h1>
+                <p className="text-xl">Clipped by {clip.creator}</p>
+              </div>
+            </Transition>
 
-          <iframe
-            src={getTwitchEmbed(clip.id, window.location.hostname)}
-            onLoad={onLoad}
-            onError={onError}
-            className="size-full rounded-lg"
-          />
+            <iframe
+              src={getTwitchEmbed(clip.id, window.location.hostname)}
+              onLoad={onLoad}
+              onError={onError}
+              className="size-full rounded-lg"
+            />
+          </div>
         </div>
       )}
     </div>

--- a/apps/website/src/pages/stream/clips.tsx
+++ b/apps/website/src/pages/stream/clips.tsx
@@ -108,7 +108,7 @@ const isPopulatedArray = <T,>(array: T[]): array is [T, ...T[]] =>
   array.length > 0;
 
 const getTwitchEmbed = (clip: string, parent: string): string => {
-  const url = new URL("https://clips.twitch.tv");
+  const url = new URL("https://clips.twitch.tv/embed");
   url.searchParams.set("clip", clip);
   url.searchParams.set("parent", parent);
   url.searchParams.set("autoplay", "true");

--- a/apps/website/src/pages/stream/clips.tsx
+++ b/apps/website/src/pages/stream/clips.tsx
@@ -120,7 +120,12 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
   // Once mounted, randomize the clips
   const [randomClips, setRandomClips] = useState<ClipData[]>([]);
   useEffect(() => {
-    setRandomClips(clips.slice().sort(() => Math.random() - 0.5));
+    const shuffled = clips.slice();
+    for (let i = shuffled.length - 1; i >= 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j]!, shuffled[i]!];
+    }
+    setRandomClips(shuffled);
   }, [clips]);
 
   const [idx, setIdx] = useState<number>(0);

--- a/apps/website/src/pages/stream/clips.tsx
+++ b/apps/website/src/pages/stream/clips.tsx
@@ -191,9 +191,11 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
   );
 
   return (
-    <div className="flex h-screen w-full">
+    <div className="flex h-screen w-full p-8">
       {clip && (
         <div className="relative my-auto aspect-video h-auto w-full">
+          <div className="absolute -inset-2 -z-10 rounded-xl bg-alveus-green shadow-lg" />
+
           <Transition show={details}>
             <div className="absolute left-2 top-2 rounded-lg bg-black/25 px-4 py-2 text-white backdrop-blur transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300">
               <h1 className="text-4xl">
@@ -210,11 +212,12 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
               <p className="text-xl">Clipped by {clip.creator}</p>
             </div>
           </Transition>
+
           <iframe
             src={getTwitchEmbed(clip.id, window.location.hostname)}
             onLoad={onLoad}
             onError={onError}
-            className="size-full rounded"
+            className="size-full rounded-lg"
           />
         </div>
       )}

--- a/apps/website/src/pages/stream/clips.tsx
+++ b/apps/website/src/pages/stream/clips.tsx
@@ -153,7 +153,7 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
     );
   }, [clip, increment]);
 
-  // As soon as the clip loads, start a timer to randomize when the clip ends
+  // As soon as the clip loads, start a timer for when the clip ends
   // Also, after a short while, hide the details of the clip
   const loadedTimer = useRef<NodeJS.Timeout>(null);
   const detailsTimer = useRef<NodeJS.Timeout>(null);
@@ -173,7 +173,7 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
     detailsTimer.current = setTimeout(() => setDetails(false), 10 * 1000);
   }, [clip, increment]);
 
-  // If the clip fails to load, randomize after 2 seconds
+  // If the clip fails to load, show another after 2 seconds
   const errorTimer = useRef<NodeJS.Timeout>(null);
   const onError = useCallback(() => {
     // Clear any other timers

--- a/apps/website/src/pages/stream/clips.tsx
+++ b/apps/website/src/pages/stream/clips.tsx
@@ -1,0 +1,93 @@
+import type { InferGetStaticPropsType, NextPage } from "next";
+
+import { type Clip, getClips } from "@/server/apis/twitch";
+import { prisma } from "@/server/db/client";
+
+import { twitchChannels } from "@/data/calendar-events";
+
+async function getTwitchClips(
+  userAccessToken: string,
+  userId: string,
+  start: Date,
+  end: Date,
+  views: number,
+) {
+  let cursor;
+  const clips: Clip[] = [];
+
+  while (true) {
+    const response = await getClips(
+      userAccessToken,
+      userId,
+      start,
+      end,
+      cursor,
+    );
+    if (response === null) break;
+
+    // Filter the clips by the minimum number of views
+    const filtered = response.data.filter((clip) => clip.view_count > views);
+    clips.push(...filtered);
+
+    // Twitch guarantees clips are returned in descending order of view count
+    // So, if we have a clip with less views than the minimum, we can stop
+    if (filtered.length !== response.data.length) break;
+
+    cursor = response.pagination.cursor;
+    if (!cursor) break;
+  }
+
+  return clips;
+}
+
+export const getStaticProps = async () => {
+  // Get auth for the Twitch account
+  const twitchChannel = await prisma.twitchChannel.findFirst({
+    where: { username: twitchChannels.alveus.username },
+    select: {
+      broadcasterAccount: {
+        select: {
+          access_token: true,
+        },
+      },
+    },
+  });
+  if (!twitchChannel?.broadcasterAccount?.access_token) {
+    throw new Error(`No access token found for Twitch account`);
+  }
+
+  // Get clips within the last year, older than a week, with at least 100 views
+  const start = new Date();
+  start.setFullYear(start.getFullYear() - 1);
+  const end = new Date();
+  end.setDate(end.getDate() - 7);
+  const clips = await getTwitchClips(
+    twitchChannel.broadcasterAccount.access_token,
+    twitchChannels.alveus.id,
+    start,
+    end,
+    100,
+  );
+  console.log(clips[0], clips.length);
+
+  return {
+    props: {
+      clips: clips.map((clip) => ({
+        url: clip.embed_url,
+        title: clip.title,
+        creator: clip.creator_name,
+        created: clip.created_at,
+        duration: clip.duration,
+      })),
+    },
+    revalidate: 1800, // revalidate after 30 minutes
+  };
+};
+
+const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
+  clips,
+}) => {
+  return null;
+};
+
+export default ClipsPage;

--- a/apps/website/src/pages/stream/clips.tsx
+++ b/apps/website/src/pages/stream/clips.tsx
@@ -1,5 +1,5 @@
 import type { GetStaticProps, InferGetStaticPropsType, NextPage } from "next";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { type Clip, getClips } from "@/server/apis/twitch";
 import { prisma } from "@/server/db/client";
@@ -178,14 +178,30 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
   );
 
   return (
-    <div className="h-screen w-full">
+    <div className="flex h-screen w-full">
       {clip && (
-        <iframe
-          src={getTwitchEmbed(clip.id, window.location.hostname)}
-          onLoad={onLoad}
-          onError={onError}
-          className="size-full"
-        />
+        <div className="relative my-auto aspect-video h-auto w-full">
+          <div className="absolute left-2 top-2 rounded-lg bg-black/25 px-4 py-2 text-white backdrop-blur">
+            <h1 className="text-4xl">
+              {clip.title}
+              <span className="ml-1 text-2xl">
+                {" "}
+                (
+                {new Date(clip.created).toLocaleDateString(undefined, {
+                  dateStyle: "long",
+                })}
+                )
+              </span>
+            </h1>
+            <p className="text-xl">Clipped by {clip.creator}</p>
+          </div>
+          <iframe
+            src={getTwitchEmbed(clip.id, window.location.hostname)}
+            onLoad={onLoad}
+            onError={onError}
+            className="size-full rounded"
+          />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Describe your changes

Fetches clips from the Alveus Twitch channel from the last year that have over 100 views, excluding the last week (to allow time for mods to catch any bad clips). Refreshes the list of clips via Next.js revalidation every 30 minutes (similar to the homepage refresh). Uses the Twitch clips player directly to avoid needing funky workarounds to download the clip videos themselves, though this does mean the logic to rotate the clips is a naive timer that doesn't factor in clip buffering/loading.

## Notes for testing your change

Clips load/play as expected.