### PR TITLE
Fix cross-device error when temp directory is on a seperate partition

### DIFF
--- a/apps/website/build-scripts/video-loader.cjs
+++ b/apps/website/build-scripts/video-loader.cjs
@@ -10,6 +10,7 @@ const {
   readdir,
   stat,
   unlink,
+  copyFile,
 } = require("fs/promises");
 const { interpolateName, getHashDigest } = require("loader-utils");
 const ffmpeg = require("@ffmpeg-installer/ffmpeg");
@@ -211,7 +212,8 @@ const videoResized = async (
 
       // Move the temporary file to the cache
       await mkdir(dirname(cacheFile), { recursive: true });
-      await rename(tmpFile, cacheFile);
+      await copyFile(tmpFile, cacheFile);
+      await unlink(tmpFile);
     }
   }
 


### PR DESCRIPTION
## Describe your changes
Use `copyFile` and `unlink` as an alternative to `rename` to fix an error on devices where the `temp` directory is not on the same partition as the target directory.

## Notes for testing your change

...
