### PR TITLE
Change Show and Tell post order to be by creation date

### DIFF
--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -100,8 +100,7 @@ function getPostFilter(filter: "approved" | "pendingApproval") {
 
 const postOrderBy = [
   { seenOnStream: "asc" }, // make sure not yet seen posts are at the top
-  { approvedAt: "desc" },
-  { updatedAt: "desc" },
+  { createdAt: "desc" },
 ] as const;
 
 const attachmentSchema = z.object({


### PR DESCRIPTION
## Describe your changes

Changes the order of show and tell posts to be by seen status, then creation date. This should prevent them from jumping in order on changes.

## Notes for testing your change

Check order is correct, when updating posts.
