### PR TITLE
Set --max-warnings 0 for ESLint lint-staged commands

### DIFF
--- a/apps/chatbot/lint-staged.config.js
+++ b/apps/chatbot/lint-staged.config.js
@@ -2,7 +2,7 @@ import mainConfig from "../../lint-staged.config.js";
 
 /** @param {string[]} filenames */
 const buildEslintCommand = (filenames) =>
-  `pnpm eslint --fix ${filenames.join(" ")}`;
+  `pnpm eslint --fix --max-warnings 0 ${filenames.join(" ")}`;
 
 const config = {
   ...mainConfig,

--- a/apps/website/lint-staged.config.js
+++ b/apps/website/lint-staged.config.js
@@ -6,7 +6,7 @@ import mainConfig from "../../lint-staged.config.js";
 // https://github.com/vercel/next.js/blob/v15.3.1/packages/next/src/cli/next-lint.ts#L76-L91
 /** @param {string[]} filenames */
 const buildEslintCommand = (filenames) =>
-  `next lint --fix --dir !. ${filenames.map((file) => `--file ${file}`).join(" ")}`;
+  `next lint --fix --max-warnings 0 --dir !. ${filenames.map((file) => `--file ${file}`).join(" ")}`;
 
 const config = {
   ...mainConfig,


### PR DESCRIPTION
## Describe your changes

Forgot about these when I added `--max-warnings 0` in #1219. I'm in favour of blocking commits if there are any warnings, in the same way we block them in PR CI -- I think they should only be warnings in an active IDE instance where you might still be working on something (e.g. an unused import because you're rewriting some logic).

## Notes for testing your change

Trying to commit with an ESLint warning preset will fail.