### PR TITLE
Use waitUntil() for notification APIs

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -54,6 +54,7 @@
     "@trpc/react-query": "11.0.0-rc.688",
     "@trpc/server": "11.0.0-rc.688",
     "@vercel/analytics": "^1.4.1",
+    "@vercel/functions": "^1.5.2",
     "country-list": "^2.3.0",
     "csv-stringify": "^6.5.2",
     "dagre": "^0.8.5",

--- a/apps/website/src/pages/api/notifications/batched-create-notification-pushes.ts
+++ b/apps/website/src/pages/api/notifications/batched-create-notification-pushes.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { waitUntil } from "@vercel/functions";
 
 import { createTokenProtectedApiHandler } from "@/server/utils/api";
 import { callEndpoint } from "@/server/utils/queue";
@@ -50,7 +51,7 @@ export default createTokenProtectedApiHandler(
         );
       });
 
-      await Promise.allSettled(calls);
+      waitUntil(Promise.allSettled(calls));
 
       return true;
     } catch (e) {

--- a/apps/website/src/pages/api/notifications/batched-retry-notification-pushes.ts
+++ b/apps/website/src/pages/api/notifications/batched-retry-notification-pushes.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { waitUntil } from "@vercel/functions";
 import type { Notification } from "@prisma/client";
 
 import { env } from "@/env";
@@ -93,7 +94,7 @@ export default createTokenProtectedApiHandler(
         );
       });
 
-      await Promise.allSettled(tasks);
+      waitUntil(Promise.allSettled(tasks));
 
       return true;
     } catch (e) {

--- a/apps/website/src/pages/api/notifications/create-notification.ts
+++ b/apps/website/src/pages/api/notifications/create-notification.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
-import { createNotification } from "@/server/notifications";
+import { waitUntil } from "@vercel/functions";
+
+import { createNotification, sendNotification } from "@/server/notifications";
 import { createTokenProtectedApiHandler } from "@/server/utils/api";
 
 export const config = {
@@ -25,7 +27,8 @@ export default createTokenProtectedApiHandler(
   notificationSchema,
   async (options) => {
     try {
-      await createNotification(options);
+      const notification = await createNotification(options);
+      waitUntil(sendNotification(notification));
       return true;
     } catch (e) {
       console.error("Failed to create notification", e);

--- a/apps/website/src/server/notifications.ts
+++ b/apps/website/src/server/notifications.ts
@@ -1,4 +1,5 @@
 import type { Notification } from "@prisma/client";
+import { waitUntil } from "@vercel/functions";
 
 import { env } from "@/env";
 
@@ -80,7 +81,7 @@ export async function createNotification(data: CreateNotificationData) {
     tasks.push(createDiscordNotifications(notification));
   }
 
-  await Promise.all(tasks);
+  await Promise.allSettled(tasks);
 }
 
 export async function resendNotification(notificationId: string) {
@@ -194,7 +195,7 @@ async function createPushNotifications(notification: Notification) {
     );
   }
 
-  return Promise.allSettled(requests);
+  waitUntil(Promise.allSettled(requests));
 }
 
 async function createDiscordNotifications({
@@ -247,5 +248,5 @@ async function createDiscordNotifications({
     );
   }
 
-  return Promise.all(tasks);
+  waitUntil(Promise.allSettled(tasks));
 }

--- a/apps/website/src/server/notifications.ts
+++ b/apps/website/src/server/notifications.ts
@@ -1,5 +1,4 @@
 import type { Notification } from "@prisma/client";
-import { waitUntil } from "@vercel/functions";
 
 import { env } from "@/env";
 
@@ -55,7 +54,7 @@ export async function createNotification(data: CreateNotificationData) {
   }
 
   const expiresAt = getNotificationExpiration(data, tagConfig);
-  const notification = await prisma.notification.create({
+  return prisma.notification.create({
     data: {
       title: data.title,
       expiresAt: expiresAt,
@@ -70,21 +69,16 @@ export async function createNotification(data: CreateNotificationData) {
       isDiscord: data.isDiscord || false,
     },
   });
-
-  const tasks = [];
-
-  if (notification.isPush) {
-    tasks.push(createPushNotifications(notification));
-  }
-
-  if (notification.isDiscord) {
-    tasks.push(createDiscordNotifications(notification));
-  }
-
-  await Promise.allSettled(tasks);
 }
 
-export async function resendNotification(notificationId: string) {
+export async function sendNotification(notification: Notification) {
+  await Promise.allSettled([
+    notification.isPush && sendNotificationPushes(notification),
+    notification.isDiscord && sendDiscordNotifications(notification),
+  ]);
+}
+
+export async function copyNotification(notificationId: string) {
   const oldNotification = await prisma.notification.findUnique({
     where: { id: notificationId },
   });
@@ -150,7 +144,7 @@ export async function retryPendingNotificationPushes() {
   await Promise.allSettled(requests);
 }
 
-async function createPushNotifications(notification: Notification) {
+async function sendNotificationPushes(notification: Notification) {
   // Get subscriptions in batches and delegate them to separate workers
   const requests = [];
   let i = 0;
@@ -195,10 +189,10 @@ async function createPushNotifications(notification: Notification) {
     );
   }
 
-  waitUntil(Promise.allSettled(requests));
+  await Promise.allSettled(requests);
 }
 
-async function createDiscordNotifications({
+async function sendDiscordNotifications({
   tag,
   id,
   title,
@@ -248,5 +242,5 @@ async function createDiscordNotifications({
     );
   }
 
-  waitUntil(Promise.allSettled(tasks));
+  await Promise.allSettled(tasks);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.4.1
         version: 1.4.1(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      '@vercel/functions':
+        specifier: ^1.5.2
+        version: 1.5.2(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.726.1))
       country-list:
         specifier: ^2.3.0
         version: 2.3.0
@@ -2999,6 +3002,15 @@ packages:
       vue:
         optional: true
       vue-router:
+        optional: true
+
+  '@vercel/functions@1.5.2':
+    resolution: {integrity: sha512-9XuynFoM/J1X+LSahgjhuAZCbZ96vm9mpXapCkSS1MX890U7zLh7n2RW/2KLNuxsXt8u8h2dOCw+Njtg+7pXgQ==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
         optional: true
 
   '@vitest/expect@2.1.8':
@@ -9729,6 +9741,10 @@ snapshots:
     optionalDependencies:
       next: 15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
+
+  '@vercel/functions@1.5.2(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.726.1))':
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.726.1)
 
   '@vitest/expect@2.1.8':
     dependencies:


### PR DESCRIPTION
## Describe your changes

Makes use of the `waitUntil` util provided by vercel to keep the "Function" running after responding to the client. This will await the actual creation of the notification, but respond early, and letting outgoing requests run after.

## Notes for testing your change

Send test notification. Observe a quick response, but all notifications to be sent.

(This might be hard with the small amount of test subscribers)
