### PR TITLE
Check subscription status for run command buttons

### DIFF
--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -368,6 +368,7 @@ const AboutTechPage: NextPage = () => {
                             <RunCommandButton
                               command="ptzload"
                               args={[camera.toLowerCase(), name]}
+                              subOnly
                             />
                             <p className="text-sm text-alveus-green-400 italic">
                               {preset.description}

--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -7,10 +7,12 @@ import commands, {
   commandCategories,
 } from "@/data/tech/commands";
 import presets from "@/data/tech/presets";
-import { channels } from "@/data/twitch";
+import { channels, scopeGroups } from "@/data/twitch";
 
+import { classes } from "@/utils/classes";
 import { typeSafeObjectEntries } from "@/utils/helpers";
 import { camelToKebab, sentenceToKebab } from "@/utils/string-case";
+import { trpc } from "@/utils/trpc";
 
 import Button from "@/components/content/Button";
 import Commands, {
@@ -52,6 +54,13 @@ const sectionLinks = [
 ];
 
 const AboutTechPage: NextPage = () => {
+  const { data: session } = trpc.auth.getSession.useQuery();
+  const subscription = trpc.stream.getSubscription.useQuery(undefined, {
+    enabled: scopeGroups.chat.every((scope) =>
+      session?.user?.scopes?.includes(scope),
+    ),
+  });
+
   return (
     <>
       <Meta
@@ -271,7 +280,7 @@ const AboutTechPage: NextPage = () => {
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             <p>
               These commands will pan, tilt and zoom the respective camera to a
-              preset view described below. Anyone who is subscribed to
+              preset view described below. Anyone who is subscribed to{" "}
               <Link href="/live/twitch" external>
                 Alveus Sanctuary on Twitch
               </Link>{" "}
@@ -298,6 +307,22 @@ const AboutTechPage: NextPage = () => {
               </p>
 
               <ProvideAuth scopeGroup="chat" className="mt-4" />
+
+              {subscription.isSuccess && (
+                <p className="mt-4">
+                  Subscription status:{" "}
+                  <span
+                    className={classes(
+                      "mx-1 rounded-md px-1.5 py-0.5 text-sm leading-tight text-alveus-tan",
+                      subscription.data ? "bg-alveus-green" : "bg-red",
+                    )}
+                  >
+                    {subscription.data
+                      ? `Subscribed at Tier ${subscription.data.tier.replace(/0+$/, "")}`
+                      : "Not subscribed"}
+                  </span>
+                </p>
+              )}
             </div>
           </div>
 

--- a/apps/website/src/server/apis/twitch.ts
+++ b/apps/website/src/server/apis/twitch.ts
@@ -123,6 +123,69 @@ export async function getUserFollowsBroadcaster(
   return false;
 }
 
+const userSubscribedToResponseSchema = z.object({
+  data: z
+    .array(
+      z
+        .object({
+          broadcaster_id: z.string(),
+          broadcaster_login: z.string(),
+          broadcaster_name: z.string(),
+          tier: z.enum(["1000", "2000", "3000"]),
+        })
+        .and(
+          z.discriminatedUnion("is_gift", [
+            z.object({
+              is_gift: z.literal(false),
+            }),
+            z.object({
+              is_gift: z.literal(true),
+              gifter_id: z.string(),
+              gifter_login: z.string(),
+              gifter_name: z.string(),
+            }),
+          ]),
+        ),
+    )
+    .length(1),
+});
+
+export async function getUserSubscribedToBroadcaster(
+  userAccessToken: string,
+  userId: string,
+  broadcasterId: string,
+) {
+  const response = await fetch(
+    `https://api.twitch.tv/helix/subscriptions/user?${new URLSearchParams({
+      user_id: userId,
+      broadcaster_id: broadcasterId,
+    })}`,
+    {
+      method: "GET",
+      headers: {
+        ...(await getUserAuthHeaders(userAccessToken)),
+      },
+    },
+  );
+
+  if (response.status === 403) {
+    throw new ExpiredAccessTokenError();
+  }
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  const json = await response.json();
+  if (response.status !== 200) {
+    console.error(json);
+    throw new Error("Could not get subscription status!");
+  }
+
+  const data = await userSubscribedToResponseSchema.parseAsync(json);
+  return data.data[0]!;
+}
+
 const usersResponseSchema = z.object({
   data: z.array(
     z.object({
@@ -165,7 +228,7 @@ export async function getUserByName(userName: string) {
   }
 
   const data = await usersResponseSchema.parseAsync(json);
-  return data?.data?.[0];
+  return data.data[0];
 }
 
 const scheduleSegmentSchema = z.object({

--- a/apps/website/src/server/trpc/router/stream.ts
+++ b/apps/website/src/server/trpc/router/stream.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-import { prisma } from "@alveusgg/database";
-
 import {
   getUserSubscribedToBroadcaster,
   sendChatMessage,
@@ -12,26 +10,9 @@ import {
   publicProcedure,
   router,
 } from "@/server/trpc/trpc";
+import { getUserTwitchAccount } from "@/server/utils/auth";
 
 import { channels } from "@/data/twitch";
-
-const getUserTwitchAccount = async (userId: string) => {
-  const { access_token: token, providerAccountId: id } =
-    (await prisma.account.findFirst({
-      where: {
-        userId,
-        provider: "twitch",
-      },
-      select: {
-        providerAccountId: true,
-        access_token: true,
-      },
-    })) ?? {};
-  if (!token || !id) {
-    throw new Error("No Twitch account found for user");
-  }
-  return { token, id };
-};
 
 export const runCommandSchema = z.object({
   command: z.enum(["ptzload"]),
@@ -42,7 +23,7 @@ export const streamRouter = router({
   getWeather: publicProcedure.query(getWeather),
 
   getSubscription: protectedProcedure.query(async ({ ctx }) => {
-    const twitchAccount = await getUserTwitchAccount(ctx.session.user.id);
+    const twitchAccount = await getUserTwitchAccount(ctx.session.user.id, true);
     return getUserSubscribedToBroadcaster(
       twitchAccount.token,
       twitchAccount.id,
@@ -53,7 +34,10 @@ export const streamRouter = router({
   runCommand: protectedProcedure
     .input(runCommandSchema)
     .mutation(async ({ ctx, input }) => {
-      const twitchAccount = await getUserTwitchAccount(ctx.session.user.id);
+      const twitchAccount = await getUserTwitchAccount(
+        ctx.session.user.id,
+        true,
+      );
       const { command, args } = input;
       await sendChatMessage(
         twitchAccount.token,

--- a/apps/website/src/server/trpc/router/stream.ts
+++ b/apps/website/src/server/trpc/router/stream.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 
 import { prisma } from "@alveusgg/database";
 
-import { sendChatMessage } from "@/server/apis/twitch";
+import {
+  getUserSubscribedToBroadcaster,
+  sendChatMessage,
+} from "@/server/apis/twitch";
 import { getWeather } from "@/server/apis/weather";
 import {
   protectedProcedure,
@@ -12,6 +15,24 @@ import {
 
 import { channels } from "@/data/twitch";
 
+const getUserTwitchAccount = async (userId: string) => {
+  const { access_token: token, providerAccountId: id } =
+    (await prisma.account.findFirst({
+      where: {
+        userId,
+        provider: "twitch",
+      },
+      select: {
+        providerAccountId: true,
+        access_token: true,
+      },
+    })) ?? {};
+  if (!token || !id) {
+    throw new Error("No Twitch account found for user");
+  }
+  return { token, id };
+};
+
 export const runCommandSchema = z.object({
   command: z.enum(["ptzload"]),
   args: z.array(z.string()).optional(),
@@ -20,29 +41,23 @@ export const runCommandSchema = z.object({
 export const streamRouter = router({
   getWeather: publicProcedure.query(getWeather),
 
+  getSubscription: protectedProcedure.query(async ({ ctx }) => {
+    const twitchAccount = await getUserTwitchAccount(ctx.session.user.id);
+    return getUserSubscribedToBroadcaster(
+      twitchAccount.token,
+      twitchAccount.id,
+      channels.alveus.id,
+    );
+  }),
+
   runCommand: protectedProcedure
     .input(runCommandSchema)
     .mutation(async ({ ctx, input }) => {
+      const twitchAccount = await getUserTwitchAccount(ctx.session.user.id);
       const { command, args } = input;
-
-      // Get the user's Twitch access token
-      const account = await prisma.account.findFirst({
-        where: {
-          userId: ctx.session.user.id,
-          provider: "twitch",
-        },
-        select: {
-          providerAccountId: true,
-          access_token: true,
-        },
-      });
-      if (!account || !account.access_token) {
-        throw new Error("No Twitch account found for user");
-      }
-
       await sendChatMessage(
-        account.access_token,
-        account.providerAccountId,
+        twitchAccount.token,
+        twitchAccount.id,
         channels.alveusgg.id,
         `!${command} ${args?.join(" ") || ""}`,
       );

--- a/apps/website/src/server/trpc/router/stream.ts
+++ b/apps/website/src/server/trpc/router/stream.ts
@@ -39,6 +39,8 @@ export const streamRouter = router({
         true,
       );
       const { command, args } = input;
+
+      // TODO: Check if user is subscribed + send directly to bot
       await sendChatMessage(
         twitchAccount.token,
         twitchAccount.id,


### PR DESCRIPTION
## Describe your changes

Adds a client-side check to only show the run command buttons if the user is subscribed to the Alveus channel.

This is only enforced client-side as there's a chance we might have commands in the future exposed to anyone, or that have other restrictions such as mod-only. Given we're just sending the commands to chat, actual authz checks are handled by the bot.

## Notes for testing your change

Subscription status is checked correctly once authed with correct scopes on the page, run buttons only show if subscribed.