### PR TITLE
Bump z-index for desktop menu dropdowns

### DIFF
--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -33,7 +33,7 @@ import IconChevronDown from "@/icons/IconChevronDown";
 const DropdownMenuItems: typeof MenuItems = ({ ...props }) => (
   <MenuItems
     transition
-    className="group/items absolute top-full right-0 z-50 mt-1 flex min-w-40 flex-col gap-0.5 rounded-sm border border-black/20 bg-alveus-green-900 p-2 shadow-lg transition ease-in-out focus:outline-hidden data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-100 data-[leave]:duration-75"
+    className="group/items absolute top-full right-0 z-10 mt-1 flex min-w-40 flex-col gap-0.5 rounded-sm border border-black/20 bg-alveus-green-900 p-2 shadow-lg transition ease-in-out focus:outline-hidden data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-100 data-[leave]:duration-75"
     as="ul"
     modal={false}
     {...props}

--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -33,7 +33,7 @@ import IconChevronDown from "@/icons/IconChevronDown";
 const DropdownMenuItems: typeof MenuItems = ({ ...props }) => (
   <MenuItems
     transition
-    className="group/items absolute top-full right-0 z-30 mt-1 flex min-w-40 flex-col gap-0.5 rounded-sm border border-black/20 bg-alveus-green-900 p-2 shadow-lg transition ease-in-out focus:outline-hidden data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-100 data-[leave]:duration-75"
+    className="group/items absolute top-full right-0 z-50 mt-1 flex min-w-40 flex-col gap-0.5 rounded-sm border border-black/20 bg-alveus-green-900 p-2 shadow-lg transition ease-in-out focus:outline-hidden data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-100 data-[leave]:duration-75"
     as="ul"
     modal={false}
     {...props}

--- a/apps/website/src/components/layout/navbar/Navbar.tsx
+++ b/apps/website/src/components/layout/navbar/Navbar.tsx
@@ -15,7 +15,7 @@ export const Navbar = () => {
   return (
     <Disclosure
       as="header"
-      className="relative z-20 bg-alveus-green-900 text-white lg:bg-transparent"
+      className="relative z-50 bg-alveus-green-900 text-white lg:bg-transparent"
     >
       {({ open }) => (
         <>

--- a/apps/website/src/pages/book-club.tsx
+++ b/apps/website/src/pages/book-club.tsx
@@ -198,7 +198,7 @@ const BookClubPage: NextPage = () => {
         <Image
           src={leafLeftImage3}
           alt=""
-          className="pointer-events-none absolute -bottom-10 left-0 z-30 hidden h-auto w-1/2 max-w-36 -scale-y-100 rotate-[20deg] drop-shadow-md select-none lg:block"
+          className="pointer-events-none absolute -bottom-10 left-0 z-10 hidden h-auto w-1/2 max-w-36 -scale-y-100 rotate-[20deg] drop-shadow-md select-none lg:block"
         />
 
         <Section


### PR DESCRIPTION
## Describe your changes

Ensures that the desktop nav floats above any floral decorations on pages.

Some floral decorations were bumped from z-10 to z-30 due to the new subnav being added at z-20, and the desktop nav was only floating at z-20 previously.

## Notes for testing your change

Nav dropdowns are always above floral decorations on any pages (/about/tech/commands was the reported page).