### PR TITLE
Make heic-to import lazy

### DIFF
--- a/apps/website/src/utils/image-converter.ts
+++ b/apps/website/src/utils/image-converter.ts
@@ -2,13 +2,12 @@ import type { heicTo } from "heic-to/csp";
 
 import type { ImageMimeType } from "./files";
 
-let heicToCache: typeof heicTo | undefined;
-const heicToLazy = () =>
-  heicToCache ??
-  import("heic-to/csp").then((m) => {
-    heicToCache = m.heicTo;
-    return heicToCache;
-  });
+let heicToPromise: Promise<typeof heicTo>;
+const heicToLazy = () => {
+  if (heicToPromise) return heicToPromise;
+  heicToPromise = import("heic-to/csp").then((module) => module.heicTo);
+  return heicToPromise;
+};
 
 async function convertHeicToJpeg(file: File) {
   const heicTo = await heicToLazy();

--- a/apps/website/src/utils/image-converter.ts
+++ b/apps/website/src/utils/image-converter.ts
@@ -1,8 +1,17 @@
-import { heicTo } from "heic-to/csp";
+import type { heicTo } from "heic-to/csp";
 
 import type { ImageMimeType } from "./files";
 
+let heicToCache: typeof heicTo | undefined;
+const heicToLazy = () =>
+  heicToCache ??
+  import("heic-to/csp").then((m) => {
+    heicToCache = m.heicTo;
+    return heicToCache;
+  });
+
 async function convertHeicToJpeg(file: File) {
+  const heicTo = await heicToLazy();
   const blob = await heicTo({
     blob: file,
     type: "image/jpeg",

--- a/apps/website/src/utils/image-converter.ts
+++ b/apps/website/src/utils/image-converter.ts
@@ -2,10 +2,16 @@ import type { heicTo } from "heic-to/csp";
 
 import type { ImageMimeType } from "./files";
 
-let heicToPromise: Promise<typeof heicTo>;
+let heicToPromise: Promise<typeof heicTo> | undefined;
 const heicToLazy = () => {
   if (heicToPromise) return heicToPromise;
-  heicToPromise = import("heic-to/csp").then((module) => module.heicTo);
+  heicToPromise = import("heic-to/csp")
+    .then((module) => module.heicTo)
+    .catch((error) => {
+      console.error("Failed to load heic-to module:", error);
+      heicToPromise = undefined; // Reset to allow retry
+      throw error; // Re-throw to propagate the error
+    });
   return heicToPromise;
 };
 


### PR DESCRIPTION
## Describe your changes

Bugfix from #1209 to allow pages w/ server-side props that have the heic-to import in their tree to render without timing out -- I suspect the timeout is happening due to the large (over 2MB) import that is heic-to.

## Notes for testing your change

/events/national-hat-day-2025 loads.
