### PR TITLE
Set force-dynamic for /api/stream/youtube/:channel

### DIFF
--- a/apps/website/src/app/api/stream/youtube/[channel]/route.ts
+++ b/apps/website/src/app/api/stream/youtube/[channel]/route.ts
@@ -10,6 +10,7 @@ type Params = {
 };
 
 // Only allow known channels
+export const dynamic = "force-dynamic";
 export const dynamicParams = false;
 export function generateStaticParams(): Params[] {
   return typeSafeObjectKeys(channels).map((channel) => ({ channel }));


### PR DESCRIPTION
## Describe your changes

Fixes #1217.

## Notes for testing your change

`/api/stream/youtube/alveus` returns a cache `HIT` with a given `X-Generated-At` that does not change for 5 minutes. After 5 minutes, a new response should be returned with a new `X-Generated-At` that should then be cached again for 5 minutes.
