### PR TITLE
Tweak caching behaviour for API routes

### DIFF
--- a/apps/website/src/app/api/stream/ambassadors/route.ts
+++ b/apps/website/src/app/api/stream/ambassadors/route.ts
@@ -107,7 +107,4 @@ export async function OPTIONS() {
   });
 }
 
-// Cache the response for 30 minutes
 export const dynamic = "force-static";
-export const revalidate = 1800;
-// export const runtime = "edge"; // Not compatible with force-static

--- a/apps/website/src/app/api/stream/ambassadors/route.ts
+++ b/apps/website/src/app/api/stream/ambassadors/route.ts
@@ -81,7 +81,8 @@ const ambassadorsV3 = typeSafeObjectFromEntries(
 
 const headers = {
   // Response can be cached for 30 minutes
-  "Cache-Control": "max-age=1800, s-maxage=1800, must-revalidate",
+  // And can be stale for 5 minutes while revalidating
+  "Cache-Control": "max-age=1800, s-maxage=1800, stale-while-revalidate=300",
 
   // Vercel doesn't respect Vary so we allow all origins to use this
   // Ideally we'd just allow specifically localhost + *.ext-twitch.tv

--- a/apps/website/src/app/api/stream/ambassadors/route.ts
+++ b/apps/website/src/app/api/stream/ambassadors/route.ts
@@ -81,8 +81,7 @@ const ambassadorsV3 = typeSafeObjectFromEntries(
 
 const headers = {
   // Response can be cached for 30 minutes
-  // And can be stale for 5 minutes while revalidating
-  "Cache-Control": "max-age=1800, s-maxage=1800, stale-while-revalidate=300",
+  "Cache-Control": "max-age=1800, s-maxage=1800, must-revalidate",
 
   // Vercel doesn't respect Vary so we allow all origins to use this
   // Ideally we'd just allow specifically localhost + *.ext-twitch.tv

--- a/apps/website/src/app/api/stream/weather/route.ts
+++ b/apps/website/src/app/api/stream/weather/route.ts
@@ -19,8 +19,3 @@ export async function GET() {
     return new Response("Weather data not available", { status: 500 });
   }
 }
-
-// Cache the response for 1 minute
-export const dynamic = "force-static";
-export const revalidate = 60;
-// export const runtime = "edge"; // Not compatible with force-static

--- a/apps/website/src/app/api/stream/weather/route.ts
+++ b/apps/website/src/app/api/stream/weather/route.ts
@@ -12,6 +12,7 @@ export async function GET() {
         // And can be stale for 5 minutes while revalidating
         "Cache-Control": "max-age=60, s-maxage=60, stale-while-revalidate=300",
         "X-Generated-At": new Date().toISOString(),
+        "X-Observed-At": data.time.utc ?? "",
       },
     });
   } catch (err) {

--- a/apps/website/src/app/api/stream/weather/route.ts
+++ b/apps/website/src/app/api/stream/weather/route.ts
@@ -8,9 +8,9 @@ export async function GET() {
 
     return new Response(resp, {
       headers: {
-        // Response can be cached for 1 minute
-        // And can be stale for 5 minutes while revalidating
-        "Cache-Control": "max-age=60, s-maxage=60, stale-while-revalidate=300",
+        // Response can be cached for 10 seconds (the underlying data is cached for 1 minute)
+        // And can be stale for 1 minute while revalidating
+        "Cache-Control": "max-age=10, s-maxage=10, stale-while-revalidate=60",
         "X-Generated-At": new Date().toISOString(),
         "X-Observed-At": data.time.utc ?? "",
       },

--- a/apps/website/src/app/api/stream/weather/route.ts
+++ b/apps/website/src/app/api/stream/weather/route.ts
@@ -11,6 +11,7 @@ export async function GET() {
         // Response can be cached for 1 minute
         // And can be stale for 5 minutes while revalidating
         "Cache-Control": "max-age=60, s-maxage=60, stale-while-revalidate=300",
+        "X-Generated-At": new Date().toISOString(),
       },
     });
   } catch (err) {

--- a/apps/website/src/app/api/stream/weather/route.ts
+++ b/apps/website/src/app/api/stream/weather/route.ts
@@ -9,8 +9,7 @@ export async function GET() {
     return new Response(resp, {
       headers: {
         // Response can be cached for 1 minute
-        // And can be stale for 5 minutes while revalidating
-        "Cache-Control": "max-age=60, s-maxage=60, stale-while-revalidate=300",
+        "Cache-Control": "max-age=60, s-maxage=60, must-revalidate",
         "X-Generated-At": new Date().toISOString(),
       },
     });

--- a/apps/website/src/app/api/stream/weather/route.ts
+++ b/apps/website/src/app/api/stream/weather/route.ts
@@ -8,9 +8,8 @@ export async function GET() {
 
     return new Response(resp, {
       headers: {
-        // Response can be cached for 10 seconds (the underlying data is cached for 1 minute)
-        // And can be stale for 1 minute while revalidating
-        "Cache-Control": "max-age=10, s-maxage=10, stale-while-revalidate=60",
+        // Response can be cached for 1 minute
+        "Cache-Control": "max-age=60, s-maxage=60, must-revalidate",
         "X-Generated-At": new Date().toISOString(),
         "X-Observed-At": data.time.utc ?? "",
       },

--- a/apps/website/src/app/api/stream/weather/route.ts
+++ b/apps/website/src/app/api/stream/weather/route.ts
@@ -9,7 +9,8 @@ export async function GET() {
     return new Response(resp, {
       headers: {
         // Response can be cached for 1 minute
-        "Cache-Control": "max-age=60, s-maxage=60, must-revalidate",
+        // And can be stale for 5 minutes while revalidating
+        "Cache-Control": "max-age=60, s-maxage=60, stale-while-revalidate=300",
         "X-Generated-At": new Date().toISOString(),
       },
     });

--- a/apps/website/src/app/api/stream/youtube/[channel]/route.ts
+++ b/apps/website/src/app/api/stream/youtube/[channel]/route.ts
@@ -39,6 +39,7 @@ export async function GET(
         // Response can be cached for 5 minutes
         // And can be stale for 1 minute while revalidating
         "Cache-Control": "max-age=300, s-maxage=300, stale-while-revalidate=60",
+        "X-Generated-At": new Date().toISOString(),
       },
     });
   } catch (err) {

--- a/apps/website/src/app/api/stream/youtube/[channel]/route.ts
+++ b/apps/website/src/app/api/stream/youtube/[channel]/route.ts
@@ -37,7 +37,8 @@ export async function GET(
     return new Response(resp, {
       headers: {
         // Response can be cached for 5 minutes
-        "Cache-Control": "max-age=300, s-maxage=300, must-revalidate",
+        // And can be stale for 1 minute while revalidating
+        "Cache-Control": "max-age=300, s-maxage=300, stale-while-revalidate=60",
         "X-Generated-At": new Date().toISOString(),
       },
     });

--- a/apps/website/src/app/api/stream/youtube/[channel]/route.ts
+++ b/apps/website/src/app/api/stream/youtube/[channel]/route.ts
@@ -37,8 +37,7 @@ export async function GET(
     return new Response(resp, {
       headers: {
         // Response can be cached for 5 minutes
-        // And can be stale for 1 minute while revalidating
-        "Cache-Control": "max-age=300, s-maxage=300, stale-while-revalidate=60",
+        "Cache-Control": "max-age=300, s-maxage=300, must-revalidate",
         "X-Generated-At": new Date().toISOString(),
       },
     });

--- a/apps/website/src/app/api/stream/youtube/[channel]/route.ts
+++ b/apps/website/src/app/api/stream/youtube/[channel]/route.ts
@@ -47,7 +47,3 @@ export async function GET(
     return new Response("YouTube data not available", { status: 500 });
   }
 }
-
-// Cache the response for 5 minutes
-export const dynamic = "force-static";
-export const revalidate = 300;

--- a/apps/website/src/app/live/youtube/chat/route.ts
+++ b/apps/website/src/app/live/youtube/chat/route.ts
@@ -28,7 +28,3 @@ export async function GET() {
     return new Response("YouTube data not available", { status: 500 });
   }
 }
-
-// Cache the response for 5 minutes
-export const dynamic = "force-static";
-export const revalidate = 300;

--- a/apps/website/src/app/live/youtube/chat/route.ts
+++ b/apps/website/src/app/live/youtube/chat/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
         Refresh: `0;url=${link}`,
         // Response can be cached for 5 minutes
         // And can be stale for 1 minute while revalidating
-        "Cache-Control": "max-age=300, s-maxage=300, must-revalidate",
+        "Cache-Control": "max-age=300, s-maxage=300, stale-while-revalidate=60",
         "X-Generated-At": new Date().toISOString(),
       },
     });

--- a/apps/website/src/app/live/youtube/chat/route.ts
+++ b/apps/website/src/app/live/youtube/chat/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
         Refresh: `0;url=${link}`,
         // Response can be cached for 5 minutes
         // And can be stale for 1 minute while revalidating
-        "Cache-Control": "max-age=300, s-maxage=300, stale-while-revalidate=60",
+        "Cache-Control": "max-age=300, s-maxage=300, must-revalidate",
         "X-Generated-At": new Date().toISOString(),
       },
     });

