### PR TITLE
Add QR code to stream overlay

### DIFF
--- a/apps/website/src/components/overlay/Cycle.tsx
+++ b/apps/website/src/components/overlay/Cycle.tsx
@@ -1,0 +1,84 @@
+import {
+  Children,
+  cloneElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Ref,
+  type ReactElement,
+} from "react";
+import { Transition } from "@headlessui/react";
+
+import { classes } from "@/utils/classes";
+
+const Cycle = ({
+  items,
+  interval = 60,
+}: {
+  items: ReactElement<{ className: string; ref: Ref<HTMLElement> }>[];
+  interval?: number;
+}) => {
+  const refs = useRef<(HTMLElement | null)[]>([]);
+  const cloned = useMemo(
+    () =>
+      items.map((item, idx) =>
+        cloneElement(item, {
+          className: classes(
+            item.props.className,
+            "transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300",
+          ),
+          ref: (el) => {
+            refs.current[idx] = el;
+          },
+        }),
+      ),
+    [items],
+  );
+
+  const [index, setIndex] = useState(0);
+  useEffect(() => {
+    const nextIndex = (index + 1) % items.length;
+    const timeout = setTimeout(() => setIndex(nextIndex), interval * 1000);
+    return () => clearTimeout(timeout);
+  }, [index, items, interval]);
+
+  return Children.map(cloned, (item, idx) => (
+    <Transition
+      show={idx === index}
+      beforeEnter={() => {
+        const ref = refs.current[idx];
+        if (!ref) return;
+
+        ref.style.zIndex = "1";
+      }}
+      beforeLeave={() => {
+        const ref = refs.current[idx];
+        if (!ref) return;
+
+        // Only offset if not absolute positioned
+        if (window.getComputedStyle(ref).position !== "absolute") {
+          // Offset by the width of the element and any gap between elements
+          const { width } = ref.getBoundingClientRect();
+          const gap = ref.parentElement
+            ? Number(
+                window
+                  .getComputedStyle(ref.parentElement)
+                  .rowGap.replace(/px$/, ""),
+              )
+            : 0;
+
+          // If we're the last element, we need to offset an element that will be to the left of us
+          ref.style[idx === items.length - 1 ? "marginLeft" : "marginRight"] =
+            `-${width + gap}px`;
+        }
+
+        ref.style.zIndex = "0";
+      }}
+    >
+      {item}
+    </Transition>
+  ));
+};
+
+export default Cycle;

--- a/apps/website/src/components/overlay/Event.tsx
+++ b/apps/website/src/components/overlay/Event.tsx
@@ -6,11 +6,13 @@ import {
   useMemo,
   useRef,
   useState,
-  type RefCallback,
+  type Ref,
   type ReactElement,
+  type HTMLProps,
 } from "react";
 import { Transition } from "@headlessui/react";
 import { keepPreviousData } from "@tanstack/react-query";
+import type { CalendarEvent } from "@prisma/client";
 
 import { trpc } from "@/utils/trpc";
 import { DATETIME_ALVEUS_ZONE, formatDateTimeRelative } from "@/utils/datetime";
@@ -22,11 +24,13 @@ import { QRCode } from "@/components/QrCode";
 
 import logoImage from "@/assets/logo.png";
 
