### PR TITLE
Tweak QR code in stream overlay

### DIFF
--- a/apps/website/src/components/overlay/Event.tsx
+++ b/apps/website/src/components/overlay/Event.tsx
@@ -30,7 +30,7 @@ const Socials = ({ className, ...props }: HTMLProps<HTMLDivElement>) => (
           />,
           <QRCode
             key="qr"
-            className="size-16 rounded-lg border-2 border-black bg-white p-1 opacity-75 drop-shadow-sm"
+            className="size-16 rounded-lg border-2 border-black/75 bg-white p-0.5 opacity-90 drop-shadow-sm"
             value={`${getShortBaseUrl()}/socials`}
           />,
         ],

--- a/apps/website/src/components/overlay/Event.tsx
+++ b/apps/website/src/components/overlay/Event.tsx
@@ -113,25 +113,20 @@ const Upcoming = ({
     {...props}
   >
     <p>Upcoming:</p>
-
-    {event && (
-      <>
-        <p className="text-xl">
-          {getFormattedTitle(event, twitchChannels.alveus.username, 30)}
-        </p>
-        <p className="text-xl">
-          {formatDateTimeRelative(
-            event.startAt,
-            {
-              style: "long",
-              time: event.hasTime ? "minutes" : undefined,
-              timezone: event.hasTime,
-            },
-            { zone: DATETIME_ALVEUS_ZONE },
-          )}
-        </p>
-      </>
-    )}
+    <p className="text-xl">
+      {getFormattedTitle(event, twitchChannels.alveus.username, 30)}
+    </p>
+    <p className="text-xl">
+      {formatDateTimeRelative(
+        event.startAt,
+        {
+          style: "long",
+          time: event.hasTime ? "minutes" : undefined,
+          timezone: event.hasTime,
+        },
+        { zone: DATETIME_ALVEUS_ZONE },
+      )}
+    </p>
   </div>
 );
 

--- a/apps/website/src/components/overlay/Event.tsx
+++ b/apps/website/src/components/overlay/Event.tsx
@@ -37,7 +37,7 @@ const Socials = ({ className, ...props }: HTMLProps<HTMLDivElement>) => (
         [],
       )}
       // We want to be back on the logo before the parent cycle switches
-      interval={cycleTime / 3}
+      interval={cycleTime / 3 + 1}
     />
 
     <div className="text-xl font-bold text-white text-stroke">


### PR DESCRIPTION
## Describe your changes

After pushing this live to the stream, it was noticed that the timing was _too_ perfect for the cycling elements, leading to the QR code fading back in as the whole socials element faded out -- the timing is tweaked here to be _slightly_ offset from the parent timing so it won't do that now.

Also, this slightly tweaks the QR code sizing and opacity to give it slightly more room to be more readable and to give it more contrast against the stream content.

## Notes for testing your change

QR code is visible. With an upcoming event, the transitions don't clash.