### PR TITLE
Only use title if text no preset for Bluesky sharing

### DIFF
--- a/apps/website/src/utils/share.ts
+++ b/apps/website/src/utils/share.ts
@@ -39,7 +39,7 @@ const sharePlatforms = {
       const share = new URL("https://bsky.app/intent/compose");
       share.searchParams.append(
         "text",
-        [title, text, url].filter(Boolean).join("\n\n"),
+        [text || title, url].filter(Boolean).join("\n\n"),
       );
       return share.toString();
     },


### PR DESCRIPTION
## Describe your changes

Given that newlines aren't really working, I think we should follow the pattern we use for X/Fb and only include the title as a fallback for text.

## Notes for testing your change

N/A
