### PR TITLE
Create single dependabot group for minor/patch Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@ updates:
       day: wednesday
       time: "00:00"
 
+    # Create a grouped PR for minor/patch updates with majors getting dedicated PRs
+    groups:
+      actions:
+        update-types:
+          - patch
+          - minor
+
   - package-ecosystem: npm
     directory: /
     schedule:


### PR DESCRIPTION
## Describe your changes

Reducing the number of dependabot PRs we need to merge each week. o7.

## Notes for testing your change

Config valid.
