### PR TITLE
Tweak WWF Give an Hour progress bars

### DIFF
--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -80,7 +80,9 @@ export const GiveAnHourProgress = ({
   end,
   text = "after",
 }: {
-  target?: number;
+  target?:
+    | number
+    | ((hours: number, ended: boolean, computed: number) => number);
   start?: DateString;
   end?: DateString;
   text?: "after" | "before";
@@ -103,7 +105,15 @@ export const GiveAnHourProgress = ({
     },
   );
   const hours = hoursQuery.data ?? 0;
-  const computedTarget = target ?? getTarget(hours, ended);
+
+  const computedTarget = useMemo(() => {
+    if (typeof target === "number") return target;
+
+    const computed = getTarget(hours, ended);
+    if (typeof target === "undefined") return computed;
+
+    return target(hours, ended, computed);
+  }, [target, hours, ended]);
   const progress = Math.min((hours / computedTarget || 0) * 100, 100);
 
   return (

--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -42,13 +42,15 @@ const getTarget = (hours: number, ended: boolean) => {
 };
 
 const GiveAnHourProgressText = ({
-  isLoading,
   hours,
   target,
+  isLoading = false,
+  ended = false,
 }: {
-  isLoading?: boolean;
   hours: number;
   target: number;
+  isLoading?: boolean;
+  ended?: boolean;
 }) => {
   // Show the equivalent number of days if we're over 72 hours
   const showDays = target > 72;
@@ -61,8 +63,8 @@ const GiveAnHourProgressText = ({
         {isLoading
           ? "Loading hours given…"
           : hours === 0
-            ? "No hours given yet"
-            : `${localeHours} already given`}
+            ? `No hours given${ended ? "" : " yet"}`
+            : `${localeHours}${ended ? "" : " already"} given`}
       </p>
       <p className="font-medium opacity-75">{localeTarget} target</p>
     </div>
@@ -108,9 +110,10 @@ export const GiveAnHourProgress = ({
     <>
       {text === "before" && (
         <GiveAnHourProgressText
-          isLoading={hoursQuery.isPending}
           hours={hours}
           target={computedTarget}
+          isLoading={hoursQuery.isPending}
+          ended={ended}
         />
       )}
 
@@ -132,9 +135,10 @@ export const GiveAnHourProgress = ({
 
       {text === "after" && (
         <GiveAnHourProgressText
-          isLoading={hoursQuery.isPending}
           hours={hours}
           target={computedTarget}
+          isLoading={hoursQuery.isPending}
+          ended={ended}
         />
       )}
     </>

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -45,6 +45,16 @@ const wwfGiveAnHourCampaigns: WWFGiveAnHourCampaign[] = [
   { start: "2024-03-01", end: "2024-04-22" },
 ];
 
+const wwfGiveAnHourTarget = (
+  hours: number,
+  ended: boolean,
+  computed: number,
+) => {
+  const round = ended ? Math.floor : Math.ceil;
+  computed = round(computed / 500) * 500;
+  return ended ? computed : Math.max(1500, computed);
+};
+
 const Card = ({
   heading,
   id,
@@ -174,7 +184,11 @@ const GiveAnHourPage: NextPage<
             page.
           </p>
           <div className="mt-2">
-            <GiveAnHourProgress start={wwf?.start} end={wwf?.end} />
+            <GiveAnHourProgress
+              start={wwf?.start}
+              end={wwf?.end}
+              target={wwf && wwfGiveAnHourTarget}
+            />
           </div>
         </div>
 
@@ -432,7 +446,11 @@ const GiveAnHourPage: NextPage<
                       })}
                     </p>
                   </div>
-                  <GiveAnHourProgress start={start} end={end} />
+                  <GiveAnHourProgress
+                    start={start}
+                    end={end}
+                    target={wwfGiveAnHourTarget}
+                  />
                 </div>
               );
             })}


### PR DESCRIPTION
## Describe your changes

Sets an initial target of 1500 hours for an active WWF campaign, and rounds the target hours for all campaigns to a multiple of 500. Also, updates the wording for ended campaign's progress bars to not seem like they're active still.

## Notes for testing your change

Wording seems fine, target logic seems correct.
