### PR TITLE
Fix corepack enable for chatbot Docker

### DIFF
--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:22-alpine
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
 WORKDIR /app
 
 ## Copy root files
@@ -15,6 +14,9 @@ WORKDIR apps/chatbot
 COPY ./apps/chatbot/tsconfig.json .
 COPY ./apps/chatbot/package.json .
 COPY ./apps/chatbot/.env .
+
+## Install dependencies
+RUN npm install -g corepack@latest && corepack enable
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile --filter "." --ignore-scripts
 
 ## Copy code

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -16,7 +16,7 @@ COPY ./apps/chatbot/package.json .
 COPY ./apps/chatbot/.env .
 
 ## Install dependencies
-RUN npm install -g corepack@latest && corepack enable
+RUN npm install -g corepack@latest && corepack enable && corepack install
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile --filter "." --ignore-scripts
 
 ## Copy code

--- a/apps/chatbot/docker-compose.yaml
+++ b/apps/chatbot/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   chatbot:
     build:


### PR DESCRIPTION
## Describe your changes

Looks like some keys got rotated somewhere and the version of corepack shipped with the Node.js 22 Docker image does not have the new ones, so we need to update corepack first before we enable it.

cc https://github.com/nodejs/corepack/issues/612#issuecomment-2618282249

Also, this moves the corepack enable call to _after_ we've copied across the package.json et al so that we know we're enabling the correct version of pnpm.

## Notes for testing your change

Deploys chatbot without issue.