### PR TITLE
Add "Did you know" facts to ambassador pages

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -27,7 +27,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@alveusgg/data": "0.59.0",
+    "@alveusgg/data": "0.60.0",
     "@alveusgg/database": "workspace:*",
     "@auth/prisma-adapter": "^2.9.1",
     "@aws-sdk/client-s3": "^3.817.0",

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -261,22 +261,22 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
 
       <div className="relative">
         <Section
-          className="min-h-[85vh] pt-64 md:pt-0"
+          className="min-h-[85vh] pt-64 lg:pt-0"
           containerClassName="flex flex-wrap"
         >
-          <div className="absolute inset-x-0 top-0 h-64 w-full md:bottom-0 md:h-full md:w-1/2">
+          <div className="absolute inset-x-0 top-0 h-64 w-full lg:bottom-0 lg:h-full lg:w-1/2">
             <Image
               src={images[0].src}
               alt={images[0].alt}
               placeholder="blur"
-              className="absolute inset-x-0 top-0 size-full object-cover md:sticky md:h-screen md:max-h-full"
+              className="absolute inset-x-0 top-0 size-full object-cover lg:sticky lg:h-screen lg:max-h-full"
               style={{ objectPosition: images[0].position }}
             />
           </div>
 
-          <div className="basis-full md:basis-1/2" />
+          <div className="basis-full lg:basis-1/2" />
 
