### PR TITLE
Proactively filter out YouTube videos that look like shorts

### DIFF
--- a/apps/website/src/server/apis/youtube.ts
+++ b/apps/website/src/server/apis/youtube.ts
@@ -69,17 +69,21 @@ export const fetchYouTubeVideos = async (
   // See https://stackoverflow.com/a/76602819 for other playlist prefixes
   return fetchYouTubeFeed("playlist", channelId.replace(/^UC/, "UULF")).then(
     (feed) =>
-      feed.map((entry) => ({
-        id: entry.id.replace(/^yt:video:/, ""),
-        title: entry.title,
-        description: entry["media:group"]["media:description"],
-        author: {
-          id: channelId,
-          name: custom?.name ?? entry.author.name,
-          uri: custom?.uri ?? entry.author.uri,
-        },
-        published: entry.published,
-      })),
+      feed
+        .map((entry) => ({
+          id: entry.id.replace(/^yt:video:/, ""),
+          title: entry.title,
+          description: entry["media:group"]["media:description"],
+          author: {
+            id: channelId,
+            name: custom?.name ?? entry.author.name,
+            uri: custom?.uri ?? entry.author.uri,
+          },
+          published: entry.published,
+        }))
+        // If a title contains a hashtag, remove it as a precaution
+        // We've seen YouTube accidentally include shorts in this playlist
+        .filter((entry) => !/\W#\w/.test(entry.title)),
   );
 };
 


### PR DESCRIPTION
## Describe your changes

A couple of times now we've seen shorts videos make their way into the auto-generated long-form video playlist for the Alveus channel -- no idea why.

As a small hack to get around this, this PR adds a bit of filtering to the videos we return from the playlist, blocking any that contain a hashtag in their title as this is relatively common in shorts and not in long-form videos.

## Notes for testing your change

Homepage videos should all be long-form, no shorts (as it currently on the production homepage).
