### PR TITLE
Install TS at root + enable erasableSyntaxOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ If you aren't working on features related to Twitch authentication, you can set 
 - Learn more about the stack at [Create T3 App - Introduction](https://create.t3.gg/en/introduction)
 - You can use the Prisma Studio to view your database. Launch it with `pnpm prisma studio`
 - You can access a direct MySQL CLI to the database with `docker compose exec db sh -c 'MYSQL_PWD=$MYSQL_ROOT_PASSWORD mysql alveusgg'`
+- If you're using VSCode, add `"typescript.tsdk": "node_modules/typescript/lib"` to `.vscode/settings.json` to ensure you're using the correct TypeScript version
 
 ### Generate secrets
 

--- a/apps/chatbot/package.json
+++ b/apps/chatbot/package.json
@@ -32,7 +32,6 @@
     "eslint": "^9.21.0",
     "eslint-config-prettier": "^10.0.2",
     "eslint-plugin-import-x": "^4.6.1",
-    "typescript": "^5.8.2",
     "typescript-eslint": "^8.25.0"
   },
   "scripts": {

--- a/apps/chatbot/tsconfig.json
+++ b/apps/chatbot/tsconfig.json
@@ -16,6 +16,8 @@
     "jsx": "preserve",
     "incremental": true,
     "noUncheckedIndexedAccess": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/chatbot/tsconfig.json
+++ b/apps/chatbot/tsconfig.json
@@ -15,6 +15,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -134,7 +134,6 @@
     "tailwindcss": "^4.0.9",
     "tsup": "^8.4.0",
     "tsx": "^4.19.3",
-    "typescript": "^5.8.2",
     "typescript-eslint": "^8.25.0",
     "vitest": "^3.0.7",
     "webpack": "^5.98.0"

--- a/apps/website/src/utils/mmcq.ts
+++ b/apps/website/src/utils/mmcq.ts
@@ -3,6 +3,14 @@
 const channels = 3;
 const sigBits = 5;
 
+const Channel = {
+  Red: 0,
+  Green: 1,
+  Blue: 2,
+} as const;
+
+type Channel = (typeof Channel)[keyof typeof Channel];
+
 type Range = [number, number];
 const cut = (
   vboxes: {
@@ -19,13 +27,7 @@ const cut = (
 
   const { ranges } = vboxes.pop()!;
 
-  const enum Channel {
-    Red,
-    Green,
-    Blue,
-  }
-
-  let maxRange = Channel.Red;
+  let maxRange: Channel = Channel.Red;
   let maxSpan = ranges[maxRange][1] - ranges[maxRange][0];
   for (let i = Channel.Green; i < ranges.length; i++) {
     const range = ranges[i];

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -16,6 +16,8 @@
     "jsx": "preserve",
     "incremental": true,
     "noUncheckedIndexedAccess": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
     "paths": {
       "@/*": ["./src/*"],
       "photoswipe/lightbox": [

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -15,6 +15,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^15.4.3",
-    "prettier": "^3.5.2"
+    "prettier": "^3.5.2",
+    "typescript": "^5.8.2"
   },
   "scripts": {
     "prepare": "husky",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       prettier:
         specifier: ^3.5.2
         version: 3.5.2
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
 
   apps/chatbot:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       eslint-plugin-import-x:
         specifier: ^4.6.1
         version: 4.6.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
-      typescript:
-        specifier: ^5.8.2
-        version: 5.8.2
       typescript-eslint:
         specifier: ^8.25.0
         version: 8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
@@ -341,7 +338,7 @@ importers:
         version: 3.8.3(eslint-plugin-import-x@4.6.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(eslint-import-resolver-typescript@3.8.3)(eslint@9.21.0(jiti@2.4.2))
+        version: 2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.8.3)(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-import-x:
         specifier: ^4.6.1
         version: 4.6.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
@@ -384,9 +381,6 @@ importers:
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
-      typescript:
-        specifier: ^5.8.2
-        version: 5.8.2
       typescript-eslint:
         specifier: ^8.25.0
         version: 8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
@@ -408,6 +402,9 @@ packages:
     peerDependencies:
       tailwindcss: ^4.0.0
       zod: ^3.0.0
+    peerDependenciesMeta:
+      tailwindcss:
+        optional: true
 
   '@asamuzakjp/css-color@2.8.2':
     resolution: {integrity: sha512-RtWv9jFN2/bLExuZgFFZ0I3pWWeezAHGgrmjqGGWclATl1aDe3yhCUaI0Ilkp6OCk9zX7+FjvDasEX8Q9Rxc5w==}
@@ -6176,8 +6173,9 @@ snapshots:
 
   '@alveusgg/data@0.54.1(tailwindcss@4.0.9)(zod@3.24.2)':
     dependencies:
-      tailwindcss: 4.0.9
       zod: 3.24.2
+    optionalDependencies:
+      tailwindcss: 4.0.9
 
   '@asamuzakjp/css-color@2.8.2':
     dependencies:
@@ -10311,15 +10309,16 @@ snapshots:
       stable-hash: 0.0.4
       tinyglobby: 0.2.12
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(eslint-import-resolver-typescript@3.8.3)(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.8.3)(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-import-x: 4.6.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.21.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.21.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import-x@4.6.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2))
@@ -10346,7 +10345,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.31.0(eslint-import-resolver-typescript@3.8.3)(eslint@9.21.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.8.3)(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -10357,7 +10356,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.21.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.21.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.21.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -10368,6 +10367,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
## Describe your changes

Moves the TS installation from both the sub-packages into the root package, allowing VSCode to detect/use it nicely.

Enables the new `erasableSyntaxOnly` only feature of TS 5.8, enforcing that we only use TS for types and not for functionality such as enums. As such, I've also removed our one usage of an enum in the codebase.

_Also enables `verbatimModuleSyntax` to ensure type imports are marked as such, and `noFallthroughCasesInSwitch` as a matter of code hygiene._

## Notes for testing your change

Type checking passes w/o issue for both bot + site.