### PR TITLE
Swap insects check for chinchillas in rounds overlay

### DIFF
--- a/apps/website/src/pages/stream/rounds.tsx
+++ b/apps/website/src/pages/stream/rounds.tsx
@@ -35,9 +35,9 @@ const checks: Record<string, Omit<Check, "status" | "description">> = {
     name: "Marmosets",
     icon: getAmbassadorImages("appa")[0],
   },
-  insects: {
-    name: "Insects",
-    icon: getAmbassadorImages("barbaraBakedBean")[0],
+  chinchillas: {
+    name: "Chinchillas",
+    icon: getAmbassadorImages("moomin")[0],
   },
   reptiles: {
     name: "Reptiles",


### PR DESCRIPTION
## Describe your changes

Insects have very limited cams, and can be checked as part of the reptiles check. Chinchillas, and the nut house as a whole, were missing from the previous list of checks.

## Notes for testing your change

Insects removed, chins added.