+const cycleTime = 60;
+
 const Cycle = ({
   items,
   interval = 60,
 }: {
-  items: ReactElement<{ className: string; ref: RefCallback<HTMLElement> }>[];
+  items: ReactElement<{ className: string; ref: Ref<HTMLElement> }>[];
   interval?: number;
 }) => {
   const [index, setIndex] = useState(0);
@@ -51,19 +55,23 @@ const Cycle = ({
         const ref = refs.current[i];
         if (!ref) return;
 
-        // Offset by the width of the element and any gap between elements
-        const { width } = ref.getBoundingClientRect();
-        const gap = ref.parentElement
-          ? Number(
-              window
-                .getComputedStyle(ref.parentElement)
-                .rowGap.replace(/px$/, ""),
-            )
-          : 0;
+        // Only offset if not absolute positioned
+        if (window.getComputedStyle(ref).position !== "absolute") {
+          // Offset by the width of the element and any gap between elements
+          const { width } = ref.getBoundingClientRect();
+          const gap = ref.parentElement
+            ? Number(
+                window
+                  .getComputedStyle(ref.parentElement)
+                  .rowGap.replace(/px$/, ""),
+              )
+            : 0;
 
-        // If we're the last element, we need to offset an element that will be to the left of us
-        ref.style[i === items.length - 1 ? "marginLeft" : "marginRight"] =
-          `-${width + gap}px`;
+          // If we're the last element, we need to offset an element that will be to the left of us
+          ref.style[i === items.length - 1 ? "marginLeft" : "marginRight"] =
+            `-${width + gap}px`;
+        }
+
         ref.style.zIndex = "0";
       }}
     >
@@ -72,7 +80,7 @@ const Cycle = ({
           item.props.className,
           "transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300",
         ),
-        ref: (el: HTMLElement | null) => {
+        ref: (el) => {
           refs.current[i] = el;
         },
       })}
@@ -80,7 +88,35 @@ const Cycle = ({
   ));
 };
 
