### PR TITLE
Update Show and Tell carousel to show images first

### DIFF
--- a/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
@@ -156,23 +156,6 @@ export function ShowAndTellGallery({
   );
 
   const carouselItems = useMemo(() => {
-    const videoItems: [string, JSX.Element][] = videoAttachments
-      .filter(({ url }) => validateNormalizedVideoUrl(url))
-      .map((videoAttachment, i) => [
-        `001-video-${i}`,
-        <VideoItem
-          key={`image-${i}`}
-          videoAttachment={videoAttachment}
-          showPreview
-          openInLightbox
-          linkAttributes={{
-            className:
-              "group/trigger pointer-events-auto flex items-center justify-center cursor-pointer select-none",
-            draggable: false,
-          }}
-        />,
-      ]);
-
     const imageItems: [string, JSX.Element][] = imageAttachments.map(
       (imageAttachment, i) => [
         `002-image-${i}`,
@@ -217,7 +200,24 @@ export function ShowAndTellGallery({
       ],
     );
 
-    return Object.fromEntries([...videoItems, ...imageItems]);
+    const videoItems: [string, JSX.Element][] = videoAttachments
+      .filter(({ url }) => validateNormalizedVideoUrl(url))
+      .map((videoAttachment, i) => [
+        `001-video-${i}`,
+        <VideoItem
+          key={`image-${i}`}
+          videoAttachment={videoAttachment}
+          showPreview
+          openInLightbox
+          linkAttributes={{
+            className:
+              "group/trigger pointer-events-auto flex items-center justify-center cursor-pointer select-none",
+            draggable: false,
+          }}
+        />,
+      ]);
+
+    return Object.fromEntries([...imageItems, ...videoItems]);
   }, [imageAttachments, videoAttachments]);
 
   const carouselCount = Object.keys(carouselItems).length;
@@ -239,38 +239,17 @@ export function ShowAndTellGallery({
     />
   );
 
-  let countItemsInPhotoswipe = 0;
+  const imageCount = imageAttachments.length;
   let thumbnails: JSX.Element | null = null;
   if (carouselCount > 1) {
     thumbnails = (
       <div className="my-2 flex flex-row flex-wrap items-center justify-center gap-2">
-        {videoAttachments.map((videoAttachment) => {
-          const parsedVideoUrl = parseVideoUrl(videoAttachment.url);
-          if (!parsedVideoUrl) return null;
-          let handleClick: MouseEventHandler<HTMLAnchorElement> | undefined =
-            undefined;
-          if ("embedUrl" in videoPlatformConfigs[parsedVideoUrl.platform]) {
-            const lightboxIndex = countItemsInPhotoswipe++;
-            handleClick = (e) => {
-              e.preventDefault();
-              openLightBox(lightboxIndex);
-            };
-          }
-
-          return (
-            <VideoItem
-              key={videoAttachment.id}
-              videoAttachment={videoAttachment}
-              linkAttributes={{ onClick: handleClick }}
-            />
-          );
-        })}
         {imageAttachments.map((imageAttachment, idx) => (
           <a
             key={imageAttachment.id}
             onClick={(e) => {
               e.preventDefault();
-              openLightBox(countItemsInPhotoswipe + idx);
+              openLightBox(idx);
             }}
             href={imageAttachment.url}
             className="group relative flex items-center justify-center select-none"
@@ -287,6 +266,27 @@ export function ShowAndTellGallery({
             />
           </a>
         ))}
+        {videoAttachments.map((videoAttachment, idx) => {
+          const parsedVideoUrl = parseVideoUrl(videoAttachment.url);
+          if (!parsedVideoUrl) return null;
+          let handleClick: MouseEventHandler<HTMLAnchorElement> | undefined =
+            undefined;
+          if ("embedUrl" in videoPlatformConfigs[parsedVideoUrl.platform]) {
+            const lightboxIndex = imageCount + idx;
+            handleClick = (e) => {
+              e.preventDefault();
+              openLightBox(lightboxIndex);
+            };
+          }
+
+          return (
+            <VideoItem
+              key={videoAttachment.id}
+              videoAttachment={videoAttachment}
+              linkAttributes={{ onClick: handleClick }}
+            />
+          );
+        })}
       </div>
     );
   }


### PR DESCRIPTION
## Describe your changes

- Changed ordering of carousel to add images first and then videos as suggested in the above issue
- Agreed with issue opener as it the first image attachment is considered the "Featured Image" therefore it makes sense to have images before videos.
- Because the featured image is just the first image attachment there is no need to pass this image as a new parameter to the gallery, made more sense just to switch the order

Resolves #1022

## Notes for testing your change

- Locally created a Show and Tell post with a video and image. Approved the post and then verified that the order had swapped
