### PR TITLE
Pin all GitHub Actions dependencies to specific hashes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,15 +7,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -37,15 +37,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -76,15 +76,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -112,15 +112,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/.github/workflows/update-chatbot.yml
+++ b/.github/workflows/update-chatbot.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Update Chatbot SSH (Production)
-        uses: appleboy/ssh-action@v1.2.2
+        uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f # v1.2.2
         with:
           envs: COMPOSE_PROJECT_NAME,CHATBOT_PATH,REF_NAME,REF_SHA
           host: ${{ secrets.CHATBOT_HOST }}
@@ -47,7 +47,7 @@ jobs:
     if: github.ref == 'refs/heads/preview'
     steps:
       - name: Update Chatbot SSH (Preview)
-        uses: appleboy/ssh-action@v1.2.2
+        uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f # v1.2.2
         with:
           envs: COMPOSE_PROJECT_NAME,CHATBOT_PATH,REF_NAME,REF_SHA
           host: ${{ secrets.CHATBOT_HOST }}

--- a/.github/workflows/update-chatbot.yml
+++ b/.github/workflows/update-chatbot.yml
@@ -33,8 +33,8 @@ jobs:
           key: ${{ secrets.CHATBOT_KEY }}
           port: ${{ secrets.CHATBOT_PORT }}
           passphrase: ${{ secrets.CHATBOT_PASSPHRASE }}
-          script_stop: true
           script: |
+            set -e
             cd $CHATBOT_PATH
             git fetch origin $REF_NAME && git reset --hard origin/$REF_NAME
             cd apps/chatbot
@@ -55,8 +55,8 @@ jobs:
           key: ${{ secrets.CHATBOT_KEY }}
           port: ${{ secrets.CHATBOT_PORT }}
           passphrase: ${{ secrets.CHATBOT_PASSPHRASE }}
-          script_stop: true
           script: |
+            set -e
             cd $CHATBOT_PATH
             git fetch origin $REF_NAME && git reset --hard origin/$REF_NAME
             cd apps/chatbot


### PR DESCRIPTION
## Describe your changes

https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/ is a good reminder that we should all pin our GitHub Actions dependencies to specific hashes that we trust, rather than mutable tags.

## Notes for testing your change

All hashes match up with the commented versions (dependabot is able to update both the hash and the commented version).