### PR TITLE
Add new studio to Alveus history + homepage hero

### DIFF
--- a/apps/website/src/pages/about/alveus.tsx
+++ b/apps/website/src/pages/about/alveus.tsx
@@ -516,6 +516,19 @@ const history: [HistoryItems, ...(HistoryCTA | HistoryItems)[]] = [
       </div>
     ),
   },
+  {
+    key: "2025-and-beyond",
+    items: [
+      {
+        key: "new-studio",
+        date: "2025-03-05",
+        content: [
+          "New Studio Launch",
+          "Alveus unveils a completely refurbished studio space, featuring live plant walls, an interactive whiteboard, a new fish tank and improved equipment for live streams.",
+        ],
+      },
+    ],
+  },
 ];
 
 const transformHistoryItem = (item: HistoryItem) => ({

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -34,6 +34,7 @@ import IconBox from "@/icons/IconBox";
 import IconPayPal from "@/icons/IconPayPal";
 
 import sirenHeroImage from "@/assets/hero/siren.jpg";
+import studioHeroImage from "@/assets/hero/studio.jpg";
 import serranoJalapenoHeroImage from "@/assets/hero/serrano-jalapeno.jpg";
 import pushPopHeroImage from "@/assets/hero/push-pop.jpg";
 import ticoMileyHeroImage from "@/assets/hero/tico-miley.jpg";
@@ -50,6 +51,10 @@ const slides = [
     src: sirenHeroImage,
     alt: ambassadors.siren.name,
     className: "object-[40%_50%] lg:object-left",
+  },
+  {
+    src: studioHeroImage,
+    alt: "Maya in the Alveus studio",
   },
   {
     src: serranoJalapenoHeroImage,


### PR DESCRIPTION
## Describe your changes

Adds the new studio launch to the About Alveus history section, and the launch photo to the homepage hero to help with the perception of Alveus being an educational org as well as a sanctuary.

## Notes for testing your change

Wording makes sense in the history entry.