### PR TITLE
Revert @headlessui/react upgrade to v2.2.2

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -35,7 +35,7 @@
     "@bart-krakowski/get-week-info-polyfill": "^1.0.8",
     "@cloudflare/stream-react": "^1.9.2",
     "@fontsource/pt-sans": "^5.2.5",
-    "@headlessui/react": "^2.2.2",
+    "@headlessui/react": "^2.2.1",
     "@iframe-resizer/react": "^5.4.6",
     "@maplibre/maplibre-gl-geocoder": "^1.8.0",
     "@next/env": "^15.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: ^5.2.5
         version: 5.2.5
       '@headlessui/react':
-        specifier: ^2.2.2
-        version: 2.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^2.2.1
+        version: 2.2.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@iframe-resizer/react':
         specifier: ^5.4.6
         version: 5.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1249,8 +1249,8 @@ packages:
   '@formatjs/intl-localematcher@0.6.1':
     resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
 
-  '@headlessui/react@2.2.2':
-    resolution: {integrity: sha512-zbniWOYBQ8GHSUIOPY7BbdIn6PzUOq0z41RFrF30HbjsxG6Rrfk+6QulR8Kgf2Vwj2a/rE6i62q5vo+2gI5dJA==}
+  '@headlessui/react@2.2.1':
+    resolution: {integrity: sha512-daiUqVLae8CKVjEVT19P/izW0aGK0GNhMSAeMlrDebKmoVZHcRRwbxzgtnEadUVDXyBsWo9/UH4KHeniO+0tMg==}
     engines: {node: '>=10'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -7806,7 +7806,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@headlessui/react@2.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@headlessui/react@2.2.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@react-aria/focus': 3.20.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -7814,7 +7814,6 @@ snapshots:
       '@tanstack/react-virtual': 3.13.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      use-sync-external-store: 1.5.0(react@19.1.0)
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
## Describe your changes

No fix has been shipped for https://github.com/tailwindlabs/headlessui/issues/3701 in two weeks, so reverting this update to avoid continued impact to the site's menu UX.

Resolves #1183.

## Notes for testing your change

Menus no longer stay open when another menu is clicked on.
