### PR TITLE
Swap wolfdogs check for wolf hybrids in rounds overlay

### DIFF
--- a/apps/website/src/pages/stream/rounds.tsx
+++ b/apps/website/src/pages/stream/rounds.tsx
@@ -15,8 +15,8 @@ import roundsDayBackground from "@/assets/rounds/day.webm";
 import roundsNightBackground from "@/assets/rounds/night.webm";
 
 const checks: Record<string, Omit<Check, "status" | "description">> = {
-  wolfdogs: {
-    name: "Wolfdogs",
+  wolves: {
+    name: "Wolf Hybrids",
     icon: getAmbassadorImages("awa")[0],
   },
   foxes: {


### PR DESCRIPTION
## Describe your changes

Swaps the name for the check on screen to match up with the cam names + ambassador species for Awa + Akela. Updates the command to be easier to type (and match the new name).

## Notes for testing your change

Spelling correct.