### PR TITLE
Re-auth with additional scopes if account requires them

### DIFF
--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -63,11 +63,6 @@ export function DesktopMenu() {
     (user.isSuperUser ||
       checkRolesGivePermission(user.roles, permissions.viewDashboard));
 
-  // If we have an invalid session (such as a deleted Twitch account), sign out
-  useEffect(() => {
-    if (sessionData?.error) signOut();
-  }, [sessionData?.error]);
-
   return (
     <div className="hidden grow flex-col gap-2 lg:flex">
       <div className="flex items-center justify-end gap-2">

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -3,12 +3,13 @@ import { type AppType } from "next/app";
 import { useRouter } from "next/router";
 import Head from "next/head";
 import { type Session } from "next-auth";
-import { SessionProvider, signOut, useSession } from "next-auth/react";
+import { SessionProvider, signIn, signOut, useSession } from "next-auth/react";
 import { Analytics } from "@vercel/analytics/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { trpc } from "@/utils/trpc";
 import { unregisterServiceWorker } from "@/utils/sw";
+import { botScopes, defaultScopes } from "@/data/twitch";
 
 import { ConsentProvider } from "@/hooks/consent";
 
@@ -26,7 +27,20 @@ const SessionChecker = ({ children }: { children: React.ReactNode }) => {
 
   // If we have an invalid session (such as a deleted Twitch account), sign out
   useEffect(() => {
-    if (data?.error) signOut();
+    if (!data?.error) return;
+
+    // Some accounts require additional auth scopes
+    if (data.error === "Additional scopes required") {
+      signIn(
+        "twitch",
+        { callbackUrl: window.location.href },
+        { scope: [...defaultScopes, ...botScopes].join(" ") },
+      );
+      return;
+    }
+
+    // Otherwise, just sign out
+    signOut();
   }, [data?.error]);
 
   return children;

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import { type AppType } from "next/app";
 import { useRouter } from "next/router";
 import Head from "next/head";
 import { type Session } from "next-auth";
-import { SessionProvider } from "next-auth/react";
+import { SessionProvider, signOut, useSession } from "next-auth/react";
 import { Analytics } from "@vercel/analytics/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
@@ -20,6 +20,17 @@ import "@/styles/globals.css";
 unregisterServiceWorker();
 
 const queryClient = new QueryClient();
+
+const SessionChecker = ({ children }: { children: React.ReactNode }) => {
+  const { data } = useSession();
+
+  // If we have an invalid session (such as a deleted Twitch account), sign out
+  useEffect(() => {
+    if (data?.error) signOut();
+  }, [data?.error]);
+
+  return children;
+};
 
 const AlveusGgWebsiteApp: AppType<{ session: Session | null }> = ({
   Component,
@@ -50,16 +61,18 @@ const AlveusGgWebsiteApp: AppType<{ session: Session | null }> = ({
 
   return (
     <SessionProvider session={session}>
-      <QueryClientProvider client={queryClient}>
-        <ConsentProvider>
-          <FontProvider>
-            <Layout>
-              <Component {...pageProps} />
-              <Analytics />
-            </Layout>
-          </FontProvider>
-        </ConsentProvider>
-      </QueryClientProvider>
+      <SessionChecker>
+        <QueryClientProvider client={queryClient}>
+          <ConsentProvider>
+            <FontProvider>
+              <Layout>
+                <Component {...pageProps} />
+                <Analytics />
+              </Layout>
+            </FontProvider>
+          </ConsentProvider>
+        </QueryClientProvider>
+      </SessionChecker>
     </SessionProvider>
   );
 };


### PR DESCRIPTION
## Describe your changes

When loading the session for the current user, if they have a linked channel check if we need additional scopes in their current session. If they do, the client will redirect them to sign in again with the additional scopes requested.

Fixes #970 

## Notes for testing your change

- A brand new user can successfully sign in. Sent to OAuth once.
- An existing regular user can successfully sign in. Sent to OAuth once.
- An admin user with no channels can successfully sign in. Sent to OAuth once.
- An admin user linked to a Twitch channel can successfully sign in. Sent to OAuth twice. Accessing `/admin/twitch` shows all scopes granted.