### PR TITLE
Move lola feed URL to tRPC method + check access frequently

### DIFF
--- a/apps/website/src/pages/stream/lola.tsx
+++ b/apps/website/src/pages/stream/lola.tsx
@@ -42,7 +42,7 @@ const LolaPage: NextPage<
             </div>
           ) : (
             <div className="h-screen w-screen">
-              <LiveCamFeed url="" />
+              <LiveCamFeed />
             </div>
           ))}
       </main>

--- a/apps/website/src/pages/stream/lola.tsx
+++ b/apps/website/src/pages/stream/lola.tsx
@@ -5,63 +5,21 @@ import type {
 } from "next";
 import { getSession } from "next-auth/react";
 
-import { env } from "@/env";
-
-import invariant from "@/utils/invariant";
-import { createJWT, signJWT } from "@/utils/jwt";
-
 import LiveCamFeed from "@/components/admin/ptz/LiveCamFeed";
 import Meta from "@/components/content/Meta";
 import { LoginWithTwitchButton } from "@/components/shared/LoginWithTwitchButton";
 
 export async function getServerSideProps(context: NextPageContext) {
-  invariant(env.CF_STREAM_KEY_ID, "CF_STREAM_KEY_ID is not set");
-  invariant(env.CF_STREAM_KEY_JWK, "CF_STREAM_KEY_JWK is not set");
-  invariant(env.CF_STREAM_LOLA_VIDEO_ID, "CF_STREAM_LOLA_VIDEO_ID is not set");
-  invariant(env.CF_STREAM_HOST, "CF_STREAM_HOST is not set");
-
   const session = await getSession(context);
   const isAuthed = session?.user?.id !== undefined;
   const hasRole = session?.user?.roles.includes("ptzControl");
 
-  if (!isAuthed || !hasRole) {
-    return { props: { isAuthed, hasRole } };
-  }
-
-  const expiresTimeInSeconds = 60 * 5;
-  const expiresIn = Math.floor(Date.now() / 1000) + expiresTimeInSeconds;
-  const token = createJWT(
-    {
-      alg: "RS256",
-      kid: env.CF_STREAM_KEY_ID,
-    },
-    {
-      sub: env.CF_STREAM_LOLA_VIDEO_ID,
-      kid: env.CF_STREAM_KEY_ID,
-      exp: expiresIn,
-      accessRules: [
-        {
-          type: "any",
-          action: "allow",
-        },
-      ],
-    },
-  );
-
-  const jwt = await signJWT(token, env.CF_STREAM_KEY_JWK);
-
-  return {
-    props: {
-      isAuthed,
-      hasRole,
-      url: `https://${env.CF_STREAM_HOST}/${jwt}/webRTC/play`,
-    },
-  };
+  return { props: { isAuthed, hasRole } };
 }
 
 const LolaPage: NextPage<
   InferGetServerSidePropsType<typeof getServerSideProps>
-> = ({ hasRole, isAuthed, url }) => {
+> = ({ hasRole, isAuthed }) => {
   return (
     <>
       <Meta title="Low-Latency Video Stream" description="" />
@@ -83,11 +41,9 @@ const LolaPage: NextPage<
               </p>
             </div>
           ) : (
-            url && (
-              <div className="h-screen w-screen">
-                <LiveCamFeed url={url} />
-              </div>
-            )
+            <div className="h-screen w-screen">
+              <LiveCamFeed url="" />
+            </div>
           ))}
       </main>
     </>

--- a/apps/website/src/pages/stream/lola.tsx
+++ b/apps/website/src/pages/stream/lola.tsx
@@ -28,7 +28,7 @@ export async function getServerSideProps(context: NextPageContext) {
     return { props: { isAuthed, hasRole } };
   }
 
-  const expiresTimeInSeconds = 60 * 60 * 48;
+  const expiresTimeInSeconds = 60 * 5;
   const expiresIn = Math.floor(Date.now() / 1000) + expiresTimeInSeconds;
   const token = createJWT(
     {
@@ -59,7 +59,7 @@ export async function getServerSideProps(context: NextPageContext) {
   };
 }
 
-const PTZPage: NextPage<
+const LolaPage: NextPage<
   InferGetServerSidePropsType<typeof getServerSideProps>
 > = ({ hasRole, isAuthed, url }) => {
   return (
@@ -94,4 +94,4 @@ const PTZPage: NextPage<
   );
 };
 
-export default PTZPage;
+export default LolaPage;


### PR DESCRIPTION
## Describe your changes

Moves the fetching of the lola URL to a tRPC method, allowing the component to be used anywhere without needing to pass a URL down from page props.

This also allows us to write logic in the component that frequently checks if the user still has access to generate lola URLs, and if not, we can stop the player (the JWT expiring does not stop an active connection, but once expired, the JWT cannot be used to reconnect).

## Notes for testing your change

lola works, lola stops if the tRPC method starts returning an error.
