### PR TITLE
Allow mods to set public + private notes on Show and Tell entries

### DIFF
--- a/apps/website/prisma/schema.prisma
+++ b/apps/website/prisma/schema.prisma
@@ -404,6 +404,8 @@ model ShowAndTellEntry {
   location            String?
   longitude           Float?
   latitude            Float?
+  notePrivate         String?   @db.Text
+  notePublic          String?   @db.Text
 
   attachments ShowAndTellEntryAttachment[]
   user        User?                        @relation(fields: [userId], references: [id])

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -160,7 +160,7 @@ const Header = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
 const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
   const content = useMemo(() => {
     try {
-      return parse(`<root>${entry.text}</root>`, parseOptions);
+      return entry.text && parse(`<root>${entry.text}</root>`, parseOptions);
     } catch (e) {
       console.error(`Failed to parse Show and Tell entry text ${entry.id}`, e);
     }
@@ -177,30 +177,34 @@ const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
     }
   }, [entry.notePublic, entry.id]);
 
+  const hasContent = isValidElement(content) && content.type !== Empty;
+  const hasNote = isValidElement(note) && note.type !== Empty;
+
   return (
-    isValidElement(content) &&
-    content.type !== Empty && (
+    (hasContent || hasNote) && (
       <div className="-m-4 mt-0 bg-white/70 p-4 text-gray-900 backdrop-blur-sm">
         <div
           className={`mx-auto w-fit ${
             isPresentationView ? "scrollbar-none max-h-[66vh] pb-6" : ""
           }`}
         >
-          <div className="alveus-ugc max-w-[1100px] hyphens-auto leading-relaxed md:text-lg xl:text-2xl">
-            <ErrorBoundary
-              FallbackComponent={Empty}
-              onError={(err) =>
-                console.error(
-                  `Failed to render Show and Tell entry text ${entry.id}`,
-                  err,
-                )
-              }
-            >
-              {content}
-            </ErrorBoundary>
-          </div>
+          {hasContent && (
+            <div className="alveus-ugc max-w-[1100px] hyphens-auto leading-relaxed md:text-lg xl:text-2xl">
+              <ErrorBoundary
+                FallbackComponent={Empty}
+                onError={(err) =>
+                  console.error(
+                    `Failed to render Show and Tell entry text ${entry.id}`,
+                    err,
+                  )
+                }
+              >
+                {content}
+              </ErrorBoundary>
+            </div>
+          )}
 
-          {note && (
+          {hasNote && (
             <div className="opacity-75">
               <h3 className="-mb-4 mt-4 text-xs font-bold uppercase text-alveus-green-600 xl:text-sm">
                 Mod Note

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -162,9 +162,20 @@ const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
     try {
       return parse(`<root>${entry.text}</root>`, parseOptions);
     } catch (e) {
-      console.error(`Failed to parse Show and Tell entry ${entry.id}`, e);
+      console.error(`Failed to parse Show and Tell entry text ${entry.id}`, e);
     }
   }, [entry.text, entry.id]);
+
+  const note = useMemo(() => {
+    try {
+      return (
+        entry.notePublic &&
+        parse(`<root>${entry.notePublic}</root>`, parseOptions)
+      );
+    } catch (e) {
+      console.error(`Failed to parse Show and Tell entry note ${entry.id}`, e);
+    }
+  }, [entry.notePublic, entry.id]);
 
   return (
     isValidElement(content) &&
@@ -180,7 +191,7 @@ const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
               FallbackComponent={Empty}
               onError={(err) =>
                 console.error(
-                  `Failed to render Show and Tell entry ${entry.id}`,
+                  `Failed to render Show and Tell entry text ${entry.id}`,
                   err,
                 )
               }
@@ -188,6 +199,28 @@ const Content = ({ entry, isPresentationView }: ShowAndTellEntryProps) => {
               {content}
             </ErrorBoundary>
           </div>
+
+          {note && (
+            <div className="opacity-75">
+              <h3 className="-mb-4 mt-4 text-xs font-bold uppercase text-alveus-green-600 xl:text-sm">
+                Mod Note
+              </h3>
+
+              <div className="alveus-ugc max-w-[1100px] hyphens-auto xl:text-lg">
+                <ErrorBoundary
+                  FallbackComponent={Empty}
+                  onError={(err) =>
+                    console.error(
+                      `Failed to render Show and Tell entry note ${entry.id}`,
+                      err,
+                    )
+                  }
+                >
+                  {note}
+                </ErrorBoundary>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     )

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import type { ShowAndTellEntry } from "@prisma/client";
 
 import type {
-  ShowAndTellEntryAttachments,
+  PublicShowAndTellEntryWithAttachments,
   ShowAndTellSubmitInput,
 } from "@/server/db/show-and-tell";
 
@@ -47,7 +47,7 @@ import { MapPickerField } from "../shared/form/MapPickerField";
 
 type ShowAndTellEntryFormProps = {
   isAnonymous?: boolean;
-  entry?: ShowAndTellEntry & { attachments: ShowAndTellEntryAttachments };
+  entry?: PublicShowAndTellEntryWithAttachments & Partial<ShowAndTellEntry>;
   action: "review" | "create" | "update";
   onUpdate?: () => void;
 };
@@ -108,7 +108,9 @@ export function ShowAndTellEntryForm({
 
   const initialLocation = useMemo<MapLocation | undefined>(
     () =>
-      entry && entry.longitude !== null && entry.latitude !== null
+      entry &&
+      typeof entry.latitude === "number" &&
+      typeof entry.longitude === "number"
         ? {
             latitude: entry.latitude,
             longitude: entry.longitude,

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -241,7 +241,12 @@ export function ShowAndTellEntryForm({
       );
     } else if (action === "review" && entry) {
       review.mutate(
-        { ...data, id: entry.id },
+        {
+          ...data,
+          id: entry.id,
+          notePrivate: (formData.get("notePrivate") as string) ?? "",
+          notePublic: (formData.get("notePublic") as string) ?? "",
+        },
         {
           onSuccess: () => {
             setSuccessMessage("Entry updated successfully!");
@@ -422,6 +427,24 @@ export function ShowAndTellEntryForm({
             />
           </div>
         </Fieldset>
+
+        {action === "review" && (
+          <Fieldset legend="Moderator Notes">
+            <div className="flex flex-col gap-5 lg:flex-row lg:gap-20">
+              <RichTextField
+                label="Private Note (only visible to moderators)"
+                name="notePrivate"
+                defaultValue={entry?.notePrivate || undefined}
+              />
+
+              <RichTextField
+                label="Public Note (visible on the post)"
+                name="notePublic"
+                defaultValue={entry?.notePublic || undefined}
+              />
+            </div>
+          </Fieldset>
+        )}
 
         {error && <MessageBox variant="failure">{error}</MessageBox>}
         {successMessage && (

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -20,7 +20,7 @@ import { extractCountriesFromLocations } from "@/utils/locations";
 
 import {
   getMapFeatures,
-  getPosts,
+  getPublicPosts,
   getPostsCount,
   getPostsToShow,
   getUsersCount,
@@ -70,7 +70,7 @@ export const bentoBoxClasses =
 // We pre-render the first page of entries using SSR and then use client-side rendering to
 // update the data and fetch more entries on demand
 export const getStaticProps = async () => {
-  const entries = await getPosts({ take: entriesPerPage + 1 });
+  const entries = await getPublicPosts({ take: entriesPerPage + 1 });
 
   let nextCursor: string | undefined = undefined;
   if (entries.length > entriesPerPage) {

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -143,14 +143,22 @@ const showAndTellSharedInputSchema = z.object({
 
 export const showAndTellCreateInputSchema = showAndTellSharedInputSchema;
 
-export type ShowAndTellUpdateInput = z.infer<
-  typeof showAndTellUpdateInputSchema
->;
 export const showAndTellUpdateInputSchema = showAndTellSharedInputSchema.and(
   z.object({
     id: z.string().cuid(),
   }),
 );
+
+export const showAndTellReviewInputSchema = showAndTellUpdateInputSchema.and(
+  z.object({
+    notePrivate: z.string().nullable(),
+    notePublic: z.string().nullable(),
+  }),
+);
+
+export type ShowAndTellUpdateInput =
+  | z.infer<typeof showAndTellUpdateInputSchema>
+  | z.infer<typeof showAndTellReviewInputSchema>;
 
 async function revalidateCache(postIdOrIds?: string | string[]) {
   const url = new URL(
@@ -394,6 +402,14 @@ export async function updatePost(
   }
 
   const text = sanitizeUserHtml(input.text);
+  const notePrivate =
+    "notePrivate" in input
+      ? sanitizeUserHtml(input.notePrivate || "")
+      : undefined;
+  const notePublic =
+    "notePublic" in input
+      ? sanitizeUserHtml(input.notePublic || "")
+      : undefined;
   const newImages = await createImageAttachments(input.imageAttachments.create);
   const newVideos = createVideoAttachments(input.videoLinks);
 
@@ -434,6 +450,8 @@ export async function updatePost(
         location: input.location,
         longitude: input.longitude,
         latitude: input.latitude,
+        notePrivate,
+        notePublic,
       },
     }),
     // Update image attachments that are in the update list

--- a/apps/website/src/server/trpc/router/admin/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/admin/show-and-tell.ts
@@ -11,10 +11,10 @@ import {
   approvePost,
   removeApprovalFromPost,
   deletePost,
-  getPostWithUserById,
   markPostAsSeen,
   unmarkPostAsSeen,
   getAdminPosts,
+  getAdminPost,
 } from "@/server/db/show-and-tell";
 import { permissions } from "@/data/permissions";
 import { deleteFileStorageObject } from "@/server/utils/file-storage";
@@ -27,7 +27,7 @@ const permittedProcedure = protectedProcedure.use(
 export const adminShowAndTellRouter = router({
   getEntry: permittedProcedure
     .input(z.string().cuid())
-    .query(({ input }) => getPostWithUserById(input)),
+    .query(({ input }) => getAdminPost(input)),
 
   review: permittedProcedure
     .input(showAndTellReviewInputSchema)
@@ -56,7 +56,7 @@ export const adminShowAndTellRouter = router({
   delete: permittedProcedure
     .input(z.string().cuid())
     .mutation(async ({ input }) => {
-      const post = await getPostWithUserById(input);
+      const post = await getAdminPost(input);
       if (!post) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Post not found" });
       }

--- a/apps/website/src/server/trpc/router/admin/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/admin/show-and-tell.ts
@@ -6,7 +6,7 @@ import {
   router,
 } from "@/server/trpc/trpc";
 import {
-  showAndTellUpdateInputSchema,
+  showAndTellReviewInputSchema,
   updatePost,
   approvePost,
   removeApprovalFromPost,
@@ -30,7 +30,7 @@ export const adminShowAndTellRouter = router({
     .query(({ input }) => getPostWithUserById(input)),
 
   review: permittedProcedure
-    .input(showAndTellUpdateInputSchema)
+    .input(showAndTellReviewInputSchema)
     .mutation(async ({ input }) => await updatePost(input, undefined, true)),
 
   approve: permittedProcedure

--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -14,13 +14,12 @@ import {
   createPost,
   deletePost,
   getPublicPostById,
-  getPostWithUserById,
-  getPosts,
+  getPublicPosts,
+  getUserPosts,
   getVolunteeringMinutes,
   showAndTellCreateInputSchema,
   showAndTellUpdateInputSchema,
   updatePost,
-  withAttachments,
 } from "@/server/db/show-and-tell";
 import { imageMimeTypes } from "@/utils/files";
 import { env } from "@/env";
@@ -45,7 +44,7 @@ export const showAndTellRouter = router({
     .query(async ({ input }) => {
       const { cursor } = input;
 
-      const items = await getPosts({
+      const items = await getPublicPosts({
         take: entriesPerPage + 1,
         cursor: cursor || undefined,
       });
@@ -77,21 +76,23 @@ export const showAndTellRouter = router({
     ),
 
   getMyEntries: protectedProcedure.query(({ ctx }) =>
-    ctx.prisma.showAndTellEntry.findMany({
-      ...withAttachments,
-      where: {
-        userId: ctx.session.user.id,
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-    }),
+    getUserPosts(ctx.session.user.id),
   ),
+
+  getMyEntry: protectedProcedure
+    .input(z.string().cuid())
+    .query(({ ctx, input }) =>
+      getUserPosts(ctx.session.user.id, input).then(
+        (posts) => posts[0] ?? null,
+      ),
+    ),
 
   delete: protectedProcedure
     .input(z.string().cuid())
     .mutation(async ({ ctx, input }) => {
-      const post = await getPostWithUserById(input, ctx.session.user.id);
+      const post = await getUserPosts(ctx.session.user.id, input).then(
+        (posts) => posts[0] ?? null,
+      );
       if (!post) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Post not found" });
       }
@@ -105,18 +106,6 @@ export const showAndTellRouter = router({
           .map((id) => deleteFileStorageObject(id)),
       ]);
     }),
-
-  getMyEntry: protectedProcedure
-    .input(z.string().cuid())
-    .query(({ ctx, input }) =>
-      ctx.prisma.showAndTellEntry.findFirst({
-        ...withAttachments,
-        where: {
-          userId: ctx.session.user.id,
-          id: input,
-        },
-      }),
-    ),
 
   createFileUpload: publicProcedure
     .input(


### PR DESCRIPTION
## Describe your changes

Resolves #716 and resolves #717 by allowing mods to set both public + private notes on the Show and Tell entry review screen. Private notes can only be seen by moderators on the review screen, while public notes will be shown on the show and tell page itself.

## Notes for testing your change

Moderators can set public + private notes during review. They persist when saved.

If a user edits their post after public + private notes have been added, they still persist when the review screen is accessed.

As a regular user, accessing "my posts" does not reveal the private notes (even in the underlying network data). Similarly, accessing an individual post does not reveal private notes.

As a regular user, or signed out, accessing the show and tell page does not reveal private notes (even in the underlying network data). Any public notes on approved posts are shown on the page.