### PR TITLE
Show Give an Hour progress for 2025 + update wording

### DIFF
--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -17,9 +17,10 @@ const useLocaleHours = (hours: number, showDays: boolean) => {
 
 const targetIntervals = [24 * 180, 24 * 90, 24 * 30, 24 * 2];
 
-const getTarget = (hours: number) => {
+const getTarget = (hours: number, ended: boolean) => {
   const multiple = targetIntervals.find((interval) => interval <= hours) ?? 24;
-  return Math.ceil((hours + 1) / multiple) * multiple;
+  const round = ended ? Math.floor : Math.ceil;
+  return round((hours + 1) / multiple) * multiple;
 };
 
 const GiveAnHourProgressText = ({
@@ -56,9 +57,11 @@ const barClasses =
 export const GiveAnHourProgress = ({
   target,
   text = "after",
+  ended = false,
 }: {
   target?: number;
   text?: "after" | "before";
+  ended?: boolean;
 }) => {
   const hoursQuery = trpc.showAndTell.getGiveAnHourProgress.useQuery(
     undefined,
@@ -67,7 +70,8 @@ export const GiveAnHourProgress = ({
     },
   );
   const hours = hoursQuery.data ?? 0;
-  const computedTarget = target ?? getTarget(hours);
+  const computedTarget = target ?? getTarget(hours, ended);
+  const progress = Math.min((hours / computedTarget || 0) * 100, 100);
 
   return (
     <>
@@ -82,7 +86,7 @@ export const GiveAnHourProgress = ({
       <div className="relative my-1 h-10 w-full rounded-full bg-alveus-green-900 shadow-lg">
         <div
           className={classes(barClasses, "bg-alveus-green")}
-          style={{ width: `${(hours / computedTarget || 0) * 100}%` }}
+          style={{ width: `${progress}%` }}
         />
 
         <div
@@ -91,7 +95,7 @@ export const GiveAnHourProgress = ({
             "bg-alveus-tan bg-gradient-to-r from-blue-800 to-green-600",
             hours === 0 ? "opacity-0" : "animate-pulse-slow",
           )}
-          style={{ width: `${(hours / computedTarget || 0) * 100}%` }}
+          style={{ width: `${progress}%` }}
         />
       </div>
 

--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -8,7 +8,7 @@ import { DATETIME_ALVEUS_ZONE } from "@/utils/datetime";
 
 import useLocaleString from "@/hooks/locale";
 
-type DateString = PartialDateString & `${number}-${number}-${number}`;
+export type DateString = PartialDateString & `${number}-${number}-${number}`;
 
 const useDateString = (date?: DateString, offset?: number) =>
   useMemo(

--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -10,17 +10,15 @@ import useLocaleString from "@/hooks/locale";
 
 export type DateString = PartialDateString & `${number}-${number}-${number}`;
 
+export const parseDateString = (date: DateString, offset?: number) =>
+  DateTime.fromFormat(date, "yyyy-MM-dd")
+    .startOf("day")
+    .plus({ days: offset ?? 0 })
+    .setZone(DATETIME_ALVEUS_ZONE, { keepLocalTime: true })
+    .toJSDate();
+
 const useDateString = (date?: DateString, offset?: number) =>
-  useMemo(
-    () =>
-      date &&
-      DateTime.fromFormat(date, "yyyy-MM-dd")
-        .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
-        .plus({ days: offset ?? 0 })
-        .setZone(DATETIME_ALVEUS_ZONE, { keepLocalTime: true })
-        .toJSDate(),
-    [date, offset],
-  );
+  useMemo(() => date && parseDateString(date, offset), [date, offset]);
 
 const useLocaleDays = (hours: number) => {
   const localeDays = useLocaleString(Math.floor(hours / 24));

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -12,6 +12,7 @@ import {
   DisclosureButton,
   DisclosurePanel,
 } from "@headlessui/react";
+import { useLocale } from "react-aria";
 
 import Image from "next/image";
 import type {
@@ -283,16 +284,28 @@ export function ShowAndTellEntryForm({
     { allowedFileTypes: imageMimeTypes },
   );
 
+  const { locale } = useLocale();
+
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
-    const hours = parseFloat(formData.get("giveAnHour") as string);
+
+    const numberGroupChar = new Intl.NumberFormat(locale, {
+      useGrouping: true,
+    })
+      .formatToParts(1000)
+      .find((part) => part.type === "group")?.value;
+    let hoursText = formData.get("giveAnHour") as string;
+    if (numberGroupChar) {
+      hoursText = hoursText.replaceAll(numberGroupChar, "");
+    }
+    const hours = parseInt(hoursText);
+
     let dominantColor = formData.get("dominantColor") as string | null;
     if (dominantColor) {
       const r = parseInt(dominantColor.slice(1, 3), 16);
       const g = parseInt(dominantColor.slice(3, 5), 16);
       const b = parseInt(dominantColor.slice(5, 7), 16);
-
       dominantColor = [r, g, b].join();
     }
 

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -532,12 +532,11 @@ export function ShowAndTellEntryForm({
         <Fieldset legend="Give an hour for Earth">
           <p>
             Do you want to track hours you spent on this activity as part of the
-            Alveus community&apos;s effort to give an hour for Earth? Originally
-            part of WWF&apos;s{" "}
+            Alveus community&apos;s effort to{" "}
             <Link href="/show-and-tell/give-an-hour" external>
               Give an Hour
             </Link>{" "}
-            initiative.
+            for Earth initiative?
           </p>
 
           <div className="flex items-center gap-8">

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -1,7 +1,10 @@
-import type { NextPage } from "next";
+import type { InferGetStaticPropsType, NextPage } from "next";
 import Image, { type ImageProps } from "next/image";
+import { useLocale } from "react-aria";
+import { DateTime } from "luxon";
 
 import { classes } from "@/utils/classes";
+import { DATETIME_ALVEUS_ZONE } from "@/utils/datetime";
 
 import IconPlus from "@/icons/IconPlus";
 
@@ -13,6 +16,7 @@ import Share from "@/components/content/Share";
 
 import {
   GiveAnHourProgress,
+  parseDateString,
   type DateString,
 } from "@/components/show-and-tell/GiveAnHourProgress";
 
@@ -31,12 +35,12 @@ import giveAnHourShopping from "@/assets/show-and-tell/give-an-hour/shopping.svg
 import giveAnHourWalk from "@/assets/show-and-tell/give-an-hour/walk.svg";
 import giveAnHourNature from "@/assets/show-and-tell/give-an-hour/nature.svg";
 
-interface WWFGiveAnHourDates {
+interface WWFGiveAnHourCampaign {
   start: DateString;
   end: DateString;
 }
 
-const wwfGiveAnHourDates: WWFGiveAnHourDates[] = [
+const wwfGiveAnHourCampaigns: WWFGiveAnHourCampaign[] = [
   { start: "2025-03-23", end: "2025-04-22" },
   { start: "2024-03-01", end: "2024-04-22" },
 ];
@@ -87,306 +91,356 @@ const Card = ({
   </div>
 );
 
-const GiveAnHourPage: NextPage = () => (
-  <>
-    <Meta
-      title="Give an Hour | Show and Tell"
-      description="Join the Alveus community and give an hour for Earth! Discover what actions you can take to help the environment and wildlife."
-      image={giveAnHourPoster.src}
-    />
+export const getStaticProps = async () => {
+  // Check if we have an active campaign within the next/previous 7 days
+  const todayDate = DateTime.local({ zone: DATETIME_ALVEUS_ZONE })
+    .startOf("day")
+    .toJSDate();
+  const wwfCampaign = wwfGiveAnHourCampaigns.find(({ start, end }) => {
+    const startDate = parseDateString(start, -7);
+    const endDate = parseDateString(end, 7);
+    return todayDate >= startDate && todayDate < endDate;
+  });
 
-    {/* Nav background */}
-    <div className="-mt-40 hidden h-40 bg-alveus-green-900 lg:block" />
+  return {
+    props: {
+      wwf: wwfCampaign && {
+        ...wwfCampaign,
+        year: wwfCampaign.start.split("-")[0]!,
+      },
+    },
+    revalidate: 60 * 60 * 6, // revalidate after 6 hours
+  };
+};
 
-    <Section
-      dark
-      className="py-8 lg:py-24"
-      containerClassName="flex flex-wrap items-center lg:flex-nowrap gap-16"
-    >
-      <div className="flex w-full grow flex-col lg:max-w-2/3">
-        <Heading>Give an Hour for Earth</Heading>
+const GiveAnHourPage: NextPage<
+  InferGetStaticPropsType<typeof getStaticProps>
+> = ({ wwf }) => {
+  const { locale } = useLocale();
 
-        <p className="text-lg">
-          Join the Alveus community in giving hours for Earth. Discover what
-          actions you can take to help the environment and wildlife. Supporting
-          WWF&apos;s Give an Hour for Earth campaign each year, we&apos;re now
-          tracking everything we do for Earth!
-        </p>
-
-        <p className="mt-8">
-          Given an hour? Share your activities with the community and inspire
-          others, via the{" "}
-          <Link href="/show-and-tell/submit-post" dark>
-            Show and Tell
-          </Link>{" "}
-          page.
-        </p>
-        <div className="mt-2">
-          <GiveAnHourProgress />
-        </div>
-      </div>
-
-      <div className="flex grow justify-center">
-        <div className="w-full max-w-48 rounded-xl bg-alveus-tan shadow-lg">
-          <Image
-            src={alveusLogo}
-            width={448}
-            alt="Alveus Logo"
-            className="size-full object-contain p-[12%]"
-          />
-        </div>
-
-        <IconPlus className="mx-2 my-auto size-8 shrink-0 text-alveus-green-50 sm:mx-4" />
-
-        <div className="w-full max-w-48 rounded-xl bg-white shadow-lg">
-          <Image
-            src={wwfLogo}
-            width={448}
-            alt="WWF Logo"
-            className="size-full object-contain p-[18%]"
-          />
-        </div>
-      </div>
-    </Section>
-
-    <Section containerClassName="max-w-6xl">
-      <div className="mx-auto mb-16 max-w-2xl text-center">
-        <Heading level={2} id="why-it-matters" link className="text-4xl">
-          Why it Matters?
-        </Heading>
-
-        <p className="text-lg">
-          <strong>
-            An essential ally against the climate crisis is nature.
-          </strong>{" "}
-          Yet, we are losing nature at an alarming and unprecedented rate. Each
-          of us can do something positive for our planet for 60 minutes and
-          together, we can create the #BiggestHourForEarth.
-        </p>
-      </div>
-
-      <Heading level={2} id="actions" link className="text-center">
-        Actions You Can Take
-      </Heading>
-
-      <div className="my-8 grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-8">
-        <Card
-          heading="Food"
-          id="actions:food"
-          image={giveAnHourShopping}
-          number={1}
-        >
-          <ul className="list-disc ps-4">
-            <li>Cook/order a plant-based meal.</li>
-            <li>Look for sustainable products at the supermarket.</li>
-            <li>Go to a farmer&apos;s market.</li>
-            <li>Swap staples with more sustainable ones.</li>
-          </ul>
-        </Card>
-
-        <div className="relative">
-          <Image
-            src={leafRightImage2}
-            alt=""
-            className="pointer-events-none absolute right-0 -bottom-14 -z-10 h-auto w-1/2 max-w-48 drop-shadow-md select-none lg:right-auto lg:-bottom-32 lg:-left-20 lg:max-w-40"
-          />
-
-          <Card
-            heading="Entertainment"
-            id="actions:entertainment"
-            image={giveAnHourEntertainment}
-            number={2}
-          >
-            <ul className="list-disc ps-4">
-              <li>Visit an art gallery/exhibition about our planet.</li>
-              <li>Watch an educational video or documentary.</li>
-            </ul>
-          </Card>
-        </div>
-
-        <Card
-          heading="Fitness & Wellness"
-          id="actions:fitness-wellness"
-          image={giveAnHourFitness}
-          number={3}
-        >
-          <ul className="list-disc ps-4">
-            <li>Attend a kayaking tour to learn about local nature.</li>
-            <li>Join an outdoor yoga session.</li>
-            <li>
-              Attend a charity run and choose WWF or Alveus as your
-              organization.
-            </li>
-            <li>Cycle or walk to work.</li>
-          </ul>
-        </Card>
-
-        <Card
-          heading="Arts & Creativity"
-          id="actions:arts-creativity"
-          image={giveAnHourArt}
-          number={4}
-        >
-          <ul className="list-disc ps-4">
-            <li>Try wildlife photography.</li>
-            <li>Upcycle something.</li>
-            <li>Draw or paint a nature scene.</li>
-          </ul>
-        </Card>
-
-        <div className="relative">
-          <Image
-            src={leafLeftImage3}
-            alt=""
-            className="pointer-events-none absolute -top-20 right-0 -z-10 h-auto w-1/2 max-w-48 -scale-100 drop-shadow-md select-none lg:-right-32 lg:max-w-40 lg:scale-x-100"
-          />
-
-          <Card
-            heading="Get Outside"
-            id="actions:get-outside"
-            image={giveAnHourWalk}
-            number={5}
-          >
-            <ul className="list-disc ps-4">
-              <li>Do a trash clean-up.</li>
-              <li>Plant a pollinator garden.</li>
-              <li>Start a compost pile.</li>
-              <li>Go for a nature walk or bird watch.</li>
-            </ul>
-          </Card>
-        </div>
-
-        <Card
-          heading="Be creative and have fun!"
-          id="actions:be-creative"
-          image={giveAnHourNature}
-        >
-          <p>As long as your activity helps to:</p>
-          <ul className="my-2 list-disc ps-4">
-            <li>Reconnect with our planet.</li>
-            <li>Restore our planet.</li>
-            <li>Learn more about our planet.</li>
-            <li>Inspire others to care for our planet.</li>
-          </ul>
-          <p>...then we want to hear about it!</p>
-        </Card>
-      </div>
-    </Section>
-
-    <Section
-      dark
-      containerClassName="flex flex-col items-center md:flex-row md:justify-between gap-8"
-    >
-      <div>
-        <Heading id="encourage-your-friends" level={2} link>
-          Encourage Your Friends
-        </Heading>
-
-        <p className="text-lg">
-          Every action and every hour matters! Share this guide and encourage
-          your friends, family, and colleagues to get involved and Give an Hour
-          for Earth.
-        </p>
-
-        <p className="mt-4 text-lg">
-          <Link href={giveAnHourPoster.src} external dark>
-            Download this guide as a poster
-          </Link>{" "}
-          to share with your community and inspire others to take action.
-        </p>
-      </div>
-
-      <Share
-        title="Give an Hour for Earth with Alveus Sanctuary"
-        text="Join the Alveus community to give an hour for Earth! Discover what actions you can take to help the environment and wildlife."
-        path="/give-an-hour"
-        dark
+  return (
+    <>
+      <Meta
+        title="Give an Hour | Show and Tell"
+        description="Join the Alveus community and Give an Hour for Earth! Discover what actions you can take to help the environment and wildlife."
+        image={giveAnHourPoster.src}
       />
-    </Section>
 
-    {/* Grow the last section to cover the page */}
-    <Section className="grow">
-      <div className="flex flex-wrap items-center justify-between">
-        <div className="w-full py-8 md:w-3/5">
-          <Heading level={2} id="share-your-activities" link>
-            Share Your Activities
+      {/* Nav background */}
+      <div className="-mt-40 hidden h-40 bg-alveus-green-900 lg:block" />
+
+      <Section
+        dark
+        className="py-8 lg:py-24"
+        containerClassName="flex flex-wrap items-center lg:flex-nowrap gap-16"
+      >
+        <div className="flex w-full grow flex-col lg:max-w-2/3">
+          <Heading>
+            Give an Hour for Earth
+            {wwf && <span className="text-alveus-green-50"> {wwf.year}</span>}
           </Heading>
 
-          <p className="text-lg">
-            Share the hours you&apos;ve given and what you&apos;ve been doing
-            with the Alveus community and inspire others, via the{" "}
-            <Link href="/show-and-tell/submit-post">Show and Tell</Link> page.
-          </p>
+          {wwf ? (
+            <p className="text-lg">
+              Join WWF and the Alveus community for the {wwf.year} Give an Hour
+              for Earth campaign! Discover what actions you can take to help the
+              environment and wildlife from{" "}
+              {new Date(wwf.start).toLocaleDateString(locale, {
+                month: "long",
+                day: "numeric",
+              })}{" "}
+              to{" "}
+              {new Date(wwf.end).toLocaleDateString(locale, {
+                month: "long",
+                day: "numeric",
+              })}
+              .
+            </p>
+          ) : (
+            <p className="text-lg">
+              Join the Alveus community in giving hours for Earth. Discover what
+              actions you can take to help the environment and wildlife.
+              Supporting WWF&apos;s Give an Hour for Earth campaign each year,
+              we&apos;re now tracking everything we do for Earth!
+            </p>
+          )}
 
-          <p className="mt-8 text-lg">
-            We need more people, more than ever. Individuals, communities,
-            businesses, and governments must all step up their actions for
-            nature, climate, and our one home to secure a Nature Positive world.
-          </p>
-        </div>
-
-        <Image
-          src={showAndTellPeepo}
-          width={448}
-          alt=""
-          className="mx-auto w-full max-w-md p-4 md:mx-0 md:w-2/5"
-        />
-      </div>
-
-      <div className="flex flex-wrap items-start justify-between py-8">
-        <div className="w-full lg:sticky lg:top-0 lg:w-1/2 lg:pl-8 xl:w-3/5">
-          <Heading level={2} id="wwf-give-an-hour" link>
-            WWF&apos;s Give an Hour for Earth
-          </Heading>
-
-          <p className="text-lg">
-            While we&apos;re tracking our hours all year round, this effort was
-            started as part of{" "}
-            <Link
-              href="https://www.worldwildlife.org/pages/earth-hour"
-              external
-            >
-              WWF&apos;s Give an Hour for Earth
+          <p className="mt-8">
+            Given an hour? Share your activities with the community and inspire
+            others, via the{" "}
+            <Link href="/show-and-tell/submit-post" dark>
+              Show and Tell
             </Link>{" "}
-            campaign. This campaign encourages people to take action for the
-            planet, and we are proud to continue to be a part of it each year!
+            page.
+          </p>
+          <div className="mt-2">
+            <GiveAnHourProgress start={wwf?.start} end={wwf?.end} />
+          </div>
+        </div>
+
+        <div className="flex grow justify-center">
+          <div className="w-full max-w-48 rounded-xl bg-alveus-tan shadow-lg">
+            <Image
+              src={alveusLogo}
+              width={448}
+              alt="Alveus Logo"
+              className="size-full object-contain p-[12%]"
+            />
+          </div>
+
+          <IconPlus className="mx-2 my-auto size-8 shrink-0 text-alveus-green-50 sm:mx-4" />
+
+          <div className="w-full max-w-48 rounded-xl bg-white shadow-lg">
+            <Image
+              src={wwfLogo}
+              width={448}
+              alt="WWF Logo"
+              className="size-full object-contain p-[18%]"
+            />
+          </div>
+        </div>
+      </Section>
+
+      <Section containerClassName="max-w-6xl">
+        <div className="mx-auto mb-16 max-w-2xl text-center">
+          <Heading level={2} id="why-it-matters" link className="text-4xl">
+            Why it Matters?
+          </Heading>
+
+          <p className="text-lg">
+            <strong>
+              An essential ally against the climate crisis is nature.
+            </strong>{" "}
+            Yet, we are losing nature at an alarming and unprecedented rate.
+            Each of us can do something positive for our planet for 60 minutes
+            and together, we can create the #BiggestHourForEarth.
           </p>
         </div>
 
-        <div className="flex w-full flex-col divide-y-1 divide-alveus-green/25 lg:order-first lg:w-1/2 xl:w-2/5">
-          {wwfGiveAnHourDates.map(({ start, end }) => {
-            const year = start.split("-")[0]!;
-            return (
-              <div key={year} className="pt-4 pb-6">
-                <div className="flex flex-wrap items-baseline justify-between">
-                  <Heading
-                    level={3}
-                    id={`wwf-give-an-hour-${year}`}
-                    link
-                    className="my-0 text-2xl"
-                  >
-                    {year}
-                  </Heading>
-                  <p className="text-sm opacity-75">
-                    {new Date(start).toLocaleDateString(undefined, {
-                      month: "long",
-                      day: "numeric",
-                    })}{" "}
-                    -{" "}
-                    {new Date(end).toLocaleDateString(undefined, {
-                      month: "long",
-                      day: "numeric",
-                    })}
-                  </p>
-                </div>
-                <GiveAnHourProgress start={start} end={end} />
-              </div>
-            );
-          })}
+        <Heading level={2} id="actions" link className="text-center">
+          Actions You Can Take
+        </Heading>
+
+        <div className="my-8 grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-8">
+          <Card
+            heading="Food"
+            id="actions:food"
+            image={giveAnHourShopping}
+            number={1}
+          >
+            <ul className="list-disc ps-4">
+              <li>Cook/order a plant-based meal.</li>
+              <li>Look for sustainable products at the supermarket.</li>
+              <li>Go to a farmer&apos;s market.</li>
+              <li>Swap staples with more sustainable ones.</li>
+            </ul>
+          </Card>
+
+          <div className="relative">
+            <Image
+              src={leafRightImage2}
+              alt=""
+              className="pointer-events-none absolute right-0 -bottom-14 -z-10 h-auto w-1/2 max-w-48 drop-shadow-md select-none lg:right-auto lg:-bottom-32 lg:-left-20 lg:max-w-40"
+            />
+
+            <Card
+              heading="Entertainment"
+              id="actions:entertainment"
+              image={giveAnHourEntertainment}
+              number={2}
+            >
+              <ul className="list-disc ps-4">
+                <li>Visit an art gallery/exhibition about our planet.</li>
+                <li>Watch an educational video or documentary.</li>
+              </ul>
+            </Card>
+          </div>
+
+          <Card
+            heading="Fitness & Wellness"
+            id="actions:fitness-wellness"
+            image={giveAnHourFitness}
+            number={3}
+          >
+            <ul className="list-disc ps-4">
+              <li>Attend a kayaking tour to learn about local nature.</li>
+              <li>Join an outdoor yoga session.</li>
+              <li>
+                Attend a charity run and choose WWF or Alveus as your
+                organization.
+              </li>
+              <li>Cycle or walk to work.</li>
+            </ul>
+          </Card>
+
+          <Card
+            heading="Arts & Creativity"
+            id="actions:arts-creativity"
+            image={giveAnHourArt}
+            number={4}
+          >
+            <ul className="list-disc ps-4">
+              <li>Try wildlife photography.</li>
+              <li>Upcycle something.</li>
+              <li>Draw or paint a nature scene.</li>
+            </ul>
+          </Card>
+
+          <div className="relative">
+            <Image
+              src={leafLeftImage3}
+              alt=""
+              className="pointer-events-none absolute -top-20 right-0 -z-10 h-auto w-1/2 max-w-48 -scale-100 drop-shadow-md select-none lg:-right-32 lg:max-w-40 lg:scale-x-100"
+            />
+
+            <Card
+              heading="Get Outside"
+              id="actions:get-outside"
+              image={giveAnHourWalk}
+              number={5}
+            >
+              <ul className="list-disc ps-4">
+                <li>Do a trash clean-up.</li>
+                <li>Plant a pollinator garden.</li>
+                <li>Start a compost pile.</li>
+                <li>Go for a nature walk or bird watch.</li>
+              </ul>
+            </Card>
+          </div>
+
+          <Card
+            heading="Be creative and have fun!"
+            id="actions:be-creative"
+            image={giveAnHourNature}
+          >
+            <p>As long as your activity helps to:</p>
+            <ul className="my-2 list-disc ps-4">
+              <li>Reconnect with our planet.</li>
+              <li>Restore our planet.</li>
+              <li>Learn more about our planet.</li>
+              <li>Inspire others to care for our planet.</li>
+            </ul>
+            <p>...then we want to hear about it!</p>
+          </Card>
         </div>
-      </div>
-    </Section>
-  </>
-);
+      </Section>
+
+      <Section
+        dark
+        containerClassName="flex flex-col items-center md:flex-row md:justify-between gap-8"
+      >
+        <div>
+          <Heading id="encourage-your-friends" level={2} link>
+            Encourage Your Friends
+          </Heading>
+
+          <p className="text-lg">
+            Every action and every hour matters! Share this guide and encourage
+            your friends, family, and colleagues to get involved and Give an
+            Hour for Earth.
+          </p>
+
+          <p className="mt-4 text-lg">
+            <Link href={giveAnHourPoster.src} external dark>
+              Download this guide as a poster
+            </Link>{" "}
+            to share with your community and inspire others to take action.
+          </p>
+        </div>
+
+        <Share
+          title="Give an Hour for Earth with Alveus Sanctuary"
+          text="Join the Alveus community to give an hour for Earth! Discover what actions you can take to help the environment and wildlife."
+          path="/give-an-hour"
+          dark
+        />
+      </Section>
+
+      {/* Grow the last section to cover the page */}
+      <Section className="grow">
+        <div className="flex flex-wrap items-center justify-between">
+          <div className="w-full py-8 md:w-3/5">
+            <Heading level={2} id="share-your-activities" link>
+              Share Your Activities
+            </Heading>
+
+            <p className="text-lg">
+              Share the hours you&apos;ve given and what you&apos;ve been doing
+              with the Alveus community and inspire others, via the{" "}
+              <Link href="/show-and-tell/submit-post">Show and Tell</Link> page.
+            </p>
+
+            <p className="mt-8 text-lg">
+              We need more people, more than ever. Individuals, communities,
+              businesses, and governments must all step up their actions for
+              nature, climate, and our one home to secure a Nature Positive
+              world.
+            </p>
+          </div>
+
+          <Image
+            src={showAndTellPeepo}
+            width={448}
+            alt=""
+            className="mx-auto w-full max-w-md p-4 md:mx-0 md:w-2/5"
+          />
+        </div>
+
+        <div className="flex flex-wrap items-start justify-between py-8">
+          <div className="w-full lg:sticky lg:top-0 lg:w-1/2 lg:pl-8 xl:w-3/5">
+            <Heading level={2} id="wwf-give-an-hour" link>
+              WWF&apos;s Give an Hour for Earth
+            </Heading>
+
+            <p className="text-lg">
+              While we&apos;re tracking our hours all year round, this effort
+              was started as part of{" "}
+              <Link
+                href="https://www.worldwildlife.org/pages/earth-hour"
+                external
+              >
+                WWF&apos;s Give an Hour for Earth
+              </Link>{" "}
+              campaign. This campaign encourages people to take action for the
+              planet, and we are proud to continue to be a part of it each year!
+            </p>
+          </div>
+
+          <div className="flex w-full flex-col divide-y-1 divide-alveus-green/25 lg:order-first lg:w-1/2 xl:w-2/5">
+            {wwfGiveAnHourCampaigns.map(({ start, end }) => {
+              const year = start.split("-")[0]!;
+              return (
+                <div key={year} className="pt-4 pb-6">
+                  <div className="flex flex-wrap items-baseline justify-between">
+                    <Heading
+                      level={3}
+                      id={`wwf-give-an-hour-${year}`}
+                      link
+                      className="my-0 text-2xl"
+                    >
+                      {year}
+                    </Heading>
+                    <p className="text-sm opacity-75">
+                      {new Date(start).toLocaleDateString(locale, {
+                        month: "long",
+                        day: "numeric",
+                      })}{" "}
+                      -{" "}
+                      {new Date(end).toLocaleDateString(locale, {
+                        month: "long",
+                        day: "numeric",
+                      })}
+                    </p>
+                  </div>
+                  <GiveAnHourProgress start={start} end={end} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </Section>
+    </>
+  );
+};
 
 export default GiveAnHourPage;

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -11,7 +11,10 @@ import Heading from "@/components/content/Heading";
 import Link from "@/components/content/Link";
 import Share from "@/components/content/Share";
 
-import { GiveAnHourProgress } from "@/components/show-and-tell/GiveAnHourProgress";
+import {
+  GiveAnHourProgress,
+  type DateString,
+} from "@/components/show-and-tell/GiveAnHourProgress";
 
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
 import leafRightImage2 from "@/assets/floral/leaf-right-2.png";
@@ -27,6 +30,16 @@ import giveAnHourFitness from "@/assets/show-and-tell/give-an-hour/fitness.svg";
 import giveAnHourShopping from "@/assets/show-and-tell/give-an-hour/shopping.svg";
 import giveAnHourWalk from "@/assets/show-and-tell/give-an-hour/walk.svg";
 import giveAnHourNature from "@/assets/show-and-tell/give-an-hour/nature.svg";
+
+interface WWFGiveAnHourDates {
+  start: DateString;
+  end: DateString;
+}
+
+const wwfGiveAnHourDates: WWFGiveAnHourDates[] = [
+  { start: "2025-03-23", end: "2025-04-22" },
+  { start: "2024-03-01", end: "2024-04-22" },
+];
 
 const Card = ({
   heading,
@@ -292,34 +305,86 @@ const GiveAnHourPage: NextPage = () => (
     </Section>
 
     {/* Grow the last section to cover the page */}
-    <Section
-      className="grow"
-      containerClassName="flex flex-wrap items-center justify-between"
-    >
-      <div className="w-full py-8 md:w-3/5">
-        <Heading level={2} id="share-your-activities" link>
-          Share Your Activities
-        </Heading>
+    <Section className="grow">
+      <div className="flex flex-wrap items-center justify-between">
+        <div className="w-full py-8 md:w-3/5">
+          <Heading level={2} id="share-your-activities" link>
+            Share Your Activities
+          </Heading>
 
-        <p className="text-lg">
-          Share the hours you&apos;ve given and what you&apos;ve been doing with
-          the Alveus community and inspire others, via the{" "}
-          <Link href="/show-and-tell/submit-post">Show and Tell</Link> page.
-        </p>
+          <p className="text-lg">
+            Share the hours you&apos;ve given and what you&apos;ve been doing
+            with the Alveus community and inspire others, via the{" "}
+            <Link href="/show-and-tell/submit-post">Show and Tell</Link> page.
+          </p>
 
-        <p className="mt-8 text-lg">
-          We need more people, more than ever. Individuals, communities,
-          businesses, and governments must all step up their actions for nature,
-          climate, and our one home to secure a Nature Positive world.
-        </p>
+          <p className="mt-8 text-lg">
+            We need more people, more than ever. Individuals, communities,
+            businesses, and governments must all step up their actions for
+            nature, climate, and our one home to secure a Nature Positive world.
+          </p>
+        </div>
+
+        <Image
+          src={showAndTellPeepo}
+          width={448}
+          alt=""
+          className="mx-auto w-full max-w-md p-4 md:mx-0 md:w-2/5"
+        />
       </div>
 
-      <Image
-        src={showAndTellPeepo}
-        width={448}
-        alt=""
-        className="mx-auto w-full max-w-md p-4 md:mx-0 md:w-2/5"
-      />
+      <div className="flex flex-wrap items-start justify-between py-8">
+        <div className="w-full lg:sticky lg:top-0 lg:w-1/2 lg:pl-8 xl:w-3/5">
+          <Heading level={2} id="wwf-give-an-hour" link>
+            WWF&apos;s Give an Hour for Earth
+          </Heading>
+
+          <p className="text-lg">
+            While we&apos;re tracking our hours all year round, this effort was
+            started as part of{" "}
+            <Link
+              href="https://www.worldwildlife.org/pages/earth-hour"
+              external
+            >
+              WWF&apos;s Give an Hour for Earth
+            </Link>{" "}
+            campaign. This campaign encourages people to take action for the
+            planet, and we are proud to continue to be a part of it each year!
+          </p>
+        </div>
+
+        <div className="flex w-full flex-col divide-y-1 divide-alveus-green/25 lg:order-first lg:w-1/2 xl:w-2/5">
+          {wwfGiveAnHourDates.map(({ start, end }) => {
+            const year = start.split("-")[0]!;
+            return (
+              <div key={year} className="pt-4 pb-6">
+                <div className="flex flex-wrap items-baseline justify-between">
+                  <Heading
+                    level={3}
+                    id={`wwf-give-an-hour-${year}`}
+                    link
+                    className="my-0 text-2xl"
+                  >
+                    {year}
+                  </Heading>
+                  <p className="text-sm opacity-75">
+                    {new Date(start).toLocaleDateString(undefined, {
+                      month: "long",
+                      day: "numeric",
+                    })}{" "}
+                    -{" "}
+                    {new Date(end).toLocaleDateString(undefined, {
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </p>
+                </div>
+                <GiveAnHourProgress start={start} end={end} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </Section>
   </>
 );

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -95,9 +95,9 @@ const GiveAnHourPage: NextPage = () => (
 
         <p className="text-lg">
           Join the Alveus community in giving hours for Earth. Discover what
-          actions you can take to help the environment and wildlife. Originally
-          part of WWF&apos;s Give an Hour for Earth campaign in 2024, we&apos;re
-          now tracking everything we do for Earth!
+          actions you can take to help the environment and wildlife. Supporting
+          WWF&apos;s Give an Hour for Earth campaign each year, we&apos;re now
+          tracking everything we do for Earth!
         </p>
 
         <p className="mt-8">

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -480,16 +480,16 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
             )}
           >
             <p className="text-left md:text-center">
-              We&apos;re tracking hours spent giving back to the planet,
-              originally as part of WWF&apos;s{" "}
+              We&apos;re tracking hours spent as part of the Alveus
+              community&apos;s effort to{" "}
               <Link
                 href="/show-and-tell/give-an-hour"
-                className="whitespace-nowrap"
+                className="text-nowrap"
                 dark
               >
                 Give an Hour
               </Link>{" "}
-              initiative.
+              for Earth.
             </p>
             <div className="mt-2">
               <GiveAnHourProgress />

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -368,9 +368,11 @@ export async function getVolunteeringMinutes({
   const res = await prisma.showAndTellEntry.aggregate({
     _sum: { volunteeringMinutes: true },
     where: {
-      ...getPostFilter("approved"),
-      ...(start && { createdAt: { gte: start } }),
-      ...(end && { createdAt: { lt: end } }),
+      AND: [
+        getPostFilter("approved"),
+        start && { createdAt: { gte: start } },
+        end && { createdAt: { lt: end } },
+      ].filter(notEmpty),
     },
   });
 

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -361,10 +361,17 @@ export async function getUsersCount() {
   return countWithUserId.length + countWithoutUserId.length;
 }
 
-export async function getVolunteeringMinutes() {
+export async function getVolunteeringMinutes({
+  start,
+  end,
+}: { start?: Date; end?: Date } = {}) {
   const res = await prisma.showAndTellEntry.aggregate({
     _sum: { volunteeringMinutes: true },
-    where: getPostFilter("approved"),
+    where: {
+      ...getPostFilter("approved"),
+      ...(start && { createdAt: { gte: start } }),
+      ...(end && { createdAt: { lt: end } }),
+    },
   });
 
   return res._sum.volunteeringMinutes ?? 0;

--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -67,6 +67,7 @@ export const showAndTellRouter = router({
         .optional(),
     )
     .query(async ({ input }) => {
+      console.log("getGiveAnHourProgress", input);
       const minutes = await getVolunteeringMinutes(input);
       return Math.round(minutes / 60);
     }),

--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -67,7 +67,6 @@ export const showAndTellRouter = router({
         .optional(),
     )
     .query(async ({ input }) => {
-      console.log("getGiveAnHourProgress", input);
       const minutes = await getVolunteeringMinutes(input);
       return Math.round(minutes / 60);
     }),

--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -60,10 +60,16 @@ export const showAndTellRouter = router({
       return { items, nextCursor };
     }),
 
-  getGiveAnHourProgress: publicProcedure.query(async () => {
-    const minutes = await getVolunteeringMinutes();
-    return Math.round(minutes / 60);
-  }),
+  getGiveAnHourProgress: publicProcedure
+    .input(
+      z
+        .object({ start: z.date().optional(), end: z.date().optional() })
+        .optional(),
+    )
+    .query(async ({ input }) => {
+      const minutes = await getVolunteeringMinutes(input);
+      return Math.round(minutes / 60);
+    }),
 
   create: publicProcedure
     .input(showAndTellCreateInputSchema)


### PR DESCRIPTION
## Describe your changes

Updates the Give an Hour wording throughout Show and Tell to be a bit more generic as Alveus participates for a second year. Also, adds a new section to the end of the Give an Hour page that shows the community hours banked within the date range of each year's WWF campaign.

## Notes for testing your change

Please double check the date logic to make sure it's using Alveus' timezone correctly and the greater-than/less-than comparisons are all correctly offset by one day where needed etc.