### PR TITLE
Add a Dependabot group for tailwind dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
     versioning-strategy: increase
 
     groups:
-      # Create dedicated (grouped) PRs for Next.js/trpc/prisma dependencies
+      # Create dedicated (grouped) PRs for Next.js/trpc/prisma/tailwind dependencies
       next:
         patterns:
           - "next"
@@ -41,6 +41,10 @@ updates:
         patterns:
           - "prisma"
           - "@prisma/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
 
       # Update `dependencies` and `devDependencies` separately
       # Create grouped PRs for minor/patch updates with majors getting dedicated PRs
@@ -57,6 +61,8 @@ updates:
           - "@tanstack/react-query"
           - "prisma"
           - "@prisma/*"
+          - "tailwindcss"
+          - "@tailwindcss/*"
       development:
         dependency-type: development
         update-types:
@@ -69,6 +75,8 @@ updates:
           - "@tanstack/react-query"
           - "prisma"
           - "@prisma/*"
+          - "tailwindcss"
+          - "@tailwindcss/*"
 
     # Manually update major versions of `@types/node` with the version specified within .nvmrc
     ignore:
@@ -81,4 +89,4 @@ updates:
     rebase-strategy: disabled
 
     # Allow enough PRs for all the groups plus some major version PRs
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20


### PR DESCRIPTION
## Describe your changes

We now have two Tailwind dependencies, the core `tailwindcss` and the split-out PostCSS plugin `@tailwindcss/postcss` -- they are versioned together, so we should make sure Dependabot updates them togther.

## Notes for testing your change

Config valid, dependency names are correct.