### PR TITLE
Allow marking show and tell posts newer than x as seen

### DIFF
--- a/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntriesPanel.tsx
+++ b/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntriesPanel.tsx
@@ -4,6 +4,8 @@ import { trpc } from "@/utils/trpc";
 import { Button } from "@/components/shared/form/Button";
 import IconLoading from "@/icons/IconLoading";
 import type { AppRouter } from "@/server/trpc/router/_app";
+import type { MarkPostAsSeenMode } from "@/server/db/show-and-tell";
+
 import { Panel } from "../Panel";
 import { AdminShowAndTellEntry } from "./AdminShowAndTellEntry";
 
@@ -38,8 +40,8 @@ export function AdminShowAndTellEntriesPanel({
     onSettled: () => entries.refetch(),
   });
   const handleMarkAsSeen = useCallback(
-    (entry: Entry, retroactive = false) => {
-      markAsSeen.mutate({ id: entry.id, retroactive });
+    (entry: Entry, mode?: MarkPostAsSeenMode) => {
+      markAsSeen.mutate({ id: entry.id, mode });
     },
     [markAsSeen],
   );

--- a/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
+++ b/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
@@ -86,7 +86,7 @@ export function AdminShowAndTellEntry({
                 onClick={() => {
                   if (
                     confirm(
-                      "Mark all posts until here and newer as seen on stream?",
+                      "Mark this post and all NEWER posts as seen on stream?",
                     )
                   ) {
                     markSeen(entry, "thisAndNewer");

--- a/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
+++ b/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
@@ -109,7 +109,7 @@ export function AdminShowAndTellEntry({
                     markSeen(entry, "thisAndOlder");
                   }
                 }}
-                title="Mark all posts from here and older as seen on stream"
+                title="Mark this post and all older posts as seen on stream"
               >
                 <IconArrowDown className="size-5" />
               </Button>

--- a/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
+++ b/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
@@ -1,5 +1,7 @@
 import type { ShowAndTellEntry, User } from "@prisma/client";
 
+import type { MarkPostAsSeenMode } from "@/server/db/show-and-tell";
+
 import { getEntityStatus } from "@/utils/entity-helpers";
 import { formatDateTimeLocal } from "@/utils/datetime";
 
@@ -15,13 +17,17 @@ import IconTrash from "@/icons/IconTrash";
 import IconEye from "@/icons/IconEye";
 import IconPlus from "@/icons/IconPlus";
 import IconCheck from "@/icons/IconCheck";
+import IconArrowUp from "@/icons/IconArrowUp";
 import IconArrowDown from "@/icons/IconArrowDown";
 
 type ShowAndTellEntryWithUser = ShowAndTellEntry & { user: User | null };
 
 type AdminShowAndTellEntryProps = {
   entry: ShowAndTellEntryWithUser;
-  markSeen: (entry: ShowAndTellEntryWithUser, retroactive?: boolean) => void;
+  markSeen: (
+    entry: ShowAndTellEntryWithUser,
+    mode?: MarkPostAsSeenMode,
+  ) => void;
   unmarkSeen: (entry: ShowAndTellEntryWithUser) => void;
   deletePost: (entry: ShowAndTellEntryWithUser) => void;
 };
@@ -73,18 +79,41 @@ export function AdminShowAndTellEntry({
               <IconPlus className="size-5" /> Seen
             </Button>
 
-            <Button
-              size="small"
-              className={secondaryButtonClasses}
-              onClick={() => {
-                if (confirm("Mark all posts until here as seen on stream?")) {
-                  markSeen(entry, true);
-                }
-              }}
-              title="Mark all posts until here as seen on stream"
-            >
-              <IconArrowDown className="size-5" /> All
-            </Button>
+            <div className="flex gap-1">
+              <Button
+                size="small"
+                className={secondaryButtonClasses}
+                onClick={() => {
+                  if (
+                    confirm(
+                      "Mark all posts until here and newer as seen on stream?",
+                    )
+                  ) {
+                    markSeen(entry, "thisAndNewer");
+                  }
+                }}
+                title="Mark all posts until here and newer as seen on stream"
+              >
+                <IconArrowUp className="size-5" />
+              </Button>
+
+              <Button
+                size="small"
+                className={secondaryButtonClasses}
+                onClick={() => {
+                  if (
+                    confirm(
+                      "Mark all posts from here and older as seen on stream?",
+                    )
+                  ) {
+                    markSeen(entry, "thisAndOlder");
+                  }
+                }}
+                title="Mark all posts from here and older as seen on stream"
+              >
+                <IconArrowDown className="size-5" />
+              </Button>
+            </div>
           </div>
         )}
         {!entry.seenOnStreamAt && status === "pendingApproval" && "no"}

--- a/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
+++ b/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
@@ -103,7 +103,7 @@ export function AdminShowAndTellEntry({
                 onClick={() => {
                   if (
                     confirm(
-                      "Mark all posts from here and older as seen on stream?",
+                      "Mark this post and all OLDER posts as seen on stream?",
                     )
                   ) {
                     markSeen(entry, "thisAndOlder");

--- a/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
+++ b/apps/website/src/components/admin/show-and-tell/AdminShowAndTellEntry.tsx
@@ -92,7 +92,7 @@ export function AdminShowAndTellEntry({
                     markSeen(entry, "thisAndNewer");
                   }
                 }}
-                title="Mark all posts until here and newer as seen on stream"
+                title="Mark this post and all newer posts as seen on stream"
               >
                 <IconArrowUp className="size-5" />
               </Button>

--- a/apps/website/src/server/trpc/router/admin/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/admin/show-and-tell.ts
@@ -11,6 +11,7 @@ import {
   approvePost,
   removeApprovalFromPost,
   deletePost,
+  markPostAsSeenModeSchema,
   markPostAsSeen,
   unmarkPostAsSeen,
   getAdminPosts,
@@ -43,11 +44,12 @@ export const adminShowAndTellRouter = router({
 
   markAsSeen: permittedProcedure
     .input(
-      z.object({ id: z.string().cuid(), retroactive: z.boolean().optional() }),
+      z.object({
+        id: z.string().cuid(),
+        mode: markPostAsSeenModeSchema,
+      }),
     )
-    .mutation(
-      async ({ input }) => await markPostAsSeen(input.id, input.retroactive),
-    ),
+    .mutation(async ({ input }) => await markPostAsSeen(input.id, input.mode)),
 
   unmarkAsSeen: permittedProcedure
     .input(z.object({ id: z.string().cuid() }))


### PR DESCRIPTION
## Describe your changes

This will introduce a new button in the show and tell admin page, that allows marking all posts as seen newer than the selected post. This is in addition to the existing button that allows marking all posts older than the selected post.

## Notes for testing your change

...
