### PR TITLE
Fix captions on Show and Tell gallery

### DIFF
--- a/apps/website/src/components/content/YouTube.tsx
+++ b/apps/website/src/components/content/YouTube.tsx
@@ -168,7 +168,7 @@ export const Lightbox = ({
     const opts = {
       ...getDefaultPhotoswipeLightboxOptions(),
       gallery: `#${photoswipeId}`,
-      mainClass: `pswp--${photoswipeId}`,
+      mainClass: `font-sans pswp--${photoswipeId}`,
       children: `a[data-lightbox-${photoswipeId}]`,
       preloaderDelay: 0,
     };

--- a/apps/website/src/components/content/YouTube.tsx
+++ b/apps/website/src/components/content/YouTube.tsx
@@ -165,14 +165,14 @@ export const Lightbox = ({
   const [photoswipe, setPhotoswipe] = useState<PhotoSwipeLightbox>();
 
   useEffect(() => {
-    const opts = {
-      ...getDefaultPhotoswipeLightboxOptions(),
+    const defaultConfig = getDefaultPhotoswipeLightboxOptions();
+    const lightbox = new PhotoSwipeLightbox({
+      ...defaultConfig,
       gallery: `#${photoswipeId}`,
-      mainClass: `font-sans pswp--${photoswipeId}`,
+      mainClass: classes(defaultConfig.mainClass, `pswp--${photoswipeId}`),
       children: `a[data-lightbox-${photoswipeId}]`,
       preloaderDelay: 0,
-    };
-    const lightbox = new PhotoSwipeLightbox(opts);
+    });
 
     // Expose the video id
     lightbox.addFilter("itemData", (itemData) => ({

--- a/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/utils/video-urls";
 import { getDefaultPhotoswipeLightboxOptions } from "@/utils/photoswipe";
 import { createImageUrl } from "@/utils/image";
+import { classes } from "@/utils/classes";
 
 import type { ImageAttachmentWithFileStorageObject } from "@/server/db/show-and-tell";
 
@@ -45,7 +46,10 @@ export function ShowAndTellGallery({
       gallery: `#${photoswipeId}`,
       children: "a[data-pswp-type]",
       appendToEl: lightboxParent || defaultConfig.appendToEl,
-      mainClass: lightboxParent ? "alveus-sat-pswp" : undefined,
+      mainClass: classes(
+        "font-sans",
+        lightboxParent && "w-[80%] overflow-hidden",
+      ),
       padding: {
         top: 0,
         right: 40,
@@ -110,7 +114,10 @@ export function ShowAndTellGallery({
 
     lightbox.on("uiRegister", () => {
       lightbox.pswp?.ui?.registerElement({
-        name: "alveus-caption",
+        className: classes(
+          "absolute bottom-0 left-1/2 w-fit max-w-[calc(100%-80px)] -translate-x-1/2 bg-black/80 p-4 leading-tight text-white empty:hidden",
+          lightboxParent && "text-lg",
+        ),
         order: 9,
         isButton: false,
         appendTo: "root",

--- a/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
@@ -47,7 +47,7 @@ export function ShowAndTellGallery({
       children: "a[data-pswp-type]",
       appendToEl: lightboxParent || defaultConfig.appendToEl,
       mainClass: classes(
-        "font-sans",
+        defaultConfig.mainClass,
         lightboxParent && "w-[80%] overflow-hidden",
       ),
       padding: {

--- a/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
@@ -48,7 +48,7 @@ export function ShowAndTellGallery({
       appendToEl: lightboxParent || defaultConfig.appendToEl,
       mainClass: classes(
         defaultConfig.mainClass,
-        lightboxParent && "w-[80%] overflow-hidden",
+        lightboxParent && "w-[80%]! overflow-hidden!",
       ),
       padding: {
         top: 0,

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -187,6 +187,7 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
   useEffect(() => {
     const lightbox = new PhotoSwipeLightbox({
       ...getDefaultPhotoswipeLightboxOptions(),
+      mainClass: "font-sans",
       gallery: `#${photoswipe}`,
       children: "a",
       loop: true,

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -187,7 +187,6 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
   useEffect(() => {
     const lightbox = new PhotoSwipeLightbox({
       ...getDefaultPhotoswipeLightboxOptions(),
-      mainClass: "font-sans",
       gallery: `#${photoswipe}`,
       children: "a",
       loop: true,

--- a/apps/website/src/styles/tailwind.css
+++ b/apps/website/src/styles/tailwind.css
@@ -101,7 +101,7 @@
   .pswp {
     @apply font-sans;
 
-    &__alveus-caption {
+    .pswp__alveus-caption {
       @apply absolute bottom-0 left-1/2 w-fit max-w-[calc(100%-80px)] -translate-x-1/2 bg-black/80 p-4 leading-tight text-white empty:hidden;
     }
   }

--- a/apps/website/src/styles/tailwind.css
+++ b/apps/website/src/styles/tailwind.css
@@ -90,22 +90,6 @@
     }
   }
 
-  .alveus-sat-pswp {
-    @apply w-[80%] overflow-hidden;
-
-    .pswp__alveus-caption {
-      @apply text-lg;
-    }
-  }
-
-  .pswp {
-    @apply font-sans;
-
-    .pswp__alveus-caption {
-      @apply absolute bottom-0 left-1/2 w-fit max-w-[calc(100%-80px)] -translate-x-1/2 bg-black/80 p-4 leading-tight text-white empty:hidden;
-    }
-  }
-
   .alveus-community-map {
     .maplibregl-popup-content {
       padding: 3px 6px !important;

--- a/apps/website/src/utils/photoswipe.ts
+++ b/apps/website/src/utils/photoswipe.ts
@@ -3,6 +3,7 @@ import type { PhotoSwipeOptions, ElementProvider } from "photoswipe";
 export function getDefaultPhotoswipeLightboxOptions() {
   return {
     pswpModule: () => import("photoswipe"),
+    mainClass: "font-sans",
     appendToEl: document.getElementById("app") as HTMLElement,
     showHideAnimationType: "fade",
     loop: false,


### PR DESCRIPTION
## Describe your changes

Resolves #1052, while also cleaning up how we handle classes for PhotoSwipe by removing the reliance on global CSS classes and instead applying the actual Tailwind classes inline where we need them.

## Notes for testing your change

All PhotoSwipe galleries continue to look correct. Show and Tell now shows captions on images when they're clicked on, both in regular and presentation mode.