### PR TITLE
Refactor Twitch scopes logic + add PTZ role/permission

### DIFF
--- a/apps/website/src/components/admin/twitch/ProvideAuth.tsx
+++ b/apps/website/src/components/admin/twitch/ProvideAuth.tsx
@@ -1,6 +1,6 @@
 import { signIn } from "next-auth/react";
 
-import { botScopes, defaultScopes, isScope, scopeLabels } from "@/data/twitch";
+import { isScope, scopeGroups, scopeLabels } from "@/data/twitch";
 
 import { trpc } from "@/utils/trpc";
 
@@ -51,7 +51,10 @@ export function ProvideAuth() {
             "twitch",
             { redirect: false },
             {
-              scope: [...defaultScopes, ...botScopes].join(" "),
+              scope: [
+                ...scopeGroups.default.scopes,
+                ...scopeGroups.api.scopes,
+              ].join(" "),
             },
           )
         }

--- a/apps/website/src/data/permissions.ts
+++ b/apps/website/src/data/permissions.ts
@@ -36,6 +36,9 @@ export const permissions = {
   manageCalendarEvents: {
     requiredRole: "calendarEvents",
   },
+  managePTZControls: {
+    requiredRole: "ptzControl",
+  },
 } as const satisfies Record<string, PermissionConfig>;
 
 export function checkRolesGivePermission(

--- a/apps/website/src/data/twitch.ts
+++ b/apps/website/src/data/twitch.ts
@@ -22,22 +22,40 @@ export type Scope = keyof typeof scopeLabels;
 
 export const isScope = (scope: string): scope is Scope => scope in scopeLabels;
 
-export const defaultScopes = [
-  "openid",
-  "user:read:email",
-  "user:read:follows",
-  "user:read:subscriptions",
-] as const satisfies Scope[];
+export const scopeGroups = {
+  default: {
+    label: "Default",
+    scopes: [
+      "openid",
+      "user:read:email",
+      "user:read:follows",
+      "user:read:subscriptions",
+    ],
+  },
+  api: {
+    label: "Broadcaster/moderator API access",
+    scopes: [
+      "chat:edit",
+      "chat:read",
+      "moderator:read:followers",
+      "channel:read:charity",
+      "channel:read:subscriptions",
+      "channel:read:vips",
+      "channel:manage:schedule",
+    ],
+  },
+} as const satisfies Record<
+  string,
+  {
+    label: string;
+    scopes: Scope[];
+  }
+>;
 
-export const botScopes = [
-  "chat:edit",
-  "chat:read",
-  "moderator:read:followers",
-  "channel:read:charity",
-  "channel:read:subscriptions",
-  "channel:read:vips",
-  "channel:manage:schedule",
-] as const satisfies Scope[];
+export type ScopeGroup = keyof typeof scopeGroups;
+
+export const isScopeGroup = (group: string): group is ScopeGroup =>
+  group in scopeGroups;
 
 interface Channel {
   username: string;

--- a/apps/website/src/data/user-roles.ts
+++ b/apps/website/src/data/user-roles.ts
@@ -34,6 +34,10 @@ export const userRoles = {
     label: "Calendar Events",
     description: "Can manage calendar events",
   },
+  ptzControl: {
+    label: "PTZ Control",
+    description: "Can manage live cam controls",
+  },
 } as const satisfies Record<string, UserRoleConfig>;
 
 export function isValidUserRole(role: string) {

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -7,8 +7,6 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
-import { scopeGroups } from "@/data/twitch";
-
 import { unregisterServiceWorker } from "@/utils/sw";
 import { trpc } from "@/utils/trpc";
 
@@ -31,15 +29,13 @@ const SessionChecker = ({ children }: { children: React.ReactNode }) => {
     if (!data?.error) return;
 
     // Some accounts require additional auth scopes
-    if (data.error === "Additional scopes required") {
+    const additional = data.error.match(/^Additional scopes required: (.+)$/);
+    if (additional?.[1]) {
       signIn(
         "twitch",
         { callbackUrl: window.location.href },
         {
-          scope: [
-            ...scopeGroups.default.scopes,
-            ...scopeGroups.api.scopes,
-          ].join(" "),
+          scope: additional[1],
         },
       );
       return;

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -7,7 +7,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
-import { botScopes, defaultScopes } from "@/data/twitch";
+import { scopeGroups } from "@/data/twitch";
 
 import { unregisterServiceWorker } from "@/utils/sw";
 import { trpc } from "@/utils/trpc";
@@ -35,7 +35,12 @@ const SessionChecker = ({ children }: { children: React.ReactNode }) => {
       signIn(
         "twitch",
         { callbackUrl: window.location.href },
-        { scope: [...defaultScopes, ...botScopes].join(" ") },
+        {
+          scope: [
+            ...scopeGroups.default.scopes,
+            ...scopeGroups.api.scopes,
+          ].join(" "),
+        },
       );
       return;
     }

--- a/apps/website/src/pages/api/auth/[...nextauth].ts
+++ b/apps/website/src/pages/api/auth/[...nextauth].ts
@@ -13,7 +13,7 @@ import {
   refreshAccessToken,
 } from "@/server/utils/oauth2";
 
-import { botScopes, defaultScopes } from "@/data/twitch";
+import { scopeGroups } from "@/data/twitch";
 
 import invariant from "@/utils/invariant";
 
@@ -24,7 +24,7 @@ const twitchProvider = TwitchProvider({
   clientSecret: env.TWITCH_CLIENT_SECRET,
   authorization: {
     params: {
-      scope: defaultScopes.join(" "),
+      scope: scopeGroups.default.scopes.join(" "),
     },
   },
 });
@@ -93,7 +93,9 @@ export const authOptions: NextAuthOptions = {
         account.twitchChannelModerator.length
       ) {
         const scopes = new Set(account.scope?.split(" "));
-        const missingScopes = botScopes.filter((scope) => !scopes.has(scope));
+        const missingScopes = scopeGroups.api.scopes.filter(
+          (scope) => !scopes.has(scope),
+        );
         if (missingScopes.length > 0) {
           return {
             expires: new Date(0).toISOString(),

--- a/apps/website/src/pages/api/auth/[...nextauth].ts
+++ b/apps/website/src/pages/api/auth/[...nextauth].ts
@@ -17,6 +17,21 @@ import { scopeGroups } from "@/data/twitch";
 
 import invariant from "@/utils/invariant";
 
+const requireScopes = (account: { scope: string | null }, scopes: string[]) => {
+  const accountScopes = new Set(account.scope?.split(" "));
+  const missingScopes = scopes.filter((scope) => !accountScopes.has(scope));
+
+  if (missingScopes.length > 0) {
+    const allScopes = [...accountScopes, ...missingScopes].join(" ");
+    return {
+      expires: new Date(0).toISOString(),
+      error: `Additional scopes required: ${allScopes}`,
+    };
+  }
+
+  return null;
+};
+
 const adapter = PrismaAdapter(prisma);
 
 const twitchProvider = TwitchProvider({
@@ -92,16 +107,8 @@ export const authOptions: NextAuthOptions = {
         account.twitchChannelBroadcaster.length ||
         account.twitchChannelModerator.length
       ) {
-        const scopes = new Set(account.scope?.split(" "));
-        const missingScopes = scopeGroups.api.scopes.filter(
-          (scope) => !scopes.has(scope),
-        );
-        if (missingScopes.length > 0) {
-          return {
-            expires: new Date(0).toISOString(),
-            error: "Additional scopes required",
-          };
-        }
+        const err = requireScopes(account, scopeGroups.api.scopes);
+        if (err) return err;
       }
 
       // Include user.id on session


### PR DESCRIPTION
## Describe your changes

The way we handled Twitch scopes in code for a while now has been on my mind as something we should restructure to be more flexible, so this does that.

This also adds a new PTZ role/permission that might get used down the road to build out tooling directly in the website stack for controlling the live stream.

## Notes for testing your change

Auth continues to work for regular users, and for users that are tied to a Twitch channel defined in the admin panel.