### PR TITLE
Add Art Auction 2025 to Events page

### DIFF
--- a/apps/website/src/data/events/index.tsx
+++ b/apps/website/src/data/events/index.tsx
@@ -4,6 +4,7 @@ import { convertToSlug } from "@/utils/slugs";
 
 import Link from "@/components/content/Link";
 
+import artAuction2025Video from "@/assets/events/art-auction-2025.mp4";
 import artAuction2024Video from "@/assets/events/art-auction-2024.mp4";
 import valentines2024Video from "@/assets/events/valentines-2024.mp4";
 import fallCarnival20232024Video from "@/assets/events/fall-carnival-2023-2024.mp4";
@@ -28,7 +29,7 @@ const events: Event[] = (
     {
       name: "Art Auction 2025",
       date: new Date("2025-04-22"),
-      video: artAuction2024Video,
+      video: artAuction2025Video,
       stats: {
         totalDonations: {
           title: "Raised for Alveus Sanctuary",

--- a/apps/website/src/data/events/index.tsx
+++ b/apps/website/src/data/events/index.tsx
@@ -26,6 +26,50 @@ export type Event = {
 const events: Event[] = (
   [
     {
+      name: "Art Auction 2025",
+      date: new Date("2025-04-22"),
+      video: artAuction2024Video,
+      stats: {
+        totalDonations: {
+          title: "Raised for Alveus Sanctuary",
+          stat: "$87,256",
+        },
+        artworksSold: {
+          title: "Artworks sold",
+          stat: "36",
+        },
+        signedPrints: {
+          title: "Signed prints for donors",
+          stat: "452",
+        },
+        averagePrice: {
+          title: "Average donation for each artwork",
+          stat: "$1,866",
+        },
+      },
+      info: (
+        <>
+          <p>
+            Celebrating Earth Day, the 2025 Art Auction was a huge success.
+            Hosted in the Session Yard again, 36 pieces of art created by the
+            ambassadors and the staff at Alveus were up for auction, as well as
+            a signed print available for anyone who donated $25 or more during
+            the event.
+          </p>
+          <p>
+            By the end of the event, we raised $87,256 for Alveus Sanctuary,
+            with 452 signed postcards sent out to donors. The most successful
+            ambassador artist this year was{" "}
+            <Link href="/ambassadors/stompy">Stompy</Link>, with his painting
+            and foot casting being won for over $12,000 combined. The top
+            painting sold for $11,111 this year, and was created by Maya
+            herself. Thank you to everyone who participated by bidding on an
+            item, donating for a signed print, or just watching the livestream!
+          </p>
+        </>
+      ),
+    },
+    {
       name: "Fall Carnival 2024",
       date: new Date("2024-11-04"),
       video: fallCarnival20232024Video,

--- a/apps/website/src/pages/about/alveus.tsx
+++ b/apps/website/src/pages/about/alveus.tsx
@@ -535,9 +535,21 @@ const history: [HistoryItems, ...(HistoryCTA | HistoryItems)[]] = [
         key: "new-studio",
         date: "2025-03-05",
         content: [
-          "New Studio Launch",
+          "New studio launch",
           "Alveus unveils a completely refurbished studio space, featuring live plant walls, an interactive whiteboard, a new fish tank and improved equipment for live streams.",
         ],
+      },
+      {
+        key: "art-auction-2025",
+        date: "2025-04",
+        content: [
+          "Art Auction fundraiser",
+          "Celebrating Earth Day and hosted in the Session Yard at Alveus, the art auction sold 36 pieces of art from the ambassadors and staff, as well as over 450 signed prints, raising over $87,000 USD.",
+        ],
+        link: {
+          text: "Explore Alveus events",
+          href: "/events#art-auction-2025",
+        },
       },
     ],
   },


### PR DESCRIPTION
## Describe your changes

Adds the recap and stats for this year's Art Auction to the events page.

## Notes for testing your change

Wording correct, stats correct.