--- a/apps/website/src/app/live/youtube/chat/route.ts
+++ b/apps/website/src/app/live/youtube/chat/route.ts
@@ -18,8 +18,7 @@ export async function GET() {
         Location: link,
         Refresh: `0;url=${link}`,
         // Response can be cached for 5 minutes
-        // And can be stale for 1 minute while revalidating
-        "Cache-Control": "max-age=300, s-maxage=300, stale-while-revalidate=60",
+        "Cache-Control": "max-age=300, s-maxage=300, must-revalidate",
         "X-Generated-At": new Date().toISOString(),
       },
     });

--- a/apps/website/src/app/live/youtube/chat/route.ts
+++ b/apps/website/src/app/live/youtube/chat/route.ts
@@ -20,6 +20,7 @@ export async function GET() {
         // Response can be cached for 5 minutes
         // And can be stale for 1 minute while revalidating
         "Cache-Control": "max-age=300, s-maxage=300, stale-while-revalidate=60",
+        "X-Generated-At": new Date().toISOString(),
       },
     });
   } catch (err) {

--- a/apps/website/src/components/overlay/Weather.tsx
+++ b/apps/website/src/components/overlay/Weather.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import { trpc } from "@/utils/trpc";
@@ -14,6 +15,16 @@ const Weather = () => {
       staleTime: 10 * 60 * 1000,
     },
   );