-const Event = ({ className }: { className?: string }) => {
+const Socials = ({ className, ...props }: HTMLProps<HTMLDivElement>) => (
+  <div className={classes(className, "flex items-center gap-2")} {...props}>
+    <Cycle
+      items={[
+        <Image
+          key="logo"
+          src={logoImage}
+          alt=""
+          height={64}
+          className="size-16 object-contain opacity-75 brightness-150 contrast-125 drop-shadow-sm grayscale"
+        />,
+        <QRCode
+          key="qr"
+          className="size-16 rounded-lg border-2 border-black bg-white p-1 opacity-75 drop-shadow-sm"
+          value={`${getShortBaseUrl()}/socials`}
+        />,
+      ]}
+      // We want to be back on the logo before the parent cycle switches
+      interval={cycleTime / 3}
+    />
+
+    <div className="text-xl font-bold text-white text-stroke">
+      <p>alveussanctuary.org</p>
+      <p>@alveussanctuary</p>
+    </div>
+  </div>
+);
+
+const useUpcoming = () => {
   // Set the range for upcoming events to the next 3 days
   // Refresh every 60s
   const [upcomingRange, setUpcomingRange] = useState<[Date, Date]>();
@@ -104,98 +140,85 @@ const Event = ({ className }: { className?: string }) => {
     { start: upcomingRange?.[0], end: upcomingRange?.[1] },
     { enabled: upcomingRange !== undefined, placeholderData: keepPreviousData },
   );
-  const firstEventId = useMemo(
-    () => events?.find(twitchChannels.alveus.filter)?.id,
-    [events],
-  );
 
-  // If we have an upcoming event, swap socials with it
-  // Swap every 60s
-  const [visibleEventId, setVisibleEventId] = useState<string>();
-  const eventInterval = useRef<NodeJS.Timeout>(null);
+  // Ensure we hold a stable reference to the event
+  const [event, setEvent] = useState<CalendarEvent>();
   useEffect(() => {
-    if (!firstEventId) {
-      setVisibleEventId(undefined);
+    if (!events) return;
+
+    const upcoming = events.find(twitchChannels.alveus.filter);
+    if (!upcoming) {
+      setEvent(undefined);
       return;
     }
 
-    const swapEvent = () =>
-      setVisibleEventId((prev) => (prev ? undefined : firstEventId));
-    swapEvent();
-    eventInterval.current = setInterval(swapEvent, 60 * 1000);
-    return () => clearInterval(eventInterval.current ?? undefined);
-  }, [firstEventId]);
-  const event = useMemo(
+    const hasChanged =
+      !event ||
+      Object.entries(upcoming).some(([key, value]) => {
+        if (!(key in event)) return true;
+        const val = event[key as keyof CalendarEvent];
+
+        // Handle dates as they are objects
+        if (value instanceof Date && val instanceof Date) {
+          return value.getTime() !== val.getTime();
+        }
+        return value !== val;
+      });
+    if (hasChanged) {
+      setEvent(upcoming);
+    }
+  }, [events, event]);
+
+  return event;
+};
+
+const Upcoming = ({
+  event,
+  className,
+  ...props
+}: { event: CalendarEvent } & HTMLProps<HTMLDivElement>) => (
+  <div
+    className={classes(className, "font-bold text-white text-stroke")}
+    {...props}
+  >
+    <p>Upcoming:</p>
+
+    {event && (
+      <>
+        <p className="text-xl">
+          {getFormattedTitle(event, twitchChannels.alveus.username, 30)}
+        </p>
+        <p className="text-xl">
+          {formatDateTimeRelative(
+            event.startAt,
+            {
+              style: "long",
+              time: event.hasTime ? "minutes" : undefined,
+              timezone: event.hasTime,
+            },
+            { zone: DATETIME_ALVEUS_ZONE },
+          )}
+        </p>
+      </>
+    )}
+  </div>
+);
+
+const Event = ({ className }: { className?: string }) => {
+  const upcoming = useUpcoming();
+
+  const items = useMemo(
     () =>
-      visibleEventId && events?.find((event) => event.id === visibleEventId),
-    [visibleEventId, events],
+      [
+        <Socials key="socials" className={className} />,
+        upcoming && (
+          <Upcoming key="upcoming" event={upcoming} className={className} />
+        ),
+      ].filter((x) => !!x),
+    [upcoming, className],
   );
 
-  return (
-    <>
-      <Transition show={event !== undefined}>
-        <div
-          className={classes(
-            className,
-            "font-bold text-white transition-opacity text-stroke data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300",
-          )}
-        >
-          <p>Upcoming:</p>
-
-          {event && (
-            <>
-              <p className="text-xl">
-                {getFormattedTitle(event, twitchChannels.alveus.username, 30)}
-              </p>
-              <p className="text-xl">
-                {formatDateTimeRelative(
-                  event.startAt,
-                  {
-                    style: "long",
-                    time: event.hasTime ? "minutes" : undefined,
-                    timezone: event.hasTime,
-                  },
-                  { zone: DATETIME_ALVEUS_ZONE },
-                )}
-              </p>
-            </>
-          )}
-        </div>
-      </Transition>
-
-      <Transition show={event === undefined}>
-        <div
-          className={classes(
-            className,
-            "flex items-center gap-2 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300",
-          )}
-        >
-          <Cycle
-            items={[
-              <Image
-                key="logo"
-                src={logoImage}
-                alt=""
-                height={64}
-                className="size-16 object-contain opacity-75 brightness-150 contrast-125 drop-shadow-sm grayscale"
-              />,
-              <QRCode
-                key="qr"
-                className="size-16 rounded-lg border-2 border-black bg-white p-1 opacity-75 drop-shadow-sm"
-                value={`${getShortBaseUrl()}/socials`}
-              />,
-            ]}
-            interval={20}
-          />
-
-          <div className="text-xl font-bold text-white text-stroke">
-            <p>alveussanctuary.org</p>
-            <p>@alveussanctuary</p>
-          </div>
-        </div>
-      </Transition>
-    </>
-  );
+  return <Cycle items={items} interval={cycleTime} />;
 };
 
 export default Event;

--- a/apps/website/src/components/overlay/Event.tsx
+++ b/apps/website/src/components/overlay/Event.tsx
@@ -6,7 +6,10 @@ import { keepPreviousData } from "@tanstack/react-query";
 import { trpc } from "@/utils/trpc";
 import { DATETIME_ALVEUS_ZONE, formatDateTimeRelative } from "@/utils/datetime";
 import { classes } from "@/utils/classes";
+import { getShortBaseUrl } from "@/utils/short-url";
 import { getFormattedTitle, twitchChannels } from "@/data/calendar-events";
+
+import { QRCode } from "@/components/QrCode";
 
 import logoImage from "@/assets/logo.png";
 
@@ -111,6 +114,11 @@ const Event = ({ className }: { className?: string }) => {
             <p>alveussanctuary.org</p>
             <p>@alveussanctuary</p>
           </div>
+
+          <QRCode
+            className="size-16 rounded-lg border-2 border-black bg-white p-1 opacity-75 drop-shadow-sm"
+            value={`${getShortBaseUrl()}/socials`}
+          />
         </div>
       </Transition>
     </>

--- a/apps/website/src/components/overlay/Event.tsx
+++ b/apps/website/src/components/overlay/Event.tsx
@@ -1,16 +1,5 @@
 import Image from "next/image";
-import {
-  Children,
-  cloneElement,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type Ref,
-  type ReactElement,
-  type HTMLProps,
-} from "react";
-import { Transition } from "@headlessui/react";
+import { useEffect, useMemo, useRef, useState, type HTMLProps } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 import type { CalendarEvent } from "@prisma/client";
 
@@ -21,79 +10,11 @@ import { getShortBaseUrl } from "@/utils/short-url";
 import { getFormattedTitle, twitchChannels } from "@/data/calendar-events";
 
 import { QRCode } from "@/components/QrCode";
+import Cycle from "@/components/overlay/Cycle";
 
 import logoImage from "@/assets/logo.png";
 
 const cycleTime = 60;
-
-const Cycle = ({
-  items,
-  interval = 60,
-}: {
-  items: ReactElement<{ className: string; ref: Ref<HTMLElement> }>[];
-  interval?: number;
-}) => {
-  const refs = useRef<(HTMLElement | null)[]>([]);
-  const cloned = useMemo(
-    () =>
-      items.map((item, idx) =>
-        cloneElement(item, {
-          className: classes(
-            item.props.className,
-            "transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300",
-          ),
-          ref: (el) => {
-            refs.current[idx] = el;
-          },
-        }),
-      ),
-    [items],
-  );
-
-  const [index, setIndex] = useState(0);
-  useEffect(() => {
-    const nextIndex = (index + 1) % items.length;
-    const timeout = setTimeout(() => setIndex(nextIndex), interval * 1000);
-    return () => clearTimeout(timeout);
-  }, [index, items, interval]);
-
-  return Children.map(cloned, (item, idx) => (
-    <Transition
-      show={idx === index}
-      beforeEnter={() => {
-        const ref = refs.current[idx];
-        if (!ref) return;
-
-        ref.style.zIndex = "1";
-      }}
-      beforeLeave={() => {
-        const ref = refs.current[idx];
-        if (!ref) return;
-
-        // Only offset if not absolute positioned
-        if (window.getComputedStyle(ref).position !== "absolute") {
-          // Offset by the width of the element and any gap between elements
-          const { width } = ref.getBoundingClientRect();
-          const gap = ref.parentElement
-            ? Number(
-                window
-                  .getComputedStyle(ref.parentElement)
-                  .rowGap.replace(/px$/, ""),
-              )
-            : 0;
-
-          // If we're the last element, we need to offset an element that will be to the left of us
-          ref.style[idx === items.length - 1 ? "marginLeft" : "marginRight"] =
-            `-${width + gap}px`;
-        }
-
-        ref.style.zIndex = "0";
-      }}
-    >
-      {item}
-    </Transition>
-  ));
-};
 
 const Socials = ({ className, ...props }: HTMLProps<HTMLDivElement>) => (
   <div className={classes(className, "flex items-center gap-2")} {...props}>


### PR DESCRIPTION
## Describe your changes

Adds a QR code cycling into the stream overlay when the socials info is shown, allowing folks to scan the QR code to quickly access all the Alveus socials.

As part of this, I've also introduced a Cycle component for the overlay that should make it _much_ easier to add more elements into the bottom left (or anywhere else) that cycle through different variations.

In the future, we could add another variation to the bottom left that pushes folks towards the schedule, and make use of a QR code there as well.

## Notes for testing your change

QR code is scannable and goes to the socials. Cycle works correctly, showing the logo/QR code, and then the upcoming event -- it should also handle no upcoming event and just stay on the socials.