### PR TITLE
Add GitHub repositories + website to system overview

### DIFF
--- a/apps/website/src/components/tech/Network.tsx
+++ b/apps/website/src/components/tech/Network.tsx
@@ -161,7 +161,7 @@ const NetworkNode = ({
       </p>
       <div className="my-auto">
         <p className="truncate text-alveus-green-900">{data.item.name}</p>
-        <p className="flex items-end gap-1 text-xs text-alveus-green-700">
+        <p className="flex items-center gap-1 text-xs text-alveus-green-700">
           <span
             className={classes(
               "shrink overflow-hidden text-ellipsis whitespace-nowrap",

--- a/apps/website/src/components/tech/Network.tsx
+++ b/apps/website/src/components/tech/Network.tsx
@@ -298,7 +298,6 @@ const tree = {
   nodeTypes: { network: Node },
   edgeType: NetworkEdge,
   nodeSize: { width: 176, height: 80 },
-  defaultZoom: 0.75,
 };
 
 const Network = () => (

--- a/apps/website/src/components/tech/Network.tsx
+++ b/apps/website/src/components/tech/Network.tsx
@@ -4,6 +4,7 @@ import {
   BaseEdge,
   EdgeLabelRenderer,
   type EdgeProps,
+  type ReactFlowInstance,
   getBezierPath,
   useNodes,
 } from "reactflow";
@@ -298,6 +299,23 @@ const tree = {
   nodeTypes: { network: Node },
   edgeType: NetworkEdge,
   nodeSize: { width: 176, height: 80 },
+  onInit: (instance: ReactFlowInstance) => {
+    // After the initial fit, vertically center on the first node
+    window.requestAnimationFrame(() => {
+      const nodes = instance.getNodes();
+
+      const firstNode = nodes[0];
+      if (!firstNode) return;
+
+      const centerX =
+        nodes.reduce((acc, node) => acc + node.position.x, 0) / nodes.length;
+
+      const viewport = instance.getViewport();
+      instance.setCenter(centerX, firstNode.position.y, {
+        zoom: viewport.zoom,
+      });
+    });
+  },
 };
 
 const Network = () => (

--- a/apps/website/src/components/tech/Network.tsx
+++ b/apps/website/src/components/tech/Network.tsx
@@ -94,7 +94,7 @@ const toTree = (items: NetworkItem[]): TreeNode<Data>[] =>
         ...item,
         description: item.model,
         eyebrow: nodeTypes[item.type].eyebrow,
-        container: nodeTypes[item.type].container,
+        container: classes("h-20 w-44", nodeTypes[item.type].container),
       },
     },
     children: "links" in item && item.links ? toTree(item.links) : [],

--- a/apps/website/src/components/tech/Node.tsx
+++ b/apps/website/src/components/tech/Node.tsx
@@ -6,13 +6,11 @@ import { classes } from "@/utils/classes";
 import IconExternal from "@/icons/IconExternal";
 
 export interface NodeData {
-  item: {
-    container: string;
-    eyebrow: { text: string; color: string };
-    name: string;
-    description?: string;
-    url?: string;
-  };
+  container: string;
+  eyebrow: { text: string; color: string };
+  name: string;
+  description?: string;
+  url?: string;
 }
 
 const Node = ({
@@ -32,24 +30,24 @@ const Node = ({
   }
 
   // If this node has a link, we need some extra props
-  const Element = data.item.url ? "a" : "div";
+  const Element = data.url ? "a" : "div";
   const linkProps = useMemo(
     () =>
-      data.item.url
+      data.url
         ? {
-            href: data.item.url,
+            href: data.url,
             target: "_blank",
             rel: "noopener noreferrer",
           }
         : {},
-    [data.item.url],
+    [data.url],
   );
 
   return (
     <Element
       className={classes(
         "group flex cursor-pointer flex-col rounded-xl border-2 bg-white px-2 py-1 hover:min-w-min hover:shadow-md focus:min-w-min focus:shadow-md",
-        data.item.container,
+        data.container,
       )}
       tabIndex={-1}
       {...linkProps}
@@ -69,18 +67,18 @@ const Node = ({
         />
       )}
 
-      <p className={classes("text-xs", data.item.eyebrow.color)}>
-        {data.item.eyebrow.text}
+      <p className={classes("text-xs", data.eyebrow.color)}>
+        {data.eyebrow.text}
       </p>
       <div className="my-auto">
-        {data.item.description && (
-          <p className="truncate text-alveus-green-900">{data.item.name}</p>
+        {data.description && (
+          <p className="truncate text-alveus-green-900">{data.name}</p>
         )}
 
         <p
           className={classes(
             "flex items-center gap-1",
-            data.item.description
+            data.description
               ? "text-xs text-alveus-green-700"
               : "text-alveus-green-900",
           )}
@@ -88,15 +86,13 @@ const Node = ({
           <span
             className={classes(
               "shrink overflow-hidden text-ellipsis whitespace-nowrap",
-              data.item.url && "group-hover:underline",
+              data.url && "group-hover:underline",
             )}
           >
-            {data.item.description || data.item.name}
+            {data.description || data.name}
           </span>
 
-          {data.item.url && (
-            <IconExternal className="shrink-0 grow-0" size={14} />
-          )}
+          {data.url && <IconExternal className="shrink-0 grow-0" size={14} />}
         </p>
       </div>
     </Element>

--- a/apps/website/src/components/tech/Node.tsx
+++ b/apps/website/src/components/tech/Node.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from "react";
+import { Handle, type NodeProps, Position, useEdges } from "reactflow";
+
+import { classes } from "@/utils/classes";
+
+import IconExternal from "@/icons/IconExternal";
+
+export interface NodeData {
+  item: {
+    container: string;
+    eyebrow: { text: string; color: string };
+    name: string;
+    description?: string;
+    url?: string;
+  };
+}
+
+const Node = ({
+  id,
+  data,
+  targetPosition = Position.Top,
+  sourcePosition = Position.Bottom,
+  isConnectable,
+}: NodeProps<NodeData>) => {
+  // Get the source and target edges
+  const edges = useEdges();
+  let targetEdge, sourceEdge;
+  for (const edge of edges) {
+    if (!targetEdge && edge.target === id) targetEdge = edge;
+    if (!sourceEdge && edge.source === id) sourceEdge = edge;
+    if (targetEdge && sourceEdge) break;
+  }
+
+  // If this node has a link, we need some extra props
+  const Element = data.item.url ? "a" : "div";
+  const linkProps = useMemo(
+    () =>
+      data.item.url
+        ? {
+            href: data.item.url,
+            target: "_blank",
+            rel: "noopener noreferrer",
+          }
+        : {},
+    [data.item.url],
+  );
+
+  return (
+    <Element
+      className={classes(
+        "group flex h-20 w-44 cursor-pointer flex-col rounded-xl border-2 bg-white px-2 py-1 hover:min-w-min hover:shadow-md focus:min-w-min focus:shadow-md",
+        data.item.container,
+      )}
+      tabIndex={-1}
+      {...linkProps}
+    >
+      {(targetEdge || isConnectable) && (
+        <Handle
+          type="target"
+          position={targetPosition}
+          isConnectable={isConnectable}
+        />
+      )}
+      {(sourceEdge || isConnectable) && (
+        <Handle
+          type="source"
+          position={sourcePosition}
+          isConnectable={isConnectable}
+        />
+      )}
+
+      <p className={classes("text-xs", data.item.eyebrow.color)}>
+        {data.item.eyebrow.text}
+      </p>
+      <div className="my-auto">
+        {data.item.description && (
+          <p className="truncate text-alveus-green-900">{data.item.name}</p>
+        )}
+
+        <p className="flex items-center gap-1 text-xs text-alveus-green-700">
+          <span
+            className={classes(
+              "shrink overflow-hidden text-ellipsis whitespace-nowrap",
+              data.item.url && "group-hover:underline",
+            )}
+          >
+            {data.item.description || data.item.name}
+          </span>
+
+          {data.item.url && (
+            <IconExternal className="shrink-0 grow-0" size={14} />
+          )}
+        </p>
+      </div>
+    </Element>
+  );
+};
+
+export default Node;

--- a/apps/website/src/components/tech/Node.tsx
+++ b/apps/website/src/components/tech/Node.tsx
@@ -48,7 +48,7 @@ const Node = ({
   return (
     <Element
       className={classes(
-        "group flex h-20 w-44 cursor-pointer flex-col rounded-xl border-2 bg-white px-2 py-1 hover:min-w-min hover:shadow-md focus:min-w-min focus:shadow-md",
+        "group flex cursor-pointer flex-col rounded-xl border-2 bg-white px-2 py-1 hover:min-w-min hover:shadow-md focus:min-w-min focus:shadow-md",
         data.item.container,
       )}
       tabIndex={-1}
@@ -77,7 +77,14 @@ const Node = ({
           <p className="truncate text-alveus-green-900">{data.item.name}</p>
         )}
 
-        <p className="flex items-center gap-1 text-xs text-alveus-green-700">
+        <p
+          className={classes(
+            "flex items-center gap-1",
+            data.item.description
+              ? "text-xs text-alveus-green-700"
+              : "text-alveus-green-900",
+          )}
+        >
           <span
             className={classes(
               "shrink overflow-hidden text-ellipsis whitespace-nowrap",

--- a/apps/website/src/components/tech/Node.tsx
+++ b/apps/website/src/components/tech/Node.tsx
@@ -58,8 +58,9 @@ const Node = ({
   return (
     <Element
       className={classes(
-        "group flex min-w-0 cursor-pointer flex-col rounded-xl border-2 bg-white px-2 py-1 shadow-sm transition-all hover:!min-w-[calc-size(min-content,size))] hover:min-w-min hover:shadow-lg focus:!min-w-[calc-size(min-content,size)] focus:min-w-min focus:shadow-lg",
+        "group flex min-w-0 flex-col rounded-xl border-2 bg-white px-2 py-1 shadow-sm transition-all hover:!min-w-[calc-size(min-content,size))] hover:min-w-min hover:shadow-lg focus:!min-w-[calc-size(min-content,size)] focus:min-w-min focus:shadow-lg",
         data.container,
+        data.url && "cursor-pointer",
       )}
       tabIndex={-1}
       {...linkProps}

--- a/apps/website/src/components/tech/Node.tsx
+++ b/apps/website/src/components/tech/Node.tsx
@@ -58,7 +58,7 @@ const Node = ({
   return (
     <Element
       className={classes(
-        "group flex cursor-pointer flex-col rounded-xl border-2 bg-white px-2 py-1 hover:min-w-min hover:shadow-md focus:min-w-min focus:shadow-md",
+        "group flex min-w-0 cursor-pointer flex-col rounded-xl border-2 bg-white px-2 py-1 shadow-sm transition-all hover:!min-w-[calc-size(min-content,size))] hover:min-w-min hover:shadow-lg focus:!min-w-[calc-size(min-content,size)] focus:min-w-min focus:shadow-lg",
         data.container,
       )}
       tabIndex={-1}

--- a/apps/website/src/components/tech/Node.tsx
+++ b/apps/website/src/components/tech/Node.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { Handle, type NodeProps, Position, useEdges } from "reactflow";
 
 import { classes } from "@/utils/classes";
@@ -43,6 +43,18 @@ const Node = ({
     [data.url],
   );
 
+  const handleRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+
+    // Get the current position of the node
+    const { offsetTop, offsetLeft } = node;
+
+    // Set an absolute position for the node
+    node.style.position = "absolute";
+    node.style.top = `${offsetTop}px`;
+    node.style.left = `${offsetLeft}px`;
+  }, []);
+
   return (
     <Element
       className={classes(
@@ -57,6 +69,8 @@ const Node = ({
           type="target"
           position={targetPosition}
           isConnectable={isConnectable}
+          ref={handleRef}
+          className="-z-10"
         />
       )}
       {(sourceEdge || isConnectable) && (
@@ -64,6 +78,8 @@ const Node = ({
           type="source"
           position={sourcePosition}
           isConnectable={isConnectable}
+          ref={handleRef}
+          className="-z-10"
         />
       )}
 

--- a/apps/website/src/components/tech/Overview.tsx
+++ b/apps/website/src/components/tech/Overview.tsx
@@ -7,11 +7,6 @@ import Tree, { type TreeNode } from "@/components/tech/Tree";
 
 import Node, { type NodeData } from "./Node";
 
-type Data = {
-  label: string;
-  item: Step;
-} & NodeData;
-
 const nodeTypes: {
   [k in Step["type"]]: {
     container: string;
@@ -49,8 +44,8 @@ const nodeTypes: {
 
 const toTree = (
   steps: Step | Step[],
-  cache?: Map<Step, TreeNode<Data>>,
-): TreeNode<Data>[] => {
+  cache?: Map<Step, TreeNode<NodeData>>,
+): TreeNode<NodeData>[] => {
   if (!cache) cache = new Map();
 
   return (Array.isArray(steps) ? steps : [steps]).map((step) => {
@@ -63,14 +58,13 @@ const toTree = (
       id: step.id,
       type: "overview",
       data: {
-        label: `${step.name} (${step.type})`,
-        item: {
-          ...step,
-          eyebrow: nodeTypes[step.type].eyebrow,
-          container: classes("h-20 w-48", nodeTypes[step.type].container),
-        },
+        container: classes("h-20 w-48", nodeTypes[step.type].container),
+        eyebrow: nodeTypes[step.type].eyebrow,
+        name: step.name,
+        description: step.description,
+        url: step.url,
       },
-      children: [] as TreeNode<Data>[],
+      children: [] as TreeNode<NodeData>[],
     };
     cache.set(step, tree);
 

--- a/apps/website/src/components/tech/Overview.tsx
+++ b/apps/website/src/components/tech/Overview.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Handle, type NodeProps, Position, useEdges } from "reactflow";
 
 import steps, { type Step } from "@/data/tech/overview";
@@ -6,6 +7,8 @@ import { classes } from "@/utils/classes";
 import { convertToSlug } from "@/utils/slugs";
 
 import Tree, { type TreeNode } from "@/components/tech/Tree";
+
+import IconExternal from "@/icons/IconExternal";
 
 interface Data {
   label: string;
@@ -94,13 +97,28 @@ const OverviewNode = ({
     if (targetEdge && sourceEdge) break;
   }
 
+  // If this node has a link, we need some extra props
+  const Element = data.step.link ? "a" : "div";
+  const linkProps = useMemo(
+    () =>
+      data.step.link
+        ? {
+            href: data.step.link,
+            target: "_blank",
+            rel: "noopener noreferrer",
+          }
+        : {},
+    [data.step.link],
+  );
+
   return (
-    <div
+    <Element
       className={classes(
         "group flex h-20 w-48 cursor-pointer flex-col rounded-xl border-2 bg-white px-2 py-1 hover:min-w-min hover:shadow-md focus:min-w-min focus:shadow-md",
         nodeTypes[data.step.type].container,
       )}
       tabIndex={-1}
+      {...linkProps}
     >
       {(targetEdge || isConnectable) && (
         <Handle
@@ -123,11 +141,17 @@ const OverviewNode = ({
         {nodeTypes[data.step.type].eyebrow.name}
       </p>
       <div className="my-auto">
-        <p className="truncate text-lg text-alveus-green-900">
-          {data.step.name}
+        <p className="flex items-center gap-1 truncate text-lg text-alveus-green-900">
+          <span className={classes(data.step.link && "group-hover:underline")}>
+            {data.step.name}
+          </span>
+
+          {data.step.link && (
+            <IconExternal className="shrink-0 grow-0" size={14} />
+          )}
         </p>
       </div>
-    </div>
+    </Element>
   );
 };
 

--- a/apps/website/src/components/tech/Overview.tsx
+++ b/apps/website/src/components/tech/Overview.tsx
@@ -60,6 +60,10 @@ const nodeTypes: {
     container: "border-green-700",
     eyebrow: { name: "Source", color: "text-green-700" },
   },
+  github: {
+    container: "border-alveus-green-700",
+    eyebrow: { name: "GitHub", color: "text-alveus-green-700" },
+  },
   service: {
     container: "border-blue-700",
     eyebrow: { name: "Service", color: "text-blue-700" },

--- a/apps/website/src/components/tech/Overview.tsx
+++ b/apps/website/src/components/tech/Overview.tsx
@@ -109,7 +109,6 @@ const tree = {
   nodeTypes: { overview: Node },
   nodeSize: { width: 192, height: 80 },
   nodeSpacing: { ranks: 60, siblings: 20 },
-  defaultZoom: 0.75,
 };
 
 const Overview = () => (

--- a/apps/website/src/components/tech/Tree.tsx
+++ b/apps/website/src/components/tech/Tree.tsx
@@ -8,6 +8,7 @@ import {
   type NodeTypes,
   Position,
   ReactFlow,
+  type ReactFlowInstance,
   type XYPosition,
 } from "reactflow";
 
@@ -46,6 +47,7 @@ interface TreeProps<T> {
   edgeType?: EdgeTypes[string];
   nodeSize?: { width: number; height: number };
   nodeSpacing?: { ranks: number; siblings: number };
+  onInit?: (instance: ReactFlowInstance) => void;
 }
 
 const withPositions = <T,>(
@@ -227,6 +229,7 @@ const Tree = <T,>({
   edgeType,
   nodeSize = { width: 180, height: 40 },
   nodeSpacing = { ranks: 100, siblings: 50 },
+  onInit,
 }: TreeProps<T>) => {
   // Take the nested data and convert it to a flat list of nodes and edges
   const { nodes, edges } = useMemo(
@@ -248,6 +251,7 @@ const Tree = <T,>({
       edgeTypes={edgeTypes}
       proOptions={{ hideAttribution: true }}
       fitView
+      onInit={onInit}
     >
       <Background />
       <Controls showInteractive={false} />

--- a/apps/website/src/components/tech/Tree.tsx
+++ b/apps/website/src/components/tech/Tree.tsx
@@ -1,6 +1,6 @@
 import type { Node as DagreNode } from "dagre";
 import { graphlib, layout } from "dagre";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import {
   Background,
   Controls,
@@ -8,7 +8,6 @@ import {
   type NodeTypes,
   Position,
   ReactFlow,
-  type ReactFlowInstance,
   type XYPosition,
 } from "reactflow";
 
@@ -47,7 +46,6 @@ interface TreeProps<T> {
   edgeType?: EdgeTypes[string];
   nodeSize?: { width: number; height: number };
   nodeSpacing?: { ranks: number; siblings: number };
-  defaultZoom?: number;
 }
 
 const withPositions = <T,>(
@@ -229,35 +227,11 @@ const Tree = <T,>({
   edgeType,
   nodeSize = { width: 180, height: 40 },
   nodeSpacing = { ranks: 100, siblings: 50 },
-  defaultZoom = 1,
 }: TreeProps<T>) => {
   // Take the nested data and convert it to a flat list of nodes and edges
   const { nodes, edges } = useMemo(
     () => withPositions(getNodesEdges(data), nodeSize, nodeSpacing),
     [data, nodeSize, nodeSpacing],
-  );
-
-  // When the tree loads, center it
-  const init = useCallback(
-    (instance: ReactFlowInstance) => {
-      const firstNode = nodes[0];
-      if (!firstNode) return;
-
-      // Center on 0, 0
-      instance.setCenter(0, 0);
-
-      // Wait for the viewport to update
-      window.requestAnimationFrame(() => {
-        const viewport = instance.getViewport();
-
-        // Center the first node vertically
-        // But remain horizontally pinned to the left
-        instance.setCenter(viewport.x, firstNode.position.y, {
-          zoom: defaultZoom,
-        });
-      });
-    },
-    [nodes, defaultZoom],
   );
 
   // Override the default edge type if one is provided
@@ -273,7 +247,7 @@ const Tree = <T,>({
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       proOptions={{ hideAttribution: true }}
-      onInit={init}
+      fitView
     >
       <Background />
       <Controls showInteractive={false} />

--- a/apps/website/src/data/tech/network.ts
+++ b/apps/website/src/data/tech/network.ts
@@ -12,7 +12,9 @@ type NetworkConnectionWireless = NetworkConnectionCore & {
   type: "wifi" | "cloud";
 };
 
-type NetworkConnection = NetworkConnectionWired | NetworkConnectionWireless;
+export type NetworkConnection =
+  | NetworkConnectionWired
+  | NetworkConnectionWireless;
 
 type NetworkItemCore = {
   type: string;

--- a/apps/website/src/data/tech/overview.ts
+++ b/apps/website/src/data/tech/overview.ts
@@ -3,7 +3,7 @@ export interface Step {
   name: string;
   type: "server" | "source" | "github" | "service" | "control" | "output";
   description?: string;
-  link?: string;
+  url?: string;
   children?: Step[];
 }
 
@@ -21,7 +21,7 @@ const chatBot = (id: string): Step => ({
       type: "github",
       description:
         "GitHub repository for the chat bot, allowing control of the stream layout and cameras.",
-      link: "https://github.com/alveusgg/chatbot",
+      url: "https://github.com/alveusgg/chatbot",
     },
   ],
 });
@@ -106,7 +106,7 @@ const steps: Step[] = [
     id: "twitch",
     name: "Twitch Stream",
     type: "output",
-    link: "/live/twitch",
+    url: "/live/twitch",
     children: [
       cloudObs,
       {
@@ -115,7 +115,7 @@ const steps: Step[] = [
         type: "github",
         description:
           "GitHub repository for the Twitch extension showing ambassador information on the stream.",
-        link: "https://github.com/alveusgg/extension",
+        url: "https://github.com/alveusgg/extension",
       },
     ],
   },
@@ -123,7 +123,7 @@ const steps: Step[] = [
     id: "youtube",
     name: "YouTube Stream",
     type: "output",
-    link: "/live/youtube",
+    url: "/live/youtube",
     children: [cloudObs],
   },
   {
@@ -131,7 +131,7 @@ const steps: Step[] = [
     name: "Website",
     type: "output",
     description: "Alveus Sanctuary website at alveussanctuary.org.",
-    link: "/",
+    url: "/",
     children: [
       {
         id: "low-latency",
@@ -161,7 +161,7 @@ const steps: Step[] = [
             name: "alveusgg/alveusgg",
             type: "github",
             description: "GitHub repository for the Alveus Sanctuary website.",
-            link: "https://github.com/alveusgg/alveusgg",
+            url: "https://github.com/alveusgg/alveusgg",
           },
         ],
       },

--- a/apps/website/src/data/tech/overview.ts
+++ b/apps/website/src/data/tech/overview.ts
@@ -3,6 +3,7 @@ export interface Step {
   name: string;
   type: "server" | "source" | "github" | "service" | "control" | "output";
   description?: string;
+  link?: string;
   children?: Step[];
 }
 
@@ -20,6 +21,7 @@ const chatBot = (id: string): Step => ({
       type: "github",
       description:
         "GitHub repository for the chat bot, allowing control of the stream layout and cameras.",
+      link: "https://github.com/alveusgg/chatbot",
     },
   ],
 });
@@ -104,6 +106,7 @@ const steps: Step[] = [
     id: "twitch",
     name: "Twitch Stream",
     type: "output",
+    link: "/live/twitch",
     children: [
       cloudObs,
       {
@@ -112,6 +115,7 @@ const steps: Step[] = [
         type: "github",
         description:
           "GitHub repository for the Twitch extension showing ambassador information on the stream.",
+        link: "https://github.com/alveusgg/extension",
       },
     ],
   },
@@ -119,6 +123,7 @@ const steps: Step[] = [
     id: "youtube",
     name: "YouTube Stream",
     type: "output",
+    link: "/live/youtube",
     children: [cloudObs],
   },
   {
@@ -126,6 +131,7 @@ const steps: Step[] = [
     name: "Website",
     type: "output",
     description: "Alveus Sanctuary website at alveussanctuary.org.",
+    link: "/",
     children: [
       {
         id: "low-latency",
@@ -155,6 +161,7 @@ const steps: Step[] = [
             name: "alveusgg/alveusgg",
             type: "github",
             description: "GitHub repository for the Alveus Sanctuary website.",
+            link: "https://github.com/alveusgg/alveusgg",
           },
         ],
       },


### PR DESCRIPTION
## Describe your changes

Given I'd added the low-latency feed coming from OBS, I figured it would also make sense to add the website as that's what consumes that feed. With the website added, and the open-source section already at the bottom of the page, I thought it'd also be useful to include where the repositories are used in the system.

As part of doing this, the Node implementations between the overview + network diagrams were becoming increasingly similar, so I decided to just abstract them into a single shared Node component that both diagrams can use -- the only major change is that the overview diagram now shows descriptions, which I think was probably an oversight on my part originally as we've been storing descriptions in the data since the start.

## Notes for testing your change

Diagram is correct.