+
+  useEffect(() => {
+    // Log the timestamp of the last weather observation
+    if (weather?.time.utc) {
+      const observedAt = new Date(weather.time.utc);
+      console.log(
+        `Weather observation received at ${observedAt.toLocaleString()}${isStale ? " (stale)" : ""}`,
+      );
+    }
+  }, [weather, isStale]);
 
   return (
     weather &&

--- a/apps/website/src/server/apis/weather.ts
+++ b/apps/website/src/server/apis/weather.ts
@@ -109,7 +109,7 @@ export async function getWeather() {
   const weather = await getCurrentObservation(
     env.WEATHER_STATION_ID,
     true,
-    300, // Cache the raw station data for 300 seconds
+    60, // Cache the raw station data for 1 minute
   );
   const feelsLike = getFeelsLike(
     weather.imperial.temp,

--- a/apps/website/src/server/apis/weather.ts
+++ b/apps/website/src/server/apis/weather.ts
@@ -71,13 +71,11 @@ const currentObservationsSchema = (imperial: boolean) =>
 export async function getCurrentObservation<T extends boolean>(
   stationId: string,
   imperial: T,
-  cache?: number,
 ): Promise<CurrentObservation<T>> {
   invariant(env.WEATHER_API_KEY, "WEATHER_API_KEY is required");
 
   const response = await fetch(
     `https://api.weather.com/v2/pws/observations/current?stationId=${encodeURIComponent(stationId)}&format=json&units=${imperial ? "e" : "m"}&numericPrecision=decimal&apiKey=${encodeURIComponent(env.WEATHER_API_KEY)}`,
-    cache ? { cache: "force-cache", next: { revalidate: cache } } : {},
   );
 
   const json = await response.json();
@@ -106,11 +104,7 @@ export async function getWeather() {
   invariant(env.WEATHER_STATION_ID, "WEATHER_STATION_ID is required");
   invariant(env.WEATHER_API_KEY, "WEATHER_API_KEY is required");
 
-  const weather = await getCurrentObservation(
-    env.WEATHER_STATION_ID,
-    true,
-    60, // Cache the raw station data for 1 minute
-  );
+  const weather = await getCurrentObservation(env.WEATHER_STATION_ID, true);
   const feelsLike = getFeelsLike(
     weather.imperial.temp,
     weather.imperial.heatIndex,


### PR DESCRIPTION
## Describe your changes

Based on what was highlighted in #1186, this adds a new header to help us better understand when responses were actually generated and entered into the cache, and also replaces the `stale-while-revalidate` directive with a `must-revalidate` directive to hopefully avoid invalid stale responses ever being sent.

## Notes for testing your change

`X-Generated-At` header present in responses, `must-revalidate` directive present in cache header in responses.