### PR TITLE
Switch ambassadors stream API endpoint to nodejs runtime

### DIFF
--- a/apps/website/src/app/api/stream/ambassadors/route.ts
+++ b/apps/website/src/app/api/stream/ambassadors/route.ts
@@ -101,4 +101,4 @@ export async function GET(request: Request) {
 // Cache the response for 30 minutes
 export const dynamic = "force-static";
 export const revalidate = 1800;
-export const runtime = "edge";
+export const runtime = "nodejs";


### PR DESCRIPTION
## Describe your changes

Fixes the `EDGE_FUNCTION_INVOCATION_FAILED` errors we're seeing on this endpoint with the edge runtime.

cc https://nextjs-forum.com/post/1331039780913287308

## Notes for testing your change

...
