### PR TITLE
Removed conditional CSS for report buttons

### DIFF
--- a/apps/website/src/pages/about/annual-reports/index.tsx
+++ b/apps/website/src/pages/about/annual-reports/index.tsx
@@ -42,10 +42,7 @@ const AnnualReportsPage: NextPage = () => {
             >
               <Heading
                 level={2}
-                className={classes(
-                  "my-0 font-sans",
-                  idx === 0 ? "text-2xl font-semibold" : "text-xl font-normal",
-                )}
+                className={classes("my-0 font-sans text-xl font-normal")}
               >
                 {year} Annual Report
               </Heading>


### PR DESCRIPTION
## Describe your changes
In this pull request I have updated the tailwind classes so that all of the Annual Report buttons. This can be seen in the photos below.  This will make the page looked more balanced as previously one of the buttons was larger than the others. This is related to the issue #1147 

before: 
![image](https://github.com/user-attachments/assets/c744b8b6-4e07-4b91-abb7-a9f376cac310)

after: 
![image](https://github.com/user-attachments/assets/3801859c-c99c-4358-b532-401338b274b1)


<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->

...

## Notes for testing your change

...
