### PR TITLE
Allow selection in Show and Tell presentation mode + clarify private notes

### DIFF
--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -277,7 +277,7 @@ export const ShowAndTellEntry = ({
       className={classes(
         "relative flex flex-shrink-0 flex-col transition-opacity delay-500 duration-500 focus:outline-none",
         isPresentationView &&
-          "h-[calc(100svh-6em)] h-[calc(100vh-6em)] w-[80%] select-none snap-center overflow-hidden bg-alveus-green text-white shadow-xl",
+          "h-[calc(100svh-6em)] h-[calc(100vh-6em)] w-[80%] snap-center overflow-hidden bg-alveus-green text-white shadow-xl",
         !isPresentationView &&
           "justify-center border-t border-alveus-green/50 first:border-t-0",
         withHeight && !isPresentationView && "min-h-[70svh] min-h-[70vh]",

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -434,7 +434,7 @@ export function ShowAndTellEntryForm({
           <Fieldset legend="Moderator Notes">
             <div className="flex flex-col gap-5 lg:flex-row lg:gap-20">
               <RichTextField
-                label="Private Note (only visible to moderators)"
+                label="Private Note (only visible in review mode)"
                 name="notePrivate"
                 defaultValue={entry?.notePrivate || undefined}
               />


### PR DESCRIPTION
## Describe your changes

Allows for text to be selected in the presentation mode for Show and Tell, as this tripped up Maya today when she was trying to select links in posts.

Also, clarifies the visibility of private mod notes as this tripped up the mod team today when a private note was added that should've been public.

## Notes for testing your change

Text can be selected, has no adverse effect.

Note clarification makes sense.
