### PR TITLE
Add Show and Tell placeholder for posts with no images

### DIFF
--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -17,6 +17,8 @@ import parse, {
 import { ErrorBoundary } from "react-error-boundary";
 
 import { DATETIME_ALVEUS_ZONE, formatDateTime } from "@/utils/datetime";
+import { classes } from "@/utils/classes";
+import { splitAttachments } from "@/utils/split-attachments";
 
 import type { PublicShowAndTellEntryWithAttachments } from "@/server/db/show-and-tell";
 
@@ -25,8 +27,8 @@ import { ShowAndTellGallery } from "@/components/show-and-tell/gallery/ShowAndTe
 import { Badge } from "@/components/show-and-tell/Badge";
 
 import IconWorld from "@/icons/IconWorld";
-import { classes } from "@/utils/classes";
-import { splitAttachments } from "@/utils/split-attachments";
+
+import showAndTellPeepo from "@/assets/show-and-tell/peepo.png";
 
 type ShowAndTellEntryProps = {
   entry: PublicShowAndTellEntryWithAttachments;
@@ -331,12 +333,29 @@ export const ShowAndTellEntry = ({
           isPresentationView={isPresentationView}
         />
 
-        <ShowAndTellGallery
-          isPresentationView={isPresentationView}
-          lightboxParentRef={wrapperRef}
-          imageAttachments={imageAttachments}
-          videoAttachments={videoAttachments}
-        />
+        {imageAttachments.length || videoAttachments.length ? (
+          <ShowAndTellGallery
+            isPresentationView={isPresentationView}
+            lightboxParentRef={wrapperRef}
+            imageAttachments={imageAttachments}
+            videoAttachments={videoAttachments}
+          />
+        ) : (
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 p-4">
+            <Image
+              src={showAndTellPeepo}
+              height={384}
+              alt=""
+              className={classes(
+                "h-full w-auto opacity-50",
+                isPresentationView ? "max-h-96" : "max-h-48",
+              )}
+            />
+            <p className="text-xs italic opacity-75">
+              This post has no videos or images.
+            </p>
+          </div>
+        )}
 
         <Content entry={entry} isPresentationView={isPresentationView} />
       </div>

--- a/apps/website/src/pages/show-and-tell/index.tsx
+++ b/apps/website/src/pages/show-and-tell/index.tsx
@@ -399,9 +399,9 @@ const ShowAndTellIndexPage: NextPage<ShowAndTellPageProps> = ({
         <div className="w-full pt-8 pb-4 md:w-3/5 md:py-20">
           <Heading>Show and Tell</Heading>
           <p className="text-lg">
-            The community shares conservation and wildlife-related activities.
-            <br />
-            Share your own via the{" "}
+            See what the Alveus community has been up to as they share their
+            conservation and wildlife-related activities, <br />
+            or share your own via the{" "}
             <Link href="/show-and-tell/submit-post" dark>
               submission page
             </Link>


### PR DESCRIPTION
## Describe your changes

We had a few posts today that had no images (and sometimes not even any content), so hopefully this makes them slightly more visually appealing and makes it more obvious the posts intentionally lack content rather than it being a bug of some kind.

## Notes for testing your change

Placeholder only renders on posts w/o images/videos, does not get in the way of a post with long content.