### PR TITLE
Show channel in pill for homepage YouTube videos

### DIFF
--- a/apps/website/src/components/content/YouTube.tsx
+++ b/apps/website/src/components/content/YouTube.tsx
@@ -91,6 +91,7 @@ const createTrigger = (id: string) => {
 
 type PreviewProps = {
   videoId: string;
+  alt?: string;
   className?: string;
 };
 
@@ -103,7 +104,7 @@ const imgSrc = (id: string, type: string) =>
     quality: 100,
   });
 
-export const Preview = ({ videoId, className }: PreviewProps) => {
+export const Preview = ({ videoId, alt = "", className }: PreviewProps) => {
   // Handle falling back to hq if there isn't a maxres image
   const [type, setType] = useState<"maxresdefault" | "hqdefault">(
     "maxresdefault",
@@ -118,7 +119,7 @@ export const Preview = ({ videoId, className }: PreviewProps) => {
       <img
         src={imgSrc(videoId, type)}
         onError={onError}
-        alt=""
+        alt={alt}
         loading="lazy"
         className={classes(
           "pointer-events-none object-cover transition group-hover/trigger:scale-102 group-hover/trigger:shadow-2xl",

--- a/apps/website/src/components/content/YouTubeCarousel.tsx
+++ b/apps/website/src/components/content/YouTubeCarousel.tsx
@@ -7,13 +7,15 @@ import { classes } from "@/utils/classes";
 
 import { Lightbox, Preview } from "@/components/content/YouTube";
 import Heading from "@/components/content/Heading";
+import Link from "@/components/content/Link";
 
 type YouTubeCarouselProps = {
   videos: YouTubeVideo[];
+  id?: string;
   dark?: boolean;
 };
 
-const YouTubeCarousel = ({ videos, dark }: YouTubeCarouselProps) => {
+const YouTubeCarousel = ({ videos, id, dark }: YouTubeCarouselProps) => {
   const [open, setOpen] = useState<string>();
 
   useEffect(() => {
@@ -24,44 +26,58 @@ const YouTubeCarousel = ({ videos, dark }: YouTubeCarouselProps) => {
   return (
     <div className="flex justify-center">
       <Lightbox
-        id="youtube-row"
+        id={id}
         className="flex flex-wrap"
         value={open}
         onChange={setOpen}
       >
         {({ Trigger }) => (
-          <div className="flex w-full flex-wrap justify-around">
+          <div className="flex w-full flex-wrap justify-around gap-y-4">
             {videos.map((video) => (
               <div
                 key={video.id}
                 className="mx-auto flex basis-full flex-col items-center justify-start p-2 md:basis-1/2 lg:basis-1/4"
               >
+                <Heading
+                  level={2}
+                  className="order-3 my-0 px-1 text-center text-2xl"
+                >
+                  {video.title}
+                </Heading>
+
                 <Trigger
                   videoId={video.id}
                   caption={`${video.title}: ${formatDateTime(video.published, {
                     style: "long",
                   })}`}
-                  triggerId={video.id}
-                  className="w-full max-w-2xl"
+                  className="order-1 w-full max-w-2xl"
                 >
-                  <Preview videoId={video.id} />
+                  <Preview videoId={video.id} alt={video.title} />
                 </Trigger>
-                <Heading
-                  level={2}
-                  id={video.id}
-                  className="text-center text-2xl"
-                >
-                  {video.title}
-                  <small
+
+                <div className="order-2 my-1 flex w-full flex-wrap items-center justify-between px-1">
+                  <p
                     className={classes(
                       dark ? "text-alveus-green-200" : "text-alveus-green-600",
-                      "block",
-                      "text-xl",
+                      "text-sm leading-tight",
                     )}
                   >
                     {formatDateTime(video.published, { style: "long" })}
-                  </small>
-                </Heading>
+                  </p>
+                  <Link
+                    href={video.author.uri}
+                    external
+                    custom
+                    className={classes(
+                      dark
+                        ? "bg-alveus-tan text-alveus-green-700"
+                        : "bg-alveus-green text-alveus-tan",
+                      "block rounded-full px-2 py-1 text-xs leading-tight transition-colors hover:bg-alveus-green-800 hover:text-alveus-tan",
+                    )}
+                  >
+                    {video.author.name}
+                  </Link>
+                </div>
               </div>
             ))}
           </div>

--- a/apps/website/src/data/youtube.ts
+++ b/apps/website/src/data/youtube.ts
@@ -1,8 +1,15 @@
+interface Channel {
+  id: string;
+  name: string;
+}
+
 export const channels = {
   alveus: {
     id: "UCbJ-1yM55NHrR1GS9hhPuvg",
+    name: "Alveus Sanctuary",
   },
   highlights: {
     id: "UCfisf6HxiQr8_4mctNBm9cQ",
+    name: "Alveus Highlights",
   },
-};
+} as const satisfies Record<string, Channel>;

--- a/apps/website/src/data/youtube.ts
+++ b/apps/website/src/data/youtube.ts
@@ -1,15 +1,18 @@
 interface Channel {
   id: string;
   name: string;
+  uri: string;
 }
 
 export const channels = {
   alveus: {
     id: "UCbJ-1yM55NHrR1GS9hhPuvg",
     name: "Alveus Sanctuary",
+    uri: "https://www.youtube.com/@AlveusSanctuary",
   },
   highlights: {
     id: "UCfisf6HxiQr8_4mctNBm9cQ",
     name: "Alveus Highlights",
+    uri: "https://www.youtube.com/@AlveusSanctuaryHighlights",
   },
 } as const satisfies Record<string, Channel>;

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -445,7 +445,7 @@ const Home: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
           <Heading level={2} id="recent-videos" link>
             Recent Videos
           </Heading>
-          <YouTubeCarousel videos={videos} dark />
+          <YouTubeCarousel videos={videos} id="recent-videos" dark />
         </div>
       </Section>
 

--- a/apps/website/src/server/apis/youtube.ts
+++ b/apps/website/src/server/apis/youtube.ts
@@ -1,6 +1,8 @@
 import { XMLParser } from "fast-xml-parser";
 import { z } from "zod";
 
+import { channels } from "@/data/youtube";
+
 const ItemSchema = z.object({
   id: z.string(),
   title: z.string(),
@@ -47,7 +49,7 @@ export interface YouTubeVideo {
   id: string;
   title: string;
   description: string;
-  author: { name: string; uri: string };
+  author: { id: string; name: string; uri: string };
   published: Date;
 }
 
@@ -56,6 +58,10 @@ export const fetchYouTubeVideos = async (
 ): Promise<YouTubeVideo[]> => {
   if (!channelId.startsWith("UC"))
     throw new Error("Invalid YouTube channel ID");
+
+  const custom = Object.values(channels).find(
+    (channel) => channel.id === channelId,
+  );
 
   // Get the built-in videos playlist for the channel
   // This contains only long-form videos, not shorts or live streams (or VoDs)
@@ -66,7 +72,11 @@ export const fetchYouTubeVideos = async (
         id: entry.id.replace(/^yt:video:/, ""),
         title: entry.title,
         description: entry["media:group"]["media:description"],
-        author: entry.author,
+        author: {
+          id: channelId,
+          name: custom?.name ?? entry.author.name,
+          uri: custom?.uri ?? entry.author.uri,
+        },
         published: entry.published,
       })),
   );


### PR DESCRIPTION
## Describe your changes

As we have two channels that feed videos onto the homepage, it can be a bit confusing whether a video is main channel one or a highlights one. This adds a little pill under each video showing which channel it is from, and linking to that channel for further content discovery.

## Notes for testing your change

Pill renders as expected on all viewports.