### PR TITLE
Add useful links + random ambassador to 404 page

### DIFF
--- a/apps/website/src/pages/404.tsx
+++ b/apps/website/src/pages/404.tsx
@@ -1,8 +1,25 @@
 import { type NextPage } from "next";
 
 import Heading from "@/components/content/Heading";
+import Link from "@/components/content/Link";
 import Meta from "@/components/content/Meta";
 import Section from "@/components/content/Section";
+
+import IconArrowRight from "@/icons/IconArrowRight";
+
+const CustomLink = ({
+  children,
+  ...props
+}: Omit<React.ComponentProps<typeof Link>, "custom">) => (
+  <Link
+    {...props}
+    custom
+    className="text-alveus-green hover:text-alveus-green-900 hover:underline transition-colors group text-shadow-sm py-1 text-lg"
+  >
+    {children}
+    <IconArrowRight className="inline-block size-4 opacity-0 -ml-4 mr-8 group-hover:ml-1 group-hover:mr-3 group-hover:opacity-100 transition-[margin,opacity] drop-shadow-sm" />
+  </Link>
+);
 
 const NotFound: NextPage = () => {
   return (
@@ -15,9 +32,48 @@ const NotFound: NextPage = () => {
       {/* Nav background */}
       <div className="-mt-40 hidden h-40 bg-alveus-green-900 lg:block" />
 
+      <Section dark className="py-8">
+        <Heading className="text-center">404 - Page Not Found</Heading>
+      </Section>
+
       {/* Grow the last section to cover the page */}
       <Section className="grow">
-        <Heading>404 - Page Not Found</Heading>
+        <Heading level={-1} className="mt-0">
+          Oops!
+        </Heading>
+
+        <p className="mb-6 text-lg text-balance">
+          Sorry, the page you are looking for does not exist. It may have been
+          removed, or you may have mistyped the URL.
+        </p>
+
+        <p className="mb-2 text-sm text-balance text-alveus-green">
+          Here are some links to help you find what you&apos;re looking for:
+        </p>
+
+        <ul className="flex max-md:flex-col flex-wrap">
+          <li>
+            <CustomLink href="/">Home</CustomLink>
+          </li>
+          <li>
+            <CustomLink href="/live">Watch Live Cams</CustomLink>
+          </li>
+          <li>
+            <CustomLink href="/ambassadors">Meet our Ambassadors</CustomLink>
+          </li>
+          <li>
+            <CustomLink href="/animal-quest">Watch Animal Quest</CustomLink>
+          </li>
+          <li>
+            <CustomLink href="/updates">Check the Schedule</CustomLink>
+          </li>
+          <li>
+            <CustomLink href="/donate">Donate to Alveus</CustomLink>
+          </li>
+          <li>
+            <CustomLink href="/about/alveus">About Alveus</CustomLink>
+          </li>
+        </ul>
       </Section>
     </>
   );

--- a/apps/website/src/pages/404.tsx
+++ b/apps/website/src/pages/404.tsx
@@ -1,6 +1,6 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import ambassadors from "@alveusgg/data/build/ambassadors/core";
 import {
@@ -14,6 +14,7 @@ import {
 } from "@alveusgg/data/build/ambassadors/images";
 import { getSpecies } from "@alveusgg/data/build/ambassadors/species";
 
+import { classes } from "@/utils/classes";
 import { typeSafeObjectKeys } from "@/utils/helpers";
 import { camelToKebab } from "@/utils/string-case";
 
@@ -24,13 +25,18 @@ import Section from "@/components/content/Section";
 
 import IconArrowRight from "@/icons/IconArrowRight";
 
+import showAndTellPeepo from "@/assets/show-and-tell/peepo.png";
+
 const useRandomAmbassador = () => {
   const [key, setKey] = useState<ActiveAmbassadorKey | null>(null);
-  useEffect(() => {
+  const pick = useCallback(() => {
     const keys = typeSafeObjectKeys(ambassadors).filter(isActiveAmbassadorKey);
     const randomIndex = Math.floor(Math.random() * keys.length);
     setKey(keys[randomIndex]!);
   }, []);
+  useEffect(() => {
+    pick();
+  }, [pick]);
 
   return useMemo(() => {
     if (!key) return {};
@@ -47,6 +53,7 @@ const useRandomAmbassador = () => {
       ambassador,
       species,
       icon,
+      pick,
     };
   }, [key]);
 };
@@ -66,7 +73,7 @@ const CustomLink = ({
 );
 
 const NotFound: NextPage = () => {
-  const { slug, ambassador, species, icon } = useRandomAmbassador();
+  const { slug, ambassador, species, icon, pick } = useRandomAmbassador();
 
   return (
     <>
@@ -144,15 +151,18 @@ const NotFound: NextPage = () => {
                 </p>
               </div>
 
-              {icon && (
-                <Image
-                  src={icon.src}
-                  alt={icon.alt}
-                  width={100}
-                  height={100}
-                  className="h-24 w-24 object-cover drop-shadow-lg -mt-2"
-                />
-              )}
+              <Image
+                src={(icon ?? showAndTellPeepo).src}
+                alt=""
+                width={100}
+                height={100}
+                className={classes(
+                  "h-24 w-auto drop-shadow-lg -mt-2 cursor-pointer",
+                  !icon && "opacity-50",
+                )}
+                onClick={pick}
+                title="Click to meet another ambassador"
+              />
             </div>
 
             <p>

--- a/apps/website/src/pages/404.tsx
+++ b/apps/website/src/pages/404.tsx
@@ -1,4 +1,21 @@
 import { type NextPage } from "next";
+import Image from "next/image";
+import { useEffect, useMemo, useState } from "react";
+
+import ambassadors from "@alveusgg/data/build/ambassadors/core";
+import {
+  type ActiveAmbassadorKey,
+  isActiveAmbassadorKey,
+} from "@alveusgg/data/build/ambassadors/filters";
+import {
+  getAmbassadorBadgeImage,
+  getAmbassadorEmoteImage,
+  getAmbassadorIconImage,
+} from "@alveusgg/data/build/ambassadors/images";
+import { getSpecies } from "@alveusgg/data/build/ambassadors/species";
+
+import { typeSafeObjectKeys } from "@/utils/helpers";
+import { camelToKebab } from "@/utils/string-case";
 
 import Heading from "@/components/content/Heading";
 import Link from "@/components/content/Link";
@@ -6,6 +23,33 @@ import Meta from "@/components/content/Meta";
 import Section from "@/components/content/Section";
 
 import IconArrowRight from "@/icons/IconArrowRight";
+
+const useRandomAmbassador = () => {
+  const [key, setKey] = useState<ActiveAmbassadorKey | null>(null);
+  useEffect(() => {
+    const keys = typeSafeObjectKeys(ambassadors).filter(isActiveAmbassadorKey);
+    const randomIndex = Math.floor(Math.random() * keys.length);
+    setKey(keys[randomIndex]!);
+  }, []);
+
+  return useMemo(() => {
+    if (!key) return {};
+
+    const ambassador = ambassadors[key];
+    const species = getSpecies(ambassador.species);
+    const icon =
+      getAmbassadorIconImage(key) ??
+      getAmbassadorBadgeImage(key) ??
+      getAmbassadorEmoteImage(key);
+
+    return {
+      slug: camelToKebab(key),
+      ambassador,
+      species,
+      icon,
+    };
+  }, [key]);
+};
 
 const CustomLink = ({
   children,
@@ -22,6 +66,8 @@ const CustomLink = ({
 );
 
 const NotFound: NextPage = () => {
+  const { slug, ambassador, species, icon } = useRandomAmbassador();
+
   return (
     <>
       <Meta
@@ -37,43 +83,89 @@ const NotFound: NextPage = () => {
       </Section>
 
       {/* Grow the last section to cover the page */}
-      <Section className="grow">
-        <Heading level={-1} className="mt-0">
-          Oops!
-        </Heading>
+      <Section
+        className="grow pt-12"
+        containerClassName="grid grid-cols-1 gap-8 lg:grid-cols-2"
+      >
+        <div>
+          {/* Align the heading height for the two columns */}
+          <p className="text-sm">&zwnj;</p>
 
-        <p className="mb-6 text-lg text-balance">
-          Sorry, the page you are looking for does not exist. It may have been
-          removed, or you may have mistyped the URL.
-        </p>
+          <Heading level={-1} className="mt-0">
+            Oops!
+          </Heading>
 
-        <p className="mb-2 text-sm text-balance text-alveus-green">
-          Here are some links to help you find what you&apos;re looking for:
-        </p>
+          <p className="mb-6 text-lg text-balance">
+            Sorry, the page you are looking for does not exist. It may have been
+            removed, or you may have mistyped the URL.
+          </p>
 
-        <ul className="flex max-md:flex-col flex-wrap">
-          <li>
-            <CustomLink href="/">Home</CustomLink>
-          </li>
-          <li>
-            <CustomLink href="/live">Watch Live Cams</CustomLink>
-          </li>
-          <li>
-            <CustomLink href="/ambassadors">Meet our Ambassadors</CustomLink>
-          </li>
-          <li>
-            <CustomLink href="/animal-quest">Watch Animal Quest</CustomLink>
-          </li>
-          <li>
-            <CustomLink href="/updates">Check the Schedule</CustomLink>
-          </li>
-          <li>
-            <CustomLink href="/donate">Donate to Alveus</CustomLink>
-          </li>
-          <li>
-            <CustomLink href="/about/alveus">About Alveus</CustomLink>
-          </li>
-        </ul>
+          <p className="mb-2 text-sm text-balance text-alveus-green">
+            Here are some links to help you find what you&apos;re looking for:
+          </p>
+
+          <ul className="flex max-md:flex-col flex-wrap">
+            <li>
+              <CustomLink href="/">Home</CustomLink>
+            </li>
+            <li>
+              <CustomLink href="/live">Watch Live Cams</CustomLink>
+            </li>
+            <li>
+              <CustomLink href="/ambassadors">Meet our Ambassadors</CustomLink>
+            </li>
+            <li>
+              <CustomLink href="/animal-quest">Watch Animal Quest</CustomLink>
+            </li>
+            <li>
+              <CustomLink href="/updates">Check the Schedule</CustomLink>
+            </li>
+            <li>
+              <CustomLink href="/donate">Donate to Alveus</CustomLink>
+            </li>
+            <li>
+              <CustomLink href="/about/alveus">About Alveus</CustomLink>
+            </li>
+          </ul>
+        </div>
+
+        {ambassador && species && (
+          <div>
+            <div className="flex justify-between items-start gap-4 mb-2">
+              <div>
+                <p className="text-sm">While you&apos;re here...</p>
+
+                <Heading level={-1} className="my-0">
+                  Meet {ambassador.name}!
+                </Heading>
+
+                <p className="text-sm text-alveus-green">
+                  {species.name} ({species.scientificName})
+                </p>
+              </div>
+
+              {icon && (
+                <Image
+                  src={icon.src}
+                  alt={icon.alt}
+                  width={100}
+                  height={100}
+                  className="h-24 w-24 object-cover drop-shadow-lg -mt-2"
+                />
+              )}
+            </div>
+
+            <p>
+              {ambassador.story} {ambassador.mission}
+            </p>
+
+            <p className="mt-4">
+              <CustomLink href={`/ambassadors/${slug}`}>
+                Learn more about {ambassador.name}
+              </CustomLink>
+            </p>
+          </div>
+        )}
       </Section>
     </>
   );


### PR DESCRIPTION
## Describe your changes

Improves the appeal + utility of the 404 page for folks that accidentally land there, including a bunch of useful links to our most important pages. Also, adds info about a random ambassador for a little bit of fun on the page.

## Notes for testing your change

Links are all correct, responsive across all viewports.