### PR TITLE
Explicitly set Prisma client output location

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ pnpm-lock.yaml
 
 apps/website/.next/
 apps/website/public/push/alveus/
+apps/website/prisma/client/

--- a/apps/website/.gitignore
+++ b/apps/website/.gitignore
@@ -6,8 +6,7 @@
 /public/sitemap.xml
 
 # database
-/prisma/db.sqlite
-/prisma/db.sqlite-journal
+/prisma/client/
 
 # next.js
 /.next/

--- a/apps/website/eslint.config.js
+++ b/apps/website/eslint.config.js
@@ -100,7 +100,7 @@ export default tseslint.config(
   },
   {
     name: "custom/ignores",
-    ignores: ["public/*", ".next/*"],
+    ignores: ["public/*", ".next/*", "prisma/client/*"],
   },
   {
     name: "custom/rules",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@alveusgg/data": "0.57.1",
+    "@auth/prisma-adapter": "^2.8.0",
     "@aws-sdk/client-s3": "^3.787.0",
     "@aws-sdk/s3-request-presigner": "^3.787.0",
     "@bart-krakowski/get-week-info-polyfill": "^1.0.8",
@@ -43,7 +44,6 @@
     "@headlessui/react": "^2.2.1",
     "@iframe-resizer/react": "^5.4.5",
     "@maplibre/maplibre-gl-geocoder": "^1.8.0",
-    "@next-auth/prisma-adapter": "^1.0.7",
     "@next/env": "^15.3.0",
     "@paralleldrive/cuid2": "^2.2.2",
     "@planetscale/database": "^1.19.0",

--- a/apps/website/prisma/schema.prisma
+++ b/apps/website/prisma/schema.prisma
@@ -1,8 +1,6 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
 generator client {
   provider = "prisma-client-js"
+  output   = "./client"
 }
 
 datasource db {

--- a/apps/website/src/components/admin/activity-feed/outgoing-webhook-feed-entry.tsx
+++ b/apps/website/src/components/admin/activity-feed/outgoing-webhook-feed-entry.tsx
@@ -1,7 +1,9 @@
-import type { FormEntry, OutgoingWebhook, User } from "@prisma/client";
+import type { FormEntry, OutgoingWebhook, User } from "@/server/db/client";
 
 import { trpc } from "@/utils/trpc";
+
 import DateTime from "@/components/content/DateTime";
+
 import IconSync from "@/icons/IconSync";
 
 type OutgoingWebhookWithFormEntry = OutgoingWebhook & {

--- a/apps/website/src/components/admin/bingo/BingoForm.tsx
+++ b/apps/website/src/components/admin/bingo/BingoForm.tsx
@@ -1,8 +1,9 @@
 import type { FormEvent } from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
-
-import type { Bingo } from "@prisma/client";
 import { useRouter } from "next/router";
+
+import type { Bingo } from "@/server/db/client";
+import type { BingoSchema } from "@/server/db/bingos";
 
 import { env } from "@/env";
 
@@ -21,8 +22,6 @@ import {
   inputValueDatetimeLocalToUtc,
   utcToInputValueDatetimeLocal,
 } from "@/utils/local-datetime";
-
-import { type BingoSchema } from "@/server/db/bingos";
 
 import { Button, defaultButtonClasses } from "@/components/shared/form/Button";
 import { TextField } from "@/components/shared/form/TextField";

--- a/apps/website/src/components/admin/calendar-events/CalendarEventForm.tsx
+++ b/apps/website/src/components/admin/calendar-events/CalendarEventForm.tsx
@@ -1,8 +1,10 @@
 import type { FormEvent } from "react";
 import { useState, useCallback } from "react";
 
-import type { CalendarEvent } from "@prisma/client";
 import { useRouter } from "next/router";
+
+import type { CalendarEvent } from "@/server/db/client";
+import type { CalendarEventSchema } from "@/server/db/calendar-events";
 
 import { trpc } from "@/utils/trpc";
 import { classes } from "@/utils/classes";
@@ -13,8 +15,6 @@ import {
   utcToInputValueDatetimeLocal,
 } from "@/utils/local-datetime";
 import { frequentLinks, standardCategories } from "@/data/calendar-events";
-
-import type { CalendarEventSchema } from "@/server/db/calendar-events";
 
 import {
   Button,

--- a/apps/website/src/components/admin/forms/FormForm.tsx
+++ b/apps/website/src/components/admin/forms/FormForm.tsx
@@ -1,8 +1,10 @@
 import type { FormEvent } from "react";
 import { useCallback, useState } from "react";
 
-import type { Form } from "@prisma/client";
 import { useRouter } from "next/router";
+
+import type { Form } from "@/server/db/client";
+import type { FormSchema } from "@/server/db/forms";
 
 import { env } from "@/env";
 
@@ -17,8 +19,6 @@ import {
   inputValueDatetimeLocalToUtc,
   utcToInputValueDatetimeLocal,
 } from "@/utils/local-datetime";
-
-import { type FormSchema } from "@/server/db/forms";
 
 import { Button, defaultButtonClasses } from "@/components/shared/form/Button";
 import Markdown from "@/components/content/Markdown";

--- a/apps/website/src/components/admin/short-links/ShortLinkForm.tsx
+++ b/apps/website/src/components/admin/short-links/ShortLinkForm.tsx
@@ -1,13 +1,13 @@
 import type { FormEvent } from "react";
 import { useCallback, useState } from "react";
 
-import type { ShortLinks } from "@prisma/client";
 import { useRouter } from "next/router";
+
+import type { ShortLinks } from "@/server/db/client";
+import type { ShortLinkSchema } from "@/server/db/short-links";
 
 import { trpc } from "@/utils/trpc";
 import { convertToSlug, SLUG_PATTERN } from "@/utils/slugs";
-
-import type { ShortLinkSchema } from "@/server/db/short-links";
 
 import { Button, defaultButtonClasses } from "@/components/shared/form/Button";
 import { TextField } from "@/components/shared/form/TextField";

--- a/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
+++ b/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
@@ -1,4 +1,4 @@
-import type { ShowAndTellEntry, User } from "@prisma/client";
+import type { ShowAndTellEntry, User } from "@/server/db/client";
 
 import type { MarkPostAsSeenMode } from "@/server/db/show-and-tell";
 
@@ -12,6 +12,7 @@ import {
   secondaryButtonClasses,
 } from "@/components/shared/form/Button";
 import DateTime from "@/components/content/DateTime";
+
 import IconPencil from "@/icons/IconPencil";
 import IconTrash from "@/icons/IconTrash";
 import IconEye from "@/icons/IconEye";

--- a/apps/website/src/components/admin/twitch/TwitchChannelForm.tsx
+++ b/apps/website/src/components/admin/twitch/TwitchChannelForm.tsx
@@ -1,8 +1,8 @@
 import type { FormEvent } from "react";
 import { useCallback } from "react";
-
-import type { TwitchChannel } from "@prisma/client";
 import { useRouter } from "next/router";
+
+import type { TwitchChannel } from "@/server/db/client";
 
 import { trpc } from "@/utils/trpc";
 

--- a/apps/website/src/components/calendar/CalendarItem.tsx
+++ b/apps/website/src/components/calendar/CalendarItem.tsx
@@ -1,9 +1,12 @@
-import type { CalendarEvent } from "@prisma/client";
-
 import type { DateTime } from "luxon";
+
+import type { CalendarEvent } from "@/server/db/client";
+
 import { getStandardCategoryColor } from "@/data/calendar-events";
+
 import { classes } from "@/utils/classes";
 import { DATETIME_ALVEUS_ZONE } from "@/utils/datetime";
+
 import Link from "@/components/content/Link";
 
 interface CalendarItemProps

--- a/apps/website/src/components/forms/EntryForm.tsx
+++ b/apps/website/src/components/forms/EntryForm.tsx
@@ -1,6 +1,7 @@
 import { useCallback, type FormEvent } from "react";
 import { useSession } from "next-auth/react";
-import type { Form } from "@prisma/client";
+
+import type { Form } from "@/server/db/client";
 
 import { LoginWithTwitchButton } from "@/components/shared/LoginWithTwitchButton";
 import { Button } from "@/components/shared/form/Button";

--- a/apps/website/src/components/forms/EntryRulesFieldset.tsx
+++ b/apps/website/src/components/forms/EntryRulesFieldset.tsx
@@ -1,4 +1,4 @@
-import type { Form } from "@prisma/client";
+import type { Form } from "@/server/db/client";
 
 import { Fieldset } from "@/components/shared/form/Fieldset";
 import { CheckboxField } from "@/components/shared/form/CheckboxField";

--- a/apps/website/src/components/notifications/Announcement.tsx
+++ b/apps/website/src/components/notifications/Announcement.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import type { Notification } from "@prisma/client";
 import { DateTime } from "luxon";
+
+import type { Notification } from "@/server/db/client";
 
 import { formatDateTime } from "@/utils/datetime";
 import { getShortBaseUrl } from "@/utils/short-url";

--- a/apps/website/src/components/notifications/NotificationEntry.tsx
+++ b/apps/website/src/components/notifications/NotificationEntry.tsx
@@ -1,9 +1,12 @@
 import { DateTime } from "luxon";
 import Link from "next/link";
-import type { Notification } from "@prisma/client";
+
+import type { Notification } from "@/server/db/client";
+
+import { formatDateTime } from "@/utils/datetime";
 
 import { getNotificationCategory } from "@/data/notifications";
-import { formatDateTime } from "@/utils/datetime";
+
 import { NotificationIcon } from "@/components/notifications/NotificationIcon";
 
 export function NotificationEntry({

--- a/apps/website/src/components/notifications/NotificationIcon.tsx
+++ b/apps/website/src/components/notifications/NotificationIcon.tsx
@@ -1,4 +1,4 @@
-import type { Notification } from "@prisma/client";
+import type { Notification } from "@/server/db/client";
 
 import IconTwitch from "@/icons/IconTwitch";
 import IconYouTube from "@/icons/IconYouTube";

--- a/apps/website/src/components/overlay/Event.tsx
+++ b/apps/website/src/components/overlay/Event.tsx
@@ -1,12 +1,14 @@
 import Image from "next/image";
 import { useEffect, useMemo, useRef, useState, type HTMLProps } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
-import type { CalendarEvent } from "@prisma/client";
+
+import type { CalendarEvent } from "@/server/db/client";
 
 import { trpc } from "@/utils/trpc";
 import { DATETIME_ALVEUS_ZONE, formatDateTimeRelative } from "@/utils/datetime";
 import { classes } from "@/utils/classes";
 import { getShortBaseUrl } from "@/utils/short-url";
+
 import { getFormattedTitle, twitchChannels } from "@/data/calendar-events";
 
 import { QRCode } from "@/components/QrCode";

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from "react";
 import { useRouter } from "next/router";
-import type { ShowAndTellEntry } from "@prisma/client";
+import Image from "next/image";
 import {
   Disclosure,
   DisclosureButton,
@@ -14,7 +14,7 @@ import {
 } from "@headlessui/react";
 import { useLocale } from "react-aria";
 
-import Image from "next/image";
+import type { ShowAndTellEntry } from "@/server/db/client";
 import type {
   PublicShowAndTellEntryWithAttachments,
   ShowAndTellSubmitInput,

--- a/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
@@ -2,7 +2,9 @@ import type { MouseEventHandler, RefObject, JSX } from "react";
 import { useCallback, useEffect, useId, useMemo, useRef } from "react";
 import PhotoSwipeLightbox from "photoswipe/lightbox";
 import Image from "next/image";
-import type { LinkAttachment } from "@prisma/client";
+
+import type { LinkAttachment } from "@/server/db/client";
+import type { ImageAttachmentWithFileStorageObject } from "@/server/db/show-and-tell";
 
 import {
   parseVideoUrl,
@@ -12,8 +14,6 @@ import {
 import { getDefaultPhotoswipeLightboxOptions } from "@/utils/photoswipe";
 import { createImageUrl } from "@/utils/image";
 import { classes } from "@/utils/classes";
-
-import type { ImageAttachmentWithFileStorageObject } from "@/server/db/show-and-tell";
 
 import { useConsent } from "@/hooks/consent";
 

--- a/apps/website/src/components/show-and-tell/gallery/VideoItem.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/VideoItem.tsx
@@ -1,11 +1,13 @@
-import type { LinkAttachment } from "@prisma/client";
 import type { AnchorHTMLAttributes, JSX } from "react";
+
+import type { LinkAttachment } from "@/server/db/client";
 
 import { parseVideoUrl, videoPlatformConfigs } from "@/utils/video-urls";
 import { createImageUrl } from "@/utils/image";
 
 import { VideoPlatformIcon } from "@/components/shared/VideoPlatformIcon";
 import { Preview } from "@/components/content/YouTube";
+
 import IconYouTube from "@/icons/IconYouTube";
 
 type VideoThumbnailProps = {

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -1,5 +1,6 @@
-import { type CalendarEvent } from "@prisma/client";
 import { type DateObjectUnits } from "luxon";
+
+import { type CalendarEvent } from "@/server/db/client";
 
 type StandardCategory = {
   name: string;

--- a/apps/website/src/data/notifications.ts
+++ b/apps/website/src/data/notifications.ts
@@ -1,4 +1,4 @@
-import type { NotificationUrgency } from "@prisma/client";
+import type { NotificationUrgency } from "@/server/db/client";
 
 import { env } from "@/env";
 

--- a/apps/website/src/pages/api/auth/[...nextauth].ts
+++ b/apps/website/src/pages/api/auth/[...nextauth].ts
@@ -1,7 +1,6 @@
 import NextAuth, { type NextAuthOptions } from "next-auth";
-import type { TwitchProfile } from "next-auth/providers/twitch";
-import TwitchProvider from "next-auth/providers/twitch";
-import { PrismaAdapter } from "@next-auth/prisma-adapter";
+import TwitchProvider, { type TwitchProfile } from "next-auth/providers/twitch";
+import { PrismaAdapter } from "@auth/prisma-adapter";
 
 import { env } from "@/env";
 import { prisma } from "@/server/db/client";

--- a/apps/website/src/pages/api/notifications/batched-retry-notification-pushes.ts
+++ b/apps/website/src/pages/api/notifications/batched-retry-notification-pushes.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
 import { waitUntil } from "@vercel/functions";
-import type { Notification } from "@prisma/client";
 
 import { env } from "@/env";
 
+import { prisma, type Notification } from "@/server/db/client";
 import { createTokenProtectedApiHandler } from "@/server/utils/api";
 import { callEndpoint } from "@/server/utils/queue";
-import { prisma } from "@/server/db/client";
 import { updateNotificationPushStatus } from "@/server/db/notifications";
 
 import type { SendPushOptions } from "@/pages/api/notifications/send-push";

--- a/apps/website/src/pages/api/notifications/send-push.ts
+++ b/apps/website/src/pages/api/notifications/send-push.ts
@@ -1,4 +1,3 @@
-import type { NotificationUrgency } from "@prisma/client";
 import { z } from "zod";
 
 import { env } from "@/env";
@@ -12,6 +11,7 @@ import {
 
 import type { NotificationPayload } from "@/utils/notification-payload";
 
+import { prisma, type NotificationUrgency } from "@/server/db/client";
 import { createTokenProtectedApiHandler } from "@/server/utils/api";
 import {
   getWebPushUrgency,
@@ -19,7 +19,6 @@ import {
   WEB_PUSH_MAX_TTL,
 } from "@/server/web-push/constants";
 import { sendWebPushNotification } from "@/server/web-push";
-import { prisma } from "@/server/db/client";
 import { updateNotificationPushStatus } from "@/server/db/notifications";
 import { markPushSubscriptionAsDeleted } from "@/server/db/push-subscriptions";
 

--- a/apps/website/src/pages/forms/[formId]/index.tsx
+++ b/apps/website/src/pages/forms/[formId]/index.tsx
@@ -4,9 +4,10 @@ import type {
   GetServerSideProps,
 } from "next";
 import { getSession } from "next-auth/react";
-import type { Form, FormEntry, MailingAddress } from "@prisma/client";
 
+import type { Form, FormEntry, MailingAddress } from "@/server/db/client";
 import { findActiveForm, getFormEntry } from "@/server/db/forms";
+
 import { EntryForm } from "@/components/forms/EntryForm";
 import Heading from "@/components/content/Heading";
 import Section from "@/components/content/Section";

--- a/apps/website/src/pages/forms/[formId]/rules.tsx
+++ b/apps/website/src/pages/forms/[formId]/rules.tsx
@@ -4,13 +4,14 @@ import type {
   NextPage,
 } from "next";
 
-import type { Form } from "@prisma/client";
+import type { Form } from "@/server/db/client";
+import { findActiveForm } from "@/server/db/forms";
+
+import { calcFormConfig } from "@/utils/forms";
 
 import Heading from "@/components/content/Heading";
 import Section from "@/components/content/Section";
 import Meta from "@/components/content/Meta";
-import { calcFormConfig } from "@/utils/forms";
-import { findActiveForm } from "@/server/db/forms";
 import Markdown from "@/components/content/Markdown";
 
 export type FormPageProps = InferGetServerSidePropsType<

--- a/apps/website/src/pages/forms/index.tsx
+++ b/apps/website/src/pages/forms/index.tsx
@@ -1,8 +1,7 @@
 import type { NextPage, GetStaticProps, InferGetStaticPropsType } from "next";
 import Link from "next/link";
 
-import type { Form } from "@prisma/client";
-import { prisma } from "@/server/db/client";
+import { prisma, type Form } from "@/server/db/client";
 
 import Section from "@/components/content/Section";
 import Heading from "@/components/content/Heading";

--- a/apps/website/src/server/db/calendar-events.ts
+++ b/apps/website/src/server/db/calendar-events.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { DateTime } from "luxon";
-import type { CalendarEvent } from "@prisma/client";
 import ambassadors from "@alveusgg/data/build/ambassadors/core";
 import {
   type ActiveAmbassador,
@@ -8,7 +7,7 @@ import {
   isActiveAmbassadorEntry,
 } from "@alveusgg/data/build/ambassadors/filters";
 
-import { prisma } from "@/server/db/client";
+import { prisma, type CalendarEvent } from "@/server/db/client";
 import {
   createScheduleSegment,
   getScheduleSegments,

--- a/apps/website/src/server/db/client.ts
+++ b/apps/website/src/server/db/client.ts
@@ -5,3 +5,5 @@ import { env } from "@/env";
 export const prisma = new PrismaClient({
   log: env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
 });
+
+export * from "@prisma/client";

--- a/apps/website/src/server/db/client.ts
+++ b/apps/website/src/server/db/client.ts
@@ -1,9 +1,9 @@
-import { PrismaClient } from "@prisma/client";
-
 import { env } from "@/env";
+
+import { PrismaClient } from "../../../prisma/client";
 
 export const prisma = new PrismaClient({
   log: env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
 });
 
-export * from "@prisma/client";
+export * from "../../../prisma/client";

--- a/apps/website/src/server/db/client.ts
+++ b/apps/website/src/server/db/client.ts
@@ -2,18 +2,6 @@ import { PrismaClient } from "@prisma/client";
 
 import { env } from "@/env";
 
-declare global {
-  // eslint-disable-next-line no-var
-  var prisma: PrismaClient | undefined;
-}
-
-export const prisma =
-  global.prisma ||
-  new PrismaClient({
-    log:
-      env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
-  });
-
-if (env.NODE_ENV !== "production") {
-  global.prisma = prisma;
-}
+export const prisma = new PrismaClient({
+  log: env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
+});

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -1,13 +1,5 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import type {
-  FileStorageObject,
-  ImageAttachment,
-  ImageMetadata,
-  LinkAttachment,
-  ShowAndTellEntry as ShowAndTellEntryModel,
-  ShowAndTellEntryAttachment,
-} from "@prisma/client";
 
 import { env } from "@/env";
 
@@ -18,8 +10,16 @@ import {
   MYSQL_MAX_VARCHAR_LENGTH,
 } from "@/data/show-and-tell";
 
+import {
+  prisma,
+  type FileStorageObject,
+  type ImageAttachment,
+  type ImageMetadata,
+  type LinkAttachment,
+  type ShowAndTellEntry as ShowAndTellEntryModel,
+  type ShowAndTellEntryAttachment,
+} from "@/server/db/client";
 import { sanitizeUserHtml } from "@/server/utils/sanitize-user-html";
-import { prisma } from "@/server/db/client";
 import { checkAndFixUploadedImageFileStorageObject } from "@/server/utils/file-storage";
 
 import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";

--- a/apps/website/src/server/notifications.ts
+++ b/apps/website/src/server/notifications.ts
@@ -1,5 +1,3 @@
-import type { Notification } from "@prisma/client";
-
 import { env } from "@/env";
 
 import type { NotificationCategory } from "@/data/notifications";
@@ -9,9 +7,10 @@ import {
   notificationCategories,
 } from "@/data/notifications";
 
-import { prisma } from "@/server/db/client";
+import { prisma, type Notification } from "@/server/db/client";
 import { callEndpoint } from "@/server/utils/queue";
 import { triggerDiscordChannelWebhook } from "@/server/outgoing-webhooks";
+
 import { escapeLinksForDiscord } from "@/utils/escape-links-for-discord";
 
 import type { CreatePushesOptions } from "@/pages/api/notifications/batched-create-notification-pushes";

--- a/apps/website/src/server/outgoing-webhooks.ts
+++ b/apps/website/src/server/outgoing-webhooks.ts
@@ -1,7 +1,6 @@
-import type { OutgoingWebhook } from "@prisma/client";
-
-import { prisma } from "@/server/db/client";
 import { env } from "@/env";
+
+import { prisma, type OutgoingWebhook } from "@/server/db/client";
 
 export type OutgoingWebhookType = "form-entry" | "unknown";
 

--- a/apps/website/src/server/web-push/constants.ts
+++ b/apps/website/src/server/web-push/constants.ts
@@ -1,4 +1,4 @@
-import type { NotificationUrgency } from "@prisma/client";
+import type { NotificationUrgency } from "@/server/db/client";
 
 export const WEB_PUSH_MAX_TTL = 2419200; // 4 weeks
 

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -39,5 +39,5 @@
     "**/*.js",
     ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "src/sw", "public"]
+  "exclude": ["node_modules", "src/sw", "public", "prisma/client"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@alveusgg/data':
         specifier: 0.57.1
         version: 0.57.1(tailwindcss@4.1.4)(zod@3.24.2)
+      '@auth/prisma-adapter':
+        specifier: ^2.8.0
+        version: 2.8.0(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.8.3))(typescript@5.8.3))
       '@aws-sdk/client-s3':
         specifier: ^3.787.0
         version: 3.787.0
@@ -113,9 +116,6 @@ importers:
       '@maplibre/maplibre-gl-geocoder':
         specifier: ^1.8.0
         version: 1.8.0(maplibre-gl@5.3.1)
-      '@next-auth/prisma-adapter':
-        specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@next/env':
         specifier: ^15.3.0
         version: 15.3.0
@@ -341,7 +341,7 @@ importers:
         version: 4.3.2(eslint-plugin-import-x@4.10.5(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0)(eslint@9.24.0(jiti@2.4.2))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(eslint-import-resolver-typescript@4.3.2)(eslint@9.24.0(jiti@2.4.2))
+        version: 2.31.0(@typescript-eslint/parser@8.30.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.2)(eslint@9.24.0(jiti@2.4.2))
       eslint-plugin-import-x:
         specifier: ^4.10.5
         version: 4.10.5(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
@@ -408,6 +408,25 @@ packages:
 
   '@asamuzakjp/css-color@3.1.2':
     resolution: {integrity: sha512-nwgc7jPn3LpZ4JWsoHtuwBsad1qSSLDDX634DdG0PBJofIuIEtSWk4KkRmuXyu178tjuHAbwiMNNzwqIyLYxZw==}
+
+  '@auth/core@0.38.0':
+    resolution: {integrity: sha512-ClHl44x4cY3wfJmHLpW+XrYqED0fZIzbHmwbExltzroCjR5ts3DLTWzADRba8mJFYZ8JIEJDa+lXnGl0E9Bl7Q==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/prisma-adapter@2.8.0':
+    resolution: {integrity: sha512-g0Bmq3l5xUDyBBiDgm/y3Zqb582CnRHzFqbloV7scrLia5AbVC0xy+ntn+CQCAWW9ibpwiqJrQKKboIWN1oGqw==}
+    peerDependencies:
+      '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5 || >=6'
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -1408,12 +1427,6 @@ packages:
   '@napi-rs/wasm-runtime@0.2.8':
     resolution: {integrity: sha512-OBlgKdX7gin7OIq4fadsjpg+cp2ZphvAIKucHsNfTdJiqdOmOEwQd/bHi0VwNrcw5xpBJyUw6cK/QilCqy1BSg==}
 
-  '@next-auth/prisma-adapter@1.0.7':
-    resolution: {integrity: sha512-Cdko4KfcmKjsyHFrWwZ//lfLUbcLqlyFqjd/nYE2m3aZ7tjMNUjpks47iw7NTCnXf+5UWz5Ypyt1dSs1EP5QJw==}
-    peerDependencies:
-      '@prisma/client': '>=2.26.0 || >=3'
-      next-auth: ^4
-
   '@next/env@13.5.11':
     resolution: {integrity: sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==}
 
@@ -1489,6 +1502,9 @@ packages:
 
   '@panva/hkdf@1.1.1':
     resolution: {integrity: sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@paralleldrive/cuid2@2.2.2':
     resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
@@ -4845,6 +4861,9 @@ packages:
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
+  jose@6.0.10:
+    resolution: {integrity: sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -5337,6 +5356,9 @@ packages:
   nwsapi@2.2.20:
     resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
 
+  oauth4webapi@3.5.0:
+    resolution: {integrity: sha512-DF3mLWNuxPkxJkHmWxbSFz4aE5CjWOsm465VBfBdWzmzX4Mg3vF8icxK+iKqfdWrIumBJ2TaoNQWx+SQc2bsPQ==}
+
   oauth@0.10.2:
     resolution: {integrity: sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==}
 
@@ -5545,8 +5567,16 @@ packages:
     peerDependencies:
       preact: '>=10'
 
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
   preact@10.19.3:
     resolution: {integrity: sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==}
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -6717,6 +6747,23 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       lru-cache: 10.4.3
+
+  '@auth/core@0.38.0':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.0.10
+      oauth4webapi: 3.5.0
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@auth/prisma-adapter@2.8.0(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.8.3))(typescript@5.8.3))':
+    dependencies:
+      '@auth/core': 0.38.0
+      '@prisma/client': 6.6.0(prisma@6.6.0(typescript@5.8.3))(typescript@5.8.3)
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -7945,11 +7992,6 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
-    dependencies:
-      '@prisma/client': 6.6.0(prisma@6.6.0(typescript@5.8.3))(typescript@5.8.3)
-      next-auth: 4.24.11(next@15.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-
   '@next/env@13.5.11': {}
 
   '@next/env@15.3.0': {}
@@ -7997,6 +8039,8 @@ snapshots:
       fastq: 1.19.1
 
   '@panva/hkdf@1.1.1': {}
+
+  '@panva/hkdf@1.2.1': {}
 
   '@paralleldrive/cuid2@2.2.2':
     dependencies:
@@ -11186,15 +11230,16 @@ snapshots:
       tinyglobby: 0.2.12
       unrs-resolver: 1.4.1
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(eslint-import-resolver-typescript@4.3.2)(eslint@9.24.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.30.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.2)(eslint@9.24.0(jiti@2.4.2))
       eslint-plugin-import-x: 4.10.5(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.2)(eslint@9.24.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.30.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.2)(eslint@9.24.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.30.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.24.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.3.2(eslint-plugin-import-x@4.10.5(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-plugin-import@2.31.0)(eslint@9.24.0(jiti@2.4.2))
@@ -11221,7 +11266,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.31.0(eslint-import-resolver-typescript@4.3.2)(eslint@9.24.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.30.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.2)(eslint@9.24.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -11232,7 +11277,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.24.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.2)(eslint@9.24.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.30.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.2)(eslint@9.24.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -11243,6 +11288,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.30.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -12119,6 +12166,8 @@ snapshots:
 
   jose@4.15.9: {}
 
+  jose@6.0.10: {}
+
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -12747,6 +12796,8 @@ snapshots:
 
   nwsapi@2.2.20: {}
 
+  oauth4webapi@3.5.0: {}
+
   oauth@0.10.2: {}
 
   oauth@0.9.15: {}
@@ -12945,7 +12996,13 @@ snapshots:
       preact: 10.19.3
       pretty-format: 3.8.0
 
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
   preact@10.19.3: {}
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
## Describe your changes

Our builds have contained `Warning: You did not specify an output path for your 'generator' in schema.prisma. This behavior is deprecated and will no longer be supported in Prisma 7.0.0. To learn more visit https://pris.ly/cli/output-path` as a warning for a while now, this fixes that by setting an explicit output location.

I've opted to have it output into the existing `prisma` directory -- as this is outside `src`, I've then re-exported everything in the `src/server/db/client` file so that usages in our code can import the client using `@/server/db/client` rather than needing to do a messy relative import to outside of `src`.

## Notes for testing your change

You'll want to `rm -rf node_modules apps/*/node_modules` and then `pnpm install --frozen-lockfile` to purge the old generated client, install the new adapter, and generate the new client.

Check Prisma continues to work.
