### PR TITLE
Adjust logic for Give an Hour progress target

### DIFF
--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -15,12 +15,7 @@ const useLocaleHours = (hours: number, showDays: boolean) => {
   return `${localeHours} hour${hours !== 1 ? "s" : ""}${showDays ? ` (${localeDays})` : ""}`;
 };
 
-const targetIntervals = [
-  4320, // 180 days
-  2160, // 90 days
-  720, // 30 days
-  48, // 2 days
-];
+const targetIntervals = [24 * 180, 24 * 90, 24 * 30, 24 * 2];
 
 const getTarget = (hours: number) => {
   const multiple = targetIntervals.find((interval) => interval <= hours) ?? 24;

--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -15,6 +15,18 @@ const useLocaleHours = (hours: number, showDays: boolean) => {
   return `${localeHours} hour${hours !== 1 ? "s" : ""}${showDays ? ` (${localeDays})` : ""}`;
 };
 
+const targetIntervals = [
+  4320, // 180 days
+  2160, // 90 days
+  720, // 30 days
+  48, // 2 days
+];
+
+const getTarget = (hours: number) => {
+  const multiple = targetIntervals.find((interval) => interval <= hours) ?? 24;
+  return Math.ceil((hours || 1) / multiple) * multiple;
+};
+
 const GiveAnHourProgressText = ({
   isLoading,
   hours,
@@ -60,13 +72,7 @@ export const GiveAnHourProgress = ({
     },
   );
   const hours = hoursQuery.data ?? 0;
-
-  // Round hours up to the nearest multiple of 24
-  // Or, if we're greater than 168 hours (7 days), the nearest multiple of 48
-  // We'll multiply by 1.2 so that we never actually hit the target itself
-  const multiple = hours > 168 ? 48 : 24;
-  const computedTarget =
-    target ?? Math.ceil(((hours || 1) * 1.2) / multiple) * multiple;
+  const computedTarget = target ?? getTarget(hours);
 
   return (
     <>

--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -24,7 +24,7 @@ const targetIntervals = [
 
 const getTarget = (hours: number) => {
   const multiple = targetIntervals.find((interval) => interval <= hours) ?? 24;
-  return Math.ceil((hours || 1) / multiple) * multiple;
+  return Math.ceil((hours + 1) / multiple) * multiple;
 };
 
 const GiveAnHourProgressText = ({


### PR DESCRIPTION
## Describe your changes

Two main adjustments:

- Have much larger multiples/intervals for the target as the number of hours increases (allowing the progress bar to go back further once a target is hit)
- Remove the 1.2 multiplier to allow the progress to get to 100% (not completely, as the +1 ensures the target and progress are never exactly equal).

## Notes for testing your change

Any value of hours generates a reasonable target, both for small amounts of hours and very large amounts as seen in production.