### PR TITLE
feat: Add click handlers to show and tell images and videos for preview

### DIFF
--- a/apps/website/src/components/shared/form/ImageUploadAttachment.tsx
+++ b/apps/website/src/components/shared/form/ImageUploadAttachment.tsx
@@ -66,18 +66,23 @@ export function ImageUploadAttachment({
   fileReference,
   children = "",
   showRemoveButton = true,
+  onClick,
 }: {
   removeFileReference: (id: string) => void;
   fileReference: FileReference;
   children?: ReactNode | ReactNode[];
   showRemoveButton?: boolean;
+  onClick?: () => void;
 }) {
   return (
     <div className="flex flex-row gap-5 rounded-lg bg-white p-2 px-4 shadow-lg">
       <div className="py-2">
-        <div className="relative size-32 overflow-hidden rounded-lg bg-gray-200">
+        <Button
+          onClick={onClick}
+          className="relative size-32 overflow-hidden rounded-lg bg-gray-200"
+        >
           <ImageUploadFilePreview fileReference={fileReference} />
-        </div>
+        </Button>
 
         {showRemoveButton && (
           <div className="p-2">

--- a/apps/website/src/components/shared/form/VideoLinksField.tsx
+++ b/apps/website/src/components/shared/form/VideoLinksField.tsx
@@ -119,7 +119,16 @@ export function VideoLinksField({
                   className="size-5"
                   platform={parseVideoUrl(url)?.platform}
                 />
-                <span className="min-w-0 flex-1 truncate text-left">{url}</span>
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-700 underline hover:cursor-pointer"
+                >
+                  <span className="min-w-0 flex-1 truncate text-left">
+                    {url}
+                  </span>
+                </a>
                 <Button
                   size="small"
                   width="auto"


### PR DESCRIPTION
## Describe your changes

Adds a modal to preview the show and tell uploaded images on click.
Opens show and tell videos in a new tab when clicking the link.

resolves #565

...

I'm still considering adding preview with embeds for videos as well, but that will take some more effort!

...
