### PR TITLE
Fix ESLint import-x unresolved errors in VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you aren't working on features related to Twitch authentication, you can set 
 - Learn more about the stack at [Create T3 App - Introduction](https://create.t3.gg/en/introduction)
 - You can use the Prisma Studio to view your database. Launch it with `pnpm prisma studio`
 - You can access a direct MySQL CLI to the database with `docker compose exec db sh -c 'MYSQL_PWD=$MYSQL_ROOT_PASSWORD mysql alveusgg'`
-- If you're using VSCode, add `"typescript.tsdk": "node_modules/typescript/lib"` to `.vscode/settings.json` to ensure you're using the correct TypeScript version
+- If you're using VSCode, add `"typescript.tsdk": "node_modules/typescript/lib"` + `"eslint.workingDirectories": [{ "pattern": "apps/*" }]` to `.vscode/settings.json` to ensure you're using the correct TypeScript version + ESLint working directories
 
 ### Generate secrets
 

--- a/apps/chatbot/eslint.config.js
+++ b/apps/chatbot/eslint.config.js
@@ -3,8 +3,7 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import prettiereslint from "eslint-config-prettier";
-
-import importXPlugin from "eslint-plugin-import-x";
+import { flatConfigs as importXPluginConfigs } from "eslint-plugin-import-x";
 
 export default tseslint.config(
   {
@@ -25,10 +24,10 @@ export default tseslint.config(
       reportUnusedDisableDirectives: true,
     },
   },
-  importXPlugin.flatConfigs.recommended,
-  importXPlugin.flatConfigs.typescript,
+  importXPluginConfigs.recommended,
+  importXPluginConfigs.typescript,
   {
-    name: "import-x/order",
+    name: "import-x/custom",
     rules: {
       "import-x/order": [
         "warn",
@@ -42,6 +41,13 @@ export default tseslint.config(
           ],
         },
       ],
+    },
+    settings: {
+      "import-x/resolver": {
+        typescript: {
+          project: import.meta.dirname,
+        },
+      },
     },
   },
   {

--- a/apps/website/eslint.config.js
+++ b/apps/website/eslint.config.js
@@ -37,7 +37,7 @@ export default tseslint.config(
   importXPluginConfigs.recommended,
   importXPluginConfigs.typescript,
   {
-    name: "import-x/order",
+    name: "import-x/custom",
     rules: {
       "import-x/order": [
         "warn",
@@ -51,6 +51,13 @@ export default tseslint.config(
           ],
         },
       ],
+    },
+    settings: {
+      "import-x/resolver": {
+        typescript: {
+          project: import.meta.dirname,
+        },
+      },
     },
   },
   {


### PR DESCRIPTION
## Describe your changes

Even though VSCode seems to be running ESLint from the correct sub-directories, the import-x resolver was getting confused about which tsconfig.json to use I think? Either way, explicitly setting the correct project directory for the resolver in each sub-directory's ESLint config has finally fixed imports resolving correctly for me in VSCode.

## Notes for testing your change

I've been using `apps/website/src/components/Consent.tsx` and `apps/chatbot/src/db/users.ts` open at the same time to test. When in doubt, `Cmd+Shift+P` > `>Developer: Restart Extension Host` + `>ESLint: Restart ESLint Server`.
