### PR TITLE
Expose formatted enclosure name in ambassadors API

### DIFF
--- a/apps/website/src/app/api/stream/ambassadors/route.ts
+++ b/apps/website/src/app/api/stream/ambassadors/route.ts
@@ -12,6 +12,7 @@ import {
   getSpecies,
   type Species,
 } from "@alveusgg/data/build/ambassadors/species";
+import enclosures from "@alveusgg/data/build/enclosures";
 import { getIUCNStatus } from "@alveusgg/data/build/iucn";
 
 import { createImageUrl } from "@/utils/image";
@@ -64,6 +65,7 @@ const ambassadorsV2 = typeSafeObjectFromEntries(
               title: getClassification(species.class),
             },
           },
+          enclosure: enclosures[val.enclosure].name,
         },
       ];
     }),

--- a/apps/website/src/app/api/stream/ambassadors/route.ts
+++ b/apps/website/src/app/api/stream/ambassadors/route.ts
@@ -22,12 +22,13 @@ import {
 import { env } from "@/env";
 
 // If these types change, the extension schema MUST be updated as well
-type AmbassadorV2 = Omit<ActiveAmbassador, "species"> & {
+type AmbassadorV2 = Omit<ActiveAmbassador, "species" | "enclosure"> & {
   image: Omit<AmbassadorImage, "src"> & { src: string };
   species: Omit<Species, "iucn" | "class"> & {
     iucn: Species["iucn"] & { title: string };
-    class: { name: Species["class"]; title: string };
+    class: { name: string; title: string };
   };
+  enclosure: string;
 };
 
 export type AmbassadorsResponse = {


### PR DESCRIPTION
## Describe your changes

Updates the types for two strings to be generic to match the change in https://github.com/alveusgg/extension/pull/252, and then returns the enclosure name as the enclosure string instead of the key.

## Notes for testing your change

API endpoint works with the extension.
