### PR TITLE
Tweak WWF Give an Hour progress bars (again)

### DIFF
--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -74,9 +74,11 @@ const useWWfGiveAnHourCampaign = (date?: DateString) =>
   }, [date]);
 
 const wwfGiveAnHourTarget = (hours: number, ended: boolean) => {
-  const round = ended ? Math.floor : Math.ceil;
-  const computed = round(hours / 500) * 500;
-  return ended ? computed : Math.max(1500, computed);
+  if (ended) return Math.floor(hours / 500) * 500;
+
+  const minimum = 1500;
+  const multiple = hours > minimum ? 1000 : 500;
+  return Math.max(Math.ceil(hours / multiple) * multiple, minimum);
 };
 
 const Card = ({

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -73,13 +73,9 @@ const useWWfGiveAnHourCampaign = (date?: DateString) =>
     };
   }, [date]);
 
-const wwfGiveAnHourTarget = (
-  hours: number,
-  ended: boolean,
-  computed: number,
-) => {
+const wwfGiveAnHourTarget = (hours: number, ended: boolean) => {
   const round = ended ? Math.floor : Math.ceil;
-  computed = round(computed / 500) * 500;
+  const computed = round(hours / 500) * 500;
   return ended ? computed : Math.max(1500, computed);
 };
 


### PR DESCRIPTION
## Describe your changes

As the number of hours in prod has grown, the logic for the target doesn't quite seem right (its using the regular computed target rounded to the nearest 500) -- as this is a shorter-lived event, I think we want to always round to the nearest 1000 (or 500 if below 1500).

## Notes for testing your change

Target calculation seems correct.