### PR TITLE
Sync targets of WWF campaign progress bars

### DIFF
--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -66,7 +66,9 @@ const GiveAnHourProgressText = ({
             ? `No hours given${ended ? "" : " yet"}`
             : `${localeHours}${ended ? "" : " already"} given`}
       </p>
-      <p className="font-medium opacity-75">{localeTarget} target</p>
+      {!ended && (
+        <p className="font-medium opacity-75">{localeTarget} target</p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Describe your changes

To help with the visual comparison of hours contributed of the years of the Give an Hour WWF campaigns, this syncs the targets of the bars to whatever the maximum target is across the bars (and hides the target for any ended progress bar).

| PR | Prod |
|-|-|
| <img width="645" alt="image" src="https://github.com/user-attachments/assets/3b5403b0-5b45-4179-82f9-b0a98b256a99" /> | <img width="655" alt="image" src="https://github.com/user-attachments/assets/da18b0fe-849d-4319-a9c1-0a9746f94342" /> |

## Notes for testing your change

In `GiveAnHourProgress.tsx`, change `const hours = ...` to `const hours = (startDate?.getFullYear() === 2024 ? 1480 : (startDate?.getFullYear() === 2025 ? 2712 : 0)) || hoursQuery.data || 0;` to simulate the current prod values.
