### PR TITLE
Set ambassadors endpoint back to edge runtime

### DIFF
--- a/apps/website/src/app/api/stream/ambassadors/route.ts
+++ b/apps/website/src/app/api/stream/ambassadors/route.ts
@@ -79,21 +79,7 @@ const headers = {
 };
 
 // API for extension
-export async function GET(request: Request) {
-  // Handle preflight requests
-  if (request.method === "OPTIONS") {
-    return new Response(null, {
-      status: 204,
-      headers: {
-        ...headers,
-        "Access-Control-Allow-Methods": "GET",
-        "Access-Control-Allow-Headers": "Content-Type",
-        "Access-Control-Max-Age": "86400",
-      },
-    });
-  }
-
-  // Otherwise, return the data
+export async function GET() {
   const resp: AmbassadorsResponse = { v2: ambassadorsV2 };
   return Response.json(resp, { headers });
 }
@@ -101,4 +87,4 @@ export async function GET(request: Request) {
 // Cache the response for 30 minutes
 export const dynamic = "force-static";
 export const revalidate = 1800;
-export const runtime = "nodejs";
+export const runtime = "edge";

--- a/apps/website/src/app/api/stream/ambassadors/route.ts
+++ b/apps/website/src/app/api/stream/ambassadors/route.ts
@@ -84,6 +84,10 @@ export async function GET() {
   return Response.json(resp, { headers });
 }
 
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers });
+}
+
 // Cache the response for 30 minutes
 export const dynamic = "force-static";
 export const revalidate = 1800;

--- a/apps/website/src/app/api/stream/ambassadors/route.ts
+++ b/apps/website/src/app/api/stream/ambassadors/route.ts
@@ -76,6 +76,7 @@ const headers = {
   // Vercel doesn't respect Vary so we allow all origins to use this
   // Ideally we'd just allow specifically localhost + *.ext-twitch.tv
   "Access-Control-Allow-Origin": "*",
+  "Access-Control-Max-Age": "86400",
 };
 
 // API for extension

--- a/apps/website/src/app/api/stream/test/route.ts
+++ b/apps/website/src/app/api/stream/test/route.ts
@@ -1,6 +1,0 @@
-export async function GET(request: Request) {
-  const opt = request.method === "OPTIONS";
-  return Response.json({ opt });
-}
-
-export const runtime = "edge";

--- a/apps/website/src/app/api/stream/test/route.ts
+++ b/apps/website/src/app/api/stream/test/route.ts
@@ -1,30 +1,6 @@
-const headers = {
-  // Response can be cached for 30 minutes
-  // And can be stale for 5 minutes while revalidating
-  "Cache-Control": "max-age=1800, s-maxage=1800, stale-while-revalidate=300",
-
-  // Vercel doesn't respect Vary so we allow all origins to use this
-  // Ideally we'd just allow specifically localhost + *.ext-twitch.tv
-  "Access-Control-Allow-Origin": "*",
-};
-
-// API for extension
 export async function GET(request: Request) {
-  // Handle preflight requests
-  if (request.method === "OPTIONS") {
-    return new Response(null, {
-      status: 204,
-      headers: {
-        ...headers,
-        "Access-Control-Allow-Methods": "GET",
-        "Access-Control-Allow-Headers": "Content-Type",
-        "Access-Control-Max-Age": "86400",
-      },
-    });
-  }
-
-  // Otherwise, return the data
-  return Response.json({ ok: true }, { headers });
+  const opt = request.method === "OPTIONS";
+  return Response.json({ opt });
 }
 
 // Cache the response for 30 minutes

--- a/apps/website/src/app/api/stream/test/route.ts
+++ b/apps/website/src/app/api/stream/test/route.ts
@@ -3,7 +3,4 @@ export async function GET(request: Request) {
   return Response.json({ opt });
 }
 
-// Cache the response for 30 minutes
-export const dynamic = "force-static";
-export const revalidate = 1800;
 export const runtime = "edge";

--- a/apps/website/src/app/api/stream/test/route.ts
+++ b/apps/website/src/app/api/stream/test/route.ts
@@ -1,0 +1,33 @@
+const headers = {
+  // Response can be cached for 30 minutes
+  // And can be stale for 5 minutes while revalidating
+  "Cache-Control": "max-age=1800, s-maxage=1800, stale-while-revalidate=300",
+
+  // Vercel doesn't respect Vary so we allow all origins to use this
+  // Ideally we'd just allow specifically localhost + *.ext-twitch.tv
+  "Access-Control-Allow-Origin": "*",
+};
+
+// API for extension
+export async function GET(request: Request) {
+  // Handle preflight requests
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        ...headers,
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Max-Age": "86400",
+      },
+    });
+  }
+
+  // Otherwise, return the data
+  return Response.json({ ok: true }, { headers });
+}
+
+// Cache the response for 30 minutes
+export const dynamic = "force-static";
+export const revalidate = 1800;
+export const runtime = "edge";


### PR DESCRIPTION
## Describe your changes

After some testing (see commits), it was discovered that the source of the `edge` runtime issues with the ambassadors endpoint was accessing `request.method`, while `force-static` was set. Instead of doing this within the `GET` handler, which appears to be used as a default handler in the `nodejs` runtime, to set the CORS headers for OPTIONS requests, we can instead export a dedicated OPTIONS handler to do the same thing.

## Notes for testing your change

GET + OPTIONS requests to the endpoint contain the expected ACAO header. Using the deployed preview URL with the extension, locally and hosted on Twitch, allows ambassador data to be successfully fetched.