-          <div className="flex basis-full flex-col py-4 md:max-w-1/2 md:basis-1/2 md:px-8 md:pt-8">
+          <div className="flex basis-full flex-col py-4 lg:max-w-1/2 lg:basis-1/2 lg:px-8 lg:pt-8">
             <Heading className="text-5xl">{ambassador.name}</Heading>
             {!!ambassador.alternate.length && (
               <p className="-mt-1 mb-2 text-lg text-alveus-green-700 italic">
@@ -292,7 +292,7 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
               <p className="my-2">{ambassador.mission}</p>
             </div>
 
-            <dl className="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-auto-2 md:grid-cols-1 lg:grid-cols-auto-2">
+            <dl className="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-auto-2 lg:grid-cols-auto-2">
               {stats.map((item) => {
                 const nested = Array.isArray(item);
                 const items = nested ? item : [item];
@@ -302,7 +302,7 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
                     className={classes(
                       "contents",
                       nested &&
-                        "xl:col-span-full xl:grid xl:grid-cols-auto-4 xl:gap-4",
+                        "col-span-full grid-cols-auto-4 gap-4 md:grid lg:contents xl:grid",
                     )}
                   >
                     {items.map(({ title, value }, idx) => (
@@ -310,7 +310,9 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
                         <div
                           className={classes(
                             "col-span-full h-px bg-alveus-green opacity-10",
-                            nested && idx % 2 !== 0 && "xl:hidden",
+                            nested &&
+                              idx % 2 !== 0 &&
+                              "md:hidden lg:block xl:hidden",
                           )}
                         />
                         <dt className="self-center text-2xl font-bold">
@@ -341,7 +343,7 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
               items={carousel}
               auto={null}
               className="my-6"
-              itemClassName="basis-1/2 md:basis-full lg:basis-1/2 xl:basis-1/3 p-2 2xl:p-4"
+              itemClassName="basis-1/2 md:basis-1/3 lg:basis-1/2 xl:basis-1/3 p-2 2xl:p-4"
             />
 
             {ambassador.plush &&

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -96,20 +96,21 @@ const getStats = (ambassador: Ambassador): Stats => {
     {
       title: "Species Lifespan",
       value: (
-        <>
+        <div className="flex flex-col flex-nowrap gap-x-4 gap-y-2 md:flex-row md:items-center lg:flex-col lg:items-start xl:flex-row xl:items-center">
           <p>
             Wild:{" "}
             {species.lifespan.wild
               ? `${stringifyLifespan(species.lifespan.wild)} years`
               : "Unknown"}
           </p>
+          <div className="hidden h-4 w-px bg-alveus-green opacity-75 md:block lg:hidden xl:block" />
           <p>
             Captivity:{" "}
             {species.lifespan.captivity
               ? `${stringifyLifespan(species.lifespan.captivity)} years`
               : "Unknown"}
           </p>
-        </>
+        </div>
       ),
     },
     [

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -331,12 +331,12 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
             </dl>
 
             {ambassador.species === "bullfrogAfrican" && (
-              <Box dark className="my-6 space-y-2 p-4">
+              <Box dark className="my-6 flex flex-col gap-2 p-4">
                 <Heading
                   level={2}
                   id="did-you-know"
                   link
-                  className="mt-0 text-2xl"
+                  className="my-0 scroll-mt-6 text-2xl"
                 >
                   Did you know?
                 </Heading>
@@ -359,7 +359,7 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
                       key={aq.episode}
                       episode={aq}
                       ambassador={ambassadorKey}
-                      className="mt-4"
+                      className="mt-2 hover:translate-y-1"
                     />
                   ))}
               </Box>

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -34,6 +34,7 @@ import { convertToSlug } from "@/utils/slugs";
 import { camelToKebab, kebabToCamel } from "@/utils/string-case";
 
 import AnimalQuest from "@/components/content/AnimalQuest";
+import Box from "@/components/content/Box";
 import Carousel from "@/components/content/Carousel";
 import Heading from "@/components/content/Heading";
 import Link from "@/components/content/Link";
@@ -328,6 +329,31 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
                 );
               })}
             </dl>
+
+            {ambassador.species === "bullfrogAfrican" && (
+              <Box dark className="my-6 space-y-2 p-4">
+                <Heading
+                  level={2}
+                  id="did-you-know"
+                  link
+                  className="mt-0 text-2xl"
+                >
+                  Did you know?
+                </Heading>
+                <p className="text-lg">
+                  African Bullfrogs, like many other amphibians, have
+                  semipermeable skin that allows them to absorb water and
+                  oxygen. This adaptation is super important to allow them to
+                  drink and breathe while they&apos;re underwater or buried in
+                  the mud.
+                </p>
+                <p className="text-lg">
+                  Unfortunately, this also means that they can absorb any
+                  harmful chemicals in their environment, which is why it is so
+                  important to keep pollution and litter out of our waterways!
+                </p>
+              </Box>
+            )}
 
             {animalQuest &&
               animalQuest.map((aq) => (

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -330,7 +330,7 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
               })}
             </dl>
 
-            {ambassador.species === "bullfrogAfrican" && (
+            {ambassador.fact ? (
               <Box dark className="my-6 flex flex-col gap-2 p-4">
                 <Heading
                   level={2}
@@ -340,29 +340,31 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
                 >
                   Did you know?
                 </Heading>
-                <p className="text-lg">
-                  African Bullfrogs, like many other amphibians, have
-                  semipermeable skin that allows them to absorb water and
-                  oxygen. This adaptation is super important to allow them to
-                  drink and breathe while they&apos;re underwater or buried in
-                  the mud.
-                </p>
-                <p className="text-lg">
-                  Unfortunately, this also means that they can absorb any
-                  harmful chemicals in their environment, which is why it is so
-                  important to keep pollution and litter out of our waterways!
-                </p>
 
-                {animalQuest &&
-                  animalQuest.map((aq) => (
-                    <AnimalQuest
-                      key={aq.episode}
-                      episode={aq}
-                      ambassador={ambassadorKey}
-                      className="mt-2 hover:translate-y-1"
-                    />
-                  ))}
+                {ambassador.fact.split("\n\n").map((fact, idx) => (
+                  <p key={idx} className="text-lg">
+                    {fact}
+                  </p>
+                ))}
+
+                {animalQuest?.map((aq) => (
+                  <AnimalQuest
+                    key={aq.episode}
+                    episode={aq}
+                    ambassador={ambassadorKey}
+                    className="mt-2 hover:translate-y-1"
+                  />
+                ))}
               </Box>
+            ) : (
+              animalQuest?.map((aq) => (
+                <AnimalQuest
+                  key={aq.episode}
+                  episode={aq}
+                  ambassador={ambassadorKey}
+                  className="my-6"
+                />
+              ))
             )}
 
             <Carousel

--- a/apps/website/src/pages/ambassadors/[ambassadorName].tsx
+++ b/apps/website/src/pages/ambassadors/[ambassadorName].tsx
@@ -352,18 +352,18 @@ const AmbassadorPage: NextPage<AmbassadorPageProps> = ({
                   harmful chemicals in their environment, which is why it is so
                   important to keep pollution and litter out of our waterways!
                 </p>
+
+                {animalQuest &&
+                  animalQuest.map((aq) => (
+                    <AnimalQuest
+                      key={aq.episode}
+                      episode={aq}
+                      ambassador={ambassadorKey}
+                      className="mt-4"
+                    />
+                  ))}
               </Box>
             )}
-
-            {animalQuest &&
-              animalQuest.map((aq) => (
-                <AnimalQuest
-                  key={aq.episode}
-                  episode={aq}
-                  ambassador={ambassadorKey}
-                  className="my-6"
-                />
-              ))}
 
             <Carousel
               id={photoswipe}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
   apps/website:
     dependencies:
       '@alveusgg/data':
-        specifier: 0.59.0
-        version: 0.59.0(tailwindcss@4.1.7)(zod@3.25.32)
+        specifier: 0.60.0
+        version: 0.60.0(tailwindcss@4.1.7)(zod@3.25.32)
       '@alveusgg/database':
         specifier: workspace:*
         version: link:../database
@@ -416,14 +416,11 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@alveusgg/data@0.59.0':
-    resolution: {integrity: sha512-tesO6cqgqg2lN1EMHOOtRLeEv9I+jFVfqJgPrIc7P2FTizl69Vi/Vkmi+MbUMVS0Ug47KnMV4KUFv4w9xRkstQ==, tarball: https://npm.pkg.github.com/download/@alveusgg/data/0.59.0/f8c6516b9a03b22d8807d9f81f6633735e5cd915}
+  '@alveusgg/data@0.60.0':
+    resolution: {integrity: sha512-f7fZoxs2LdD7ezen5SexFqHT4gF+Jm6j4gajmPpoGpOebQbRtN5s+ZlB/VUiOPmZEivrgAB99F9IK20AQJwVAA==, tarball: https://npm.pkg.github.com/download/@alveusgg/data/0.60.0/64f0e320cf1b7138492b6e935d02473e19b8a3c4}
     peerDependencies:
       tailwindcss: ^4.0.0
       zod: ^3.0.0
-    peerDependenciesMeta:
-      tailwindcss:
-        optional: true
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -6568,11 +6565,10 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@alveusgg/data@0.59.0(tailwindcss@4.1.7)(zod@3.25.32)':
+  '@alveusgg/data@0.60.0(tailwindcss@4.1.7)(zod@3.25.32)':
     dependencies:
-      zod: 3.25.32
-    optionalDependencies:
       tailwindcss: 4.1.7
+      zod: 3.25.32
 
   '@ampproject/remapping@2.3.0':
     dependencies:


### PR DESCRIPTION
## Describe your changes

cc https://github.com/alveusgg/data/pull/152

Tweaks the layout of the stats section on the ambassador pages to take up less vertical space by having nested stats at certain breakpoints. Adds a new "Did you know" fact box to ambassadors where we have a fact stored in the data repo for them.

While not exactly the original suggestion, I believe that this resolves #289.

## Notes for testing your change

Layout of ambassador stats looks good across all viewports. Fact card renders on ambassadors with a fact only. Animal quest CTA renders inside fact card for ambassadors with a fact. Animal quest CTA continues to render as normal on ambassadors without a fact.