### PR TITLE
Allow Dependabot to access @alveusgg/data from GitHub Packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,11 @@
 version: 2
+
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.GH_PKG_REGISTRY_TOKEN}}
+
 updates:
   - package-ecosystem: github-actions
     directory: /
@@ -13,6 +20,9 @@ updates:
       interval: weekly
       day: wednesday
       time: "00:00"
+
+    # Allow usage of any registry including npm-github w/ auth as above
+    registries: "*"
 
     # Ensure the new version is stored in `package.json`
     versioning-strategy: increase

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Explicitly set the default registry to npmjs.org
+# Stops Dependabot using its GitHub Packages registry definition for everything
+registry=https://registry.npmjs.org
+
+# Use the GitHub Packages registry for @alveusgg packages
+@alveusgg:registry=https://npm.pkg.github.com

--- a/apps/website/.npmrc
+++ b/apps/website/.npmrc
@@ -1,1 +1,0 @@
-@alveusgg:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Describe your changes

Per Dependabot's docs, you just need to define a custom registry for GitHub Packages with a token stored in the repository's Dependabot secrets and it'll work... or not.

After a lot of testing and confusion with it not working, instead using GitHub Packages for _everything_ suddenly and then timing out, I eventually stumbled upon https://github.com/dependabot/dependabot-core/issues/10227 with a one-line fix in the most recent comment suggesting explicitly defining a default registry for NPM. With that in place, in my testing, Dependabot suddenly starts behaving again.

## Notes for testing your change

I've extensively tested this in a fork.