### PR TITLE
Prevent form submission on Enter key in map picker

### DIFF
--- a/apps/website/src/components/content/Box.tsx
+++ b/apps/website/src/components/content/Box.tsx
@@ -12,7 +12,7 @@ type BoxProps = {
 const Box = ({ dark, className, ringClassName, children }: BoxProps) => (
   <div
     className={classes(
-      "relative rounded-xl shadow-xl",
+      "relative overflow-hidden rounded-xl shadow-xl",
       // add padding if not overwritten via className
       !/\bp-\d+\b/.test(className || "") && "p-8",
       // add background color if not overwritten via className

--- a/apps/website/src/components/shared/form/MapPickerField.tsx
+++ b/apps/website/src/components/shared/form/MapPickerField.tsx
@@ -260,6 +260,10 @@ export const MapPickerField = ({
         <div className="h-[500px] w-full overflow-hidden rounded-lg">
           <div
             ref={mapContainerRef}
+            onKeyDown={(e) => {
+              // If enter is pressed, don't bubble up to submit the form
+              if (e.key === "Enter") e.preventDefault();
+            }}
             style={{
               width: "100%",
               height: "500px",

--- a/apps/website/src/components/shared/form/MapPickerField.tsx
+++ b/apps/website/src/components/shared/form/MapPickerField.tsx
@@ -15,6 +15,8 @@ import mapStyle from "@/data/map-style";
 import IconWorld from "@/icons/IconWorld";
 import IconX from "@/icons/IconX";
 
+import Box from "@/components/content/Box";
+
 import { CheckboxField } from "./CheckboxField";
 
 /**
@@ -257,20 +259,16 @@ export const MapPickerField = ({
       </div>
 
       {showMap && (
-        <div className="h-[500px] w-full overflow-hidden rounded-lg">
+        <Box className="p-0">
           <div
             ref={mapContainerRef}
             onKeyDown={(e) => {
               // If enter is pressed, don't bubble up to submit the form
               if (e.key === "Enter") e.preventDefault();
             }}
-            style={{
-              width: "100%",
-              height: "500px",
-              visibility: showMap ? "visible" : "hidden",
-            }}
+            className="h-128"
           />
-        </div>
+        </Box>
       )}
     </>
   );

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -64,7 +64,7 @@ export type ShowAndTellPageProps = InferGetStaticPropsType<
 const entriesPerPage = 10;
 
 export const bentoBoxClasses =
-  "bg-alveus-green-600 text-center text-white flex flex-col justify-center gap-2 overflow-hidden";
+  "bg-alveus-green-600 text-center text-white flex flex-col justify-center gap-2";
 
 // We pre-render the first page of entries using SSR and then use client-side rendering to
 // update the data and fetch more entries on demand


### PR DESCRIPTION
## Describe your changes

Resolves #1054. The geocoder input does not accept/suppress the Enter key, it just searches as you type (denounced), so when the Enter key was pressed it bubbled up to the form and would attempt a submission -- if an Enter key press event makes it to the surrounding div for the map, it will be prevented beyond that.

Also, tweaks the styling for the map.

## Notes for testing your change

In the show and tell form, typing and pressing Enter within the map search box will not attempt a submission of the form as a whole.