### PR TITLE
Add dedicated category for ambassador birthday events

### DIFF
--- a/apps/website/src/components/calendar/CalendarItem.tsx
+++ b/apps/website/src/components/calendar/CalendarItem.tsx
@@ -25,7 +25,7 @@ export function CalendarItem({
       className={classes(
         className,
         getStandardCategoryColor(event.category),
-        "mb-auto block rounded-xs p-1 leading-none transition-colors",
+        "mb-auto block rounded-sm border-2 border-black/10 p-1 leading-none transition-colors hover:border-black/20",
         event.startAt.getTime() < today.toMillis() && "opacity-50",
       )}
       custom

--- a/apps/website/src/components/calendar/Schedule.tsx
+++ b/apps/website/src/components/calendar/Schedule.tsx
@@ -137,7 +137,7 @@ export function Schedule() {
                 <div
                   className={classes(
                     category.color,
-                    "rounded-md border-2 border-gray-400 p-2",
+                    "rounded-md border-2 border-black/10 p-2 hover:border-black/20",
                   )}
                 />
                 <p className="shrink-0 opacity-75">{category.name}</p>

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -13,6 +13,10 @@ export const standardCategories: StandardCategory[] = [
     name: "Alveus Collaboration Stream",
     color: "bg-blue-100 hover:bg-blue-50",
   },
+  {
+    name: "Alveus Ambassador Birthday",
+    color: "bg-pink-100 hover:bg-pink-200",
+  },
   { name: "Alveus YouTube Video", color: "bg-red-50 hover:bg-red-100" },
   { name: "Maya Stream", color: "bg-gray-200 hover:bg-gray-300" },
   { name: "Maya YouTube Video", color: "bg-red-100 hover:bg-red-50" },

--- a/apps/website/src/server/db/calendar-events.ts
+++ b/apps/website/src/server/db/calendar-events.ts
@@ -127,7 +127,7 @@ export async function createRegularCalendarEvents(date: Date) {
       events.push({
         title: `${ambassador.name}'s Birthday`,
         description: `Wish ${ambassador.name} a happy birthday!`,
-        category: "Alveus Special Stream",
+        category: "Alveus Ambassador Birthday",
         link: `${getShortBaseUrl()}/${camelToKebab(name)}`,
       });
     }


### PR DESCRIPTION
## Describe your changes

Should help avoid confusion about whether the auto-generated birthday events in the calendar represent streams or not, by having them in a dedicated birthday category.

## Notes for testing your change

Color seems fine, border seems fine.