### PR TITLE
Disable admin auth for easier local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ Hey there! Welcome to Alveus.gg! There's a few ways that you can help contribute
 ## Development setup
 
 > [!NOTE]
-> If you only want to work on the front end, you may skip the prerequisite and skip setting up a database or file storage (steps 3 and 4.iv).
+> If you only want to work on the front end, you may skip the prerequisite and skip setting up a database or file storage (step 3).
 > But you may encounter some errors when running the website without a database or file storage.
 
 ### Prerequisite
 
-Create a [Twitch application](https://dev.twitch.tv/console/apps/create), setting the OAuth callback to be `http://localhost:3000/api/auth/callback/twitch`. Note down your client ID and client secret.
+If you aren't working on features related to Twitch authentication, you can set the `DISABLE_ADMIN_AUTH` to `true` in your `apps/website/.env` file (see step 4 and 4.i) in order to use the admin dashboard immediately. Otherwise, create a [Twitch application](https://dev.twitch.tv/console/apps/create), setting the OAuth callback to be `http://localhost:3000/api/auth/callback/twitch`. Note down your client ID and client secret.
 
 ### Local development
 
@@ -71,11 +71,12 @@ Create a [Twitch application](https://dev.twitch.tv/console/apps/create), settin
 2. Install dependencies: `pnpm install --frozen-lockfile`
 3. Run `docker compose up -d` from within `apps/website` to start a local MySQL database, and an S3 bucket with MinIO.
 4. Copy `apps/website/.env.example` to `apps/website/.env` and open your copy in a text editor and fill it:
-   1. The vapid keys for web notifications have to be generated using `pnpx web-push generate-vapid-keys`
-   2. The Next Auth secret (`NEXTAUTH_SECRET`), Action API secret (`ACTION_API_SECRET`) and Vercel Cron Secret (`CRON_SECRET`) have to be filled with 32-byte Base64-encoded secrets. See [Generate secrets](#generate-secrets) below.
-   3. The data encryption passphrase (`DATA_ENCRYPTION_PASSPHRASE`) has to be filled with a 24-byte Base64-encoded secret. See [Generate secrets](#generate-secrets) below.
-   4. You may define a Weather API key (`WEATHER_API_KEY`) to use the weather API and stream overlay. See [Weather API](#weather-api) below.
-   5. You may define privileged users once they have signed in in the `SUPER_USER_IDS` variable with their CUID (using comma separated values)
+   1. If your feature is not related to Twitch authentication, you can set `DISABLE_ADMIN_AUTH` to `true` in order to use the admin dashboard without authentication. Otherwise, fill in `TWITCH_CLIENT_ID` and `TWITCH_CLIENT_SECRET` as mentioned above.
+   2. The vapid keys for web notifications have to be generated using `pnpx web-push generate-vapid-keys`
+   3. The Next Auth secret (`NEXTAUTH_SECRET`), Action API secret (`ACTION_API_SECRET`) and Vercel Cron Secret (`CRON_SECRET`) have to be filled with 32-byte Base64-encoded secrets. See [Generate secrets](#generate-secrets) below.
+   4. The data encryption passphrase (`DATA_ENCRYPTION_PASSPHRASE`) has to be filled with a 24-byte Base64-encoded secret. See [Generate secrets](#generate-secrets) below.
+   5. You may define a Weather API key (`WEATHER_API_KEY`) to use the weather API and stream overlay. See [Weather API](#weather-api) below.
+   6. If you are using Twitch authentication, you may define privileged users once they have signed in in the `SUPER_USER_IDS` variable with their CUID (using comma separated values)
 5. Push the database schema to the new database using `pnpm prisma db push` from within `apps/website`.
 6. Start the dev server using `pnpm dev` from within `apps/website`
 7. The website should be running at `http://localhost:3000/` (open in browser)

--- a/apps/website/.env.example
+++ b/apps/website/.env.example
@@ -86,6 +86,9 @@ FILE_STORAGE_PATH_STYLE=true # MinIO requires path style
 UPSTASH_QSTASH_URL=https://qstash.upstash.io/v1/publish/
 UPSTASH_QSTASH_KEY=
 
+# Disable admin authentication for local development
+DISABLE_ADMIN_AUTH=true
+
 # Super users
 SUPER_USER_IDS=
 

--- a/apps/website/.env.example
+++ b/apps/website/.env.example
@@ -87,7 +87,7 @@ UPSTASH_QSTASH_URL=https://qstash.upstash.io/v1/publish/
 UPSTASH_QSTASH_KEY=
 
 # Disable admin authentication for local development
-DISABLE_ADMIN_AUTH=true
+DISABLE_ADMIN_AUTH=false
 
 # Super users
 SUPER_USER_IDS=

--- a/apps/website/src/env/index.js
+++ b/apps/website/src/env/index.js
@@ -78,6 +78,7 @@ export const env = createEnv({
     CRON_SECRET: z.string().optional(),
     WEATHER_API_KEY: z.string().optional(),
     WEATHER_STATION_ID: z.string().optional(),
+    DISABLE_ADMIN_AUTH: optionalBoolSchema,
     SUPER_USER_IDS: z.string(),
     WEB_PUSH_VAPID_PRIVATE_KEY: z
       .string()
@@ -163,6 +164,7 @@ export const env = createEnv({
     CRON_SECRET: process.env.CRON_SECRET,
     WEATHER_API_KEY: process.env.WEATHER_API_KEY,
     WEATHER_STATION_ID: process.env.WEATHER_STATION_ID,
+    DISABLE_ADMIN_AUTH: process.env.DISABLE_ADMIN_AUTH,
     SUPER_USER_IDS: process.env.SUPER_USER_IDS,
     WEB_PUSH_VAPID_PRIVATE_KEY: process.env.WEB_PUSH_VAPID_PRIVATE_KEY,
     WEB_PUSH_VAPID_SUBJECT: process.env.WEB_PUSH_VAPID_SUBJECT,

--- a/apps/website/src/server/common/get-server-auth-session.ts
+++ b/apps/website/src/server/common/get-server-auth-session.ts
@@ -1,5 +1,6 @@
 import { type GetServerSidePropsContext } from "next";
 import { unstable_getServerSession } from "next-auth";
+import { env } from "@/env";
 
 import { authOptions } from "../../pages/api/auth/[...nextauth]";
 
@@ -10,5 +11,7 @@ export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext["req"];
   res: GetServerSidePropsContext["res"];
 }) => {
-  return await unstable_getServerSession(ctx.req, ctx.res, authOptions);
+  return env.NODE_ENV === "development" && env.DISABLE_ADMIN_AUTH
+    ? { user: {} }
+    : await unstable_getServerSession(ctx.req, ctx.res, authOptions);
 };

--- a/apps/website/src/server/common/get-server-auth-session.ts
+++ b/apps/website/src/server/common/get-server-auth-session.ts
@@ -1,5 +1,6 @@
 import { type GetServerSidePropsContext } from "next";
 import { unstable_getServerSession } from "next-auth";
+import { DEV_ADMIN_SESSION } from "@/utils/dev-admin-session";
 import { env } from "@/env";
 
 import { authOptions } from "../../pages/api/auth/[...nextauth]";
@@ -12,6 +13,6 @@ export const getServerAuthSession = async (ctx: {
   res: GetServerSidePropsContext["res"];
 }) => {
   return env.NODE_ENV === "development" && env.DISABLE_ADMIN_AUTH
-    ? { user: {} }
+    ? DEV_ADMIN_SESSION
     : await unstable_getServerSession(ctx.req, ctx.res, authOptions);
 };

--- a/apps/website/src/server/utils/admin.ts
+++ b/apps/website/src/server/utils/admin.ts
@@ -2,6 +2,7 @@ import { getSession } from "next-auth/react";
 import type { GetSessionParams } from "next-auth/react";
 import type { PermissionConfig } from "@/data/permissions";
 import { checkRolesGivePermission, permissions } from "@/data/permissions";
+import { env } from "@/env";
 import { notEmpty } from "@/utils/helpers";
 import { checkIsSuperUserSession, checkPermissions } from "@/server/utils/auth";
 
@@ -62,7 +63,10 @@ export async function getAdminSSP(
   context: GetSessionParams,
   permission: PermissionConfig,
 ) {
-  const session = await getSession(context);
+  const session =
+    env.NODE_ENV === "development" && env.DISABLE_ADMIN_AUTH
+      ? { user: {} }
+      : await getSession(context);
 
   const user = session?.user;
   if (!user) {

--- a/apps/website/src/server/utils/admin.ts
+++ b/apps/website/src/server/utils/admin.ts
@@ -4,6 +4,7 @@ import type { PermissionConfig } from "@/data/permissions";
 import { checkRolesGivePermission, permissions } from "@/data/permissions";
 import { env } from "@/env";
 import { notEmpty } from "@/utils/helpers";
+import { DEV_ADMIN_SESSION } from "@/utils/dev-admin-session";
 import { checkIsSuperUserSession, checkPermissions } from "@/server/utils/auth";
 
 const menuItems = [
@@ -65,7 +66,7 @@ export async function getAdminSSP(
 ) {
   const session =
     env.NODE_ENV === "development" && env.DISABLE_ADMIN_AUTH
-      ? { user: {} }
+      ? DEV_ADMIN_SESSION
       : await getSession(context);
 
   const user = session?.user;

--- a/apps/website/src/server/utils/auth.ts
+++ b/apps/website/src/server/utils/auth.ts
@@ -8,6 +8,10 @@ export function getSuperUserIds() {
 }
 
 export function checkIsSuperUserId(id?: string) {
+  if (env.NODE_ENV === "development" && env.DISABLE_ADMIN_AUTH) {
+    return true;
+  }
+
   if (!id) {
     return false;
   }

--- a/apps/website/src/utils/dev-admin-session.ts
+++ b/apps/website/src/utils/dev-admin-session.ts
@@ -1,0 +1,10 @@
+import { type Session } from "next-auth";
+
+export const DEV_ADMIN_SESSION: Session = {
+  user: {
+    id: "dev-admin",
+    roles: [] as string[],
+    isSuperUser: true,
+  },
+  expires: "2090-01-01T00:00:00.000Z",
+};


### PR DESCRIPTION
## Describe your changes

The local development instructions ask you to create a Twitch application in order to use the admin dashboard. This PR makes it easier to get started by disabling authentication for local development, so that you can use the admin dashboard immediately, without having to create a Twitch application. It adds a `DISABLE_ADMIN_AUTH` environment variable that is set to `false` by default in `.env.example`. When this variable is set to true, and the `NODE_ENV` environment variable is set to "development", the admin dashboard will not require authentication.

I've also added corresponding instructions in the README.

## Notes for testing your change

1. Comment out the `TWITCH_CLIENT_ID` and `TWITCH_CLIENT_SECRET` environment variables from your local `.env` file.
2. Set `DISABLE_ADMIN_AUTH` to `true`
3. See that you still access the admin dashboard in local dev.