### PR TITLE
Move camera presets to dedicated page

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -188,6 +188,11 @@ const config: NextConfig = {
       permanent: true,
     },
     {
+      source: "/presets",
+      destination: "/about/tech/presets",
+      permanent: true,
+    },
+    {
       source: "/vote",
       destination: "/voters-guide",
       permanent: true,

--- a/apps/website/src/data/tech/commands.ts
+++ b/apps/website/src/data/tech/commands.ts
@@ -51,7 +51,6 @@ export type CommandCategoryId = keyof typeof commandCategories;
 
 export interface CommandCategory {
   heading: string;
-  description?: string;
 }
 
 export const commandCategories = {
@@ -69,8 +68,6 @@ export const commandCategories = {
   },
   Presets: {
     heading: "Presets",
-    description:
-      "These commands will pan, tilt and zoom the respective camera to a preset view. The presets are listed below.",
   },
   Audio: {
     heading: "Audio",

--- a/apps/website/src/hooks/clipboard.ts
+++ b/apps/website/src/hooks/clipboard.ts
@@ -1,15 +1,21 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 export type CopyToClipboardOptions = {
+  initialText?: string;
   timeToKeepStatus?: number;
 };
 
 export function useCopyToClipboard({
+  initialText = "Copy",
   timeToKeepStatus = 2_000,
 }: CopyToClipboardOptions = {}) {
   const [status, setStatus] = useState<undefined | "success" | "error">();
   const statusText =
-    status === "success" ? "Copied!" : status === "error" ? "Failed" : "Copy";
+    status === "success"
+      ? "Copied!"
+      : status === "error"
+        ? "Failed"
+        : initialText;
   useEffect(() => {
     if (status !== undefined) {
       const timeout = setTimeout(() => {

--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -192,10 +192,6 @@ const AboutTechCommandsPage: NextPage = () => {
                     >
                       {category.heading}
                     </Heading>
-
-                    {"description" in category && (
-                      <p className="mb-4">{category.description}</p>
-                    )}
                   </dt>
                   <dd className="mx-2">
                     <Commands commands={commands} />
@@ -208,29 +204,23 @@ const AboutTechCommandsPage: NextPage = () => {
       </div>
 
       <Section className="bg-alveus-green-100">
-        <Heading
-          level={2}
-          className="mt-0 mb-2 scroll-mt-14"
-          id="fossabot"
-          link
-        >
-          Fossabot
+        <Heading level={2} className="mt-0 mb-2 scroll-mt-14" id="presets" link>
+          Presets
         </Heading>
 
         <div className="flex flex-row flex-wrap items-center gap-x-16 gap-y-4 lg:flex-nowrap">
           <p className="text-lg">
-            Alongside the custom chat bot for all the commands above, Fossabot
-            is also used in the Twitch chat to provide a set of commands that
-            anyone can access, providing easy access to a bunch of common
-            information and links.
+            Almost all of the cameras on the livestream have a set of saved
+            preset positions that can be loaded through chat commands, or
+            directly on the website. Anyone who is subscribed to{" "}
+            <Link href="/live/twitch" external>
+              Alveus Sanctuary on Twitch
+            </Link>{" "}
+            can load these presets to control what views are shown on stream.
           </p>
 
-          <Button
-            href="https://fossabot.com/alveussanctuary/commands"
-            external
-            className="shrink-0"
-          >
-            Explore Fossabot Commands
+          <Button href="/about/tech/presets" className="shrink-0">
+            View Camera Presets
           </Button>
         </div>
       </Section>
@@ -247,25 +237,27 @@ const AboutTechCommandsPage: NextPage = () => {
           <Heading
             level={2}
             className="mt-0 mb-2 scroll-mt-14"
-            id="presets"
+            id="fossabot"
             link
           >
-            Presets
+            Fossabot
           </Heading>
 
           <div className="flex flex-row flex-wrap items-center gap-x-16 gap-y-4 lg:flex-nowrap">
             <p className="text-lg">
-              Almost all of the cameras on the livestream have a set of saved
-              preset positions that can be loaded through chat commands, or
-              directly on the website. Anyone who is subscribed to{" "}
-              <Link href="/live/twitch" external dark>
-                Alveus Sanctuary on Twitch
-              </Link>{" "}
-              can load these presets to control what views are shown on stream.
+              Alongside the custom chat bot for all the commands above, Fossabot
+              is also used in the Twitch chat to provide a set of commands that
+              anyone can access, providing easy access to a bunch of common
+              information and links.
             </p>
 
-            <Button href="/about/tech/presets" className="shrink-0" dark>
-              View Camera Presets
+            <Button
+              href="https://fossabot.com/alveussanctuary/commands"
+              external
+              className="shrink-0"
+              dark
+            >
+              Explore Fossabot Commands
             </Button>
           </div>
         </Section>

--- a/apps/website/src/pages/about/tech/commands.tsx
+++ b/apps/website/src/pages/about/tech/commands.tsx
@@ -1,18 +1,14 @@
 import { type NextPage } from "next";
 import Image from "next/image";
-import { Fragment, useState } from "react";
+import { Fragment } from "react";
 
 import commands, {
   type CommandCategoryId,
   commandCategories,
 } from "@/data/tech/commands";
-import presets, { type Camera } from "@/data/tech/presets";
-import { channels, scopeGroups } from "@/data/twitch";
 
-import { classes } from "@/utils/classes";
-import { typeSafeObjectEntries, typeSafeObjectKeys } from "@/utils/helpers";
-import { camelToKebab, sentenceToKebab } from "@/utils/string-case";
-import { trpc } from "@/utils/trpc";
+import { typeSafeObjectEntries } from "@/utils/helpers";
+import { sentenceToKebab } from "@/utils/string-case";
 
 import Button from "@/components/content/Button";
 import Commands, {
@@ -23,12 +19,6 @@ import Heading from "@/components/content/Heading";
 import Link from "@/components/content/Link";
 import Meta from "@/components/content/Meta";
 import Section from "@/components/content/Section";
-import SubNav from "@/components/content/SubNav";
-import ProvideAuth from "@/components/shared/LoginWithExtraScopes";
-import CopyToClipboardButton from "@/components/shared/actions/CopyToClipboardButton";
-import RunCommandButton from "@/components/shared/actions/RunCommandButton";
-
-import IconVideoCamera from "@/icons/IconVideoCamera";
 
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
@@ -48,23 +38,7 @@ const grouped = typeSafeObjectEntries(commands).reduce(
   {} as Record<CommandCategoryId, NamedCommand[]>,
 );
 
-const sectionLinks = [
-  { name: "Commands", href: "#commands" },
-  { name: "Presets", href: "#presets" },
-];
-
-const AboutTechPage: NextPage = () => {
-  const { data: session } = trpc.auth.getSession.useQuery();
-  const subscription = trpc.stream.getSubscription.useQuery(undefined, {
-    enabled: scopeGroups.chat.every((scope) =>
-      session?.user?.scopes?.includes(scope),
-    ),
-  });
-
-  const [selectedCamera, setSelectedCamera] = useState<Camera>(
-    typeSafeObjectKeys(presets)[0]!,
-  );
-
+const AboutTechCommandsPage: NextPage = () => {
   return (
     <>
       <Meta
@@ -94,8 +68,6 @@ const AboutTechPage: NextPage = () => {
           </div>
         </Section>
       </div>
-
-      <SubNav links={sectionLinks} className="z-20" />
 
       <div className="relative">
         <Image
@@ -271,7 +243,7 @@ const AboutTechPage: NextPage = () => {
           className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 drop-shadow-md select-none lg:block"
         />
 
-        <Section className="grow">
+        <Section className="grow bg-alveus-green-900" dark>
           <Heading
             level={2}
             className="mt-0 mb-2 scroll-mt-14"
@@ -281,159 +253,20 @@ const AboutTechPage: NextPage = () => {
             Presets
           </Heading>
 
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-            <p>
-              These commands will pan, tilt and zoom the respective camera to a
-              preset view described below. Anyone who is subscribed to{" "}
-              <Link href="/live/twitch" external>
+          <div className="flex flex-row flex-wrap items-center gap-x-16 gap-y-4 lg:flex-nowrap">
+            <p className="text-lg">
+              Almost all of the cameras on the livestream have a set of saved
+              preset positions that can be loaded through chat commands, or
+              directly on the website. Anyone who is subscribed to{" "}
+              <Link href="/live/twitch" external dark>
                 Alveus Sanctuary on Twitch
               </Link>{" "}
-              can run these commands in the chat.
+              can load these presets to control what views are shown on stream.
             </p>
 
-            <div>
-              <p>
-                If you&apos;re subscribed, you can run these commands directly
-                from this page by clicking the{" "}
-                <span className="font-semibold text-alveus-green">
-                  Run command{" "}
-                  <IconVideoCamera className="mb-0.5 inline-block size-4" />
-                </span>{" "}
-                button in each preset card. This will automatically send the
-                command to the{" "}
-                <Link
-                  href={`https://twitch.tv/${channels.alveusgg.username}`}
-                  external
-                >
-                  {channels.alveusgg.username} Twitch chat
-                </Link>{" "}
-                as if you had typed it in the chat yourself.
-              </p>
-
-              <ProvideAuth scopeGroup="chat" className="mt-4" />
-
-              {subscription.isSuccess && (
-                <p className="mt-4">
-                  Subscription status:{" "}
-                  <span
-                    className={classes(
-                      "mx-1 rounded-md px-1.5 py-0.5 text-sm leading-tight text-alveus-tan",
-                      subscription.data ? "bg-alveus-green" : "bg-red",
-                    )}
-                  >
-                    {subscription.data
-                      ? `Subscribed at Tier ${subscription.data.tier.replace(/0+$/, "")}`
-                      : "Not subscribed"}
-                  </span>
-                </p>
-              )}
-            </div>
-          </div>
-
-          <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-4">
-            {/* Camera List */}
-            <div className="col-span-1 space-y-2">
-              {/* Mobile: Dropdown */}
-              <div className="mb-2 block lg:hidden">
-                <label htmlFor="camera-select" className="sr-only">
-                  Select Camera
-                </label>
-                <select
-                  id="camera-select"
-                  value={selectedCamera}
-                  onChange={(e) => setSelectedCamera(e.target.value as Camera)}
-                  className="w-full rounded border border-alveus-green-200 bg-alveus-green-50 px-3 py-2 text-lg font-semibold focus:ring-2 focus:ring-alveus-green focus:outline-none"
-                >
-                  {typeSafeObjectKeys(presets).map((camera) => (
-                    <option key={camera} value={camera}>
-                      {presets[camera].title} ({camera.toLowerCase()})
-                    </option>
-                  ))}
-                </select>
-              </div>
-              {/* Desktop: Button List */}
-              <div className="hidden space-y-2 lg:block">
-                {typeSafeObjectKeys(presets).map((camera) => (
-                  <button
-                    key={camera}
-                    onClick={() => setSelectedCamera(camera)}
-                    className={classes(
-                      "w-full rounded px-3 py-2 text-left text-lg font-semibold",
-                      selectedCamera === camera
-                        ? "bg-alveus-green text-white"
-                        : "bg-alveus-green-50 hover:bg-alveus-green-100",
-                    )}
-                  >
-                    {presets[camera].title}
-                    <span className="text-sm text-alveus-green-400 italic">
-                      {` (${camera.toLowerCase()})`}
-                    </span>
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Preset List */}
-            <div className="col-span-1 lg:col-span-3">
-              {selectedCamera && (
-                <Fragment key={selectedCamera}>
-                  <Heading
-                    level={3}
-                    className="scroll-mt-14 text-2xl"
-                    id={`presets:${camelToKebab(selectedCamera)}`}
-                  >
-                    {presets[selectedCamera].title}
-                    <span className="text-sm text-alveus-green-400 italic">
-                      {` (${selectedCamera.toLowerCase()})`}
-                    </span>
-                  </Heading>
-
-                  <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-                    {typeSafeObjectEntries(presets[selectedCamera].presets).map(
-                      ([name, preset]) => (
-                        <div
-                          key={name}
-                          className="overflow-hidden rounded-lg border shadow-lg"
-                        >
-                          <div className="group relative aspect-video">
-                            {preset.image ? (
-                              <Image
-                                src={preset.image}
-                                alt={preset.description}
-                                fill
-                                className="aspect-video w-full object-cover transition-transform"
-                              />
-                            ) : (
-                              <div className="flex aspect-video items-center justify-center bg-alveus-green-50 text-xs text-alveus-green-300">
-                                No Image
-                              </div>
-                            )}
-                          </div>
-                          <div className="flex flex-col gap-1 bg-alveus-tan p-2">
-                            <div className="flex items-center justify-between">
-                              <h4 className="text-lg font-semibold">{name}</h4>
-                              <div className="flex gap-1">
-                                <CopyToClipboardButton
-                                  text={`!ptzload ${selectedCamera.toLowerCase()} ${name}`}
-                                />
-                                <RunCommandButton
-                                  command="ptzload"
-                                  args={[selectedCamera.toLowerCase(), name]}
-                                  subOnly
-                                />
-                              </div>
-                            </div>
-                            <p className="text-sm text-alveus-green-600 italic">
-                              {preset.description}
-                            </p>
-                          </div>
-                        </div>
-                      ),
-                    )}
-                  </div>
-                </Fragment>
-              )}
-            </div>
+            <Button href="/about/tech/presets" className="shrink-0" dark>
+              View Camera Presets
+            </Button>
           </div>
         </Section>
       </div>
@@ -441,4 +274,4 @@ const AboutTechPage: NextPage = () => {
   );
 };
 
-export default AboutTechPage;
+export default AboutTechCommandsPage;

--- a/apps/website/src/pages/about/tech/index.tsx
+++ b/apps/website/src/pages/about/tech/index.tsx
@@ -146,6 +146,27 @@ const AboutTechPage: NextPage = () => {
         </Section>
       </div>
 
+      <Section className="bg-alveus-green-100">
+        <Heading level={2} className="mt-0 mb-2 scroll-mt-14" id="presets" link>
+          Camera Presets
+        </Heading>
+
+        <div className="flex flex-row flex-wrap items-center gap-x-16 gap-y-4 lg:flex-nowrap">
+          <p className="text-lg">
+            Overwhelmed by the number of camera presets available, or just
+            don&apos;t want to run commands by hand in chat? We&apos;ve got you
+            covered with our camera presets page! View thumbnail previews and
+            descriptions of all the camera presets available, and if you&apos;re
+            signed in as a subscriber, you can load them directly from the page
+            to control what views are shown on stream.
+          </p>
+
+          <Button href="/about/tech/presets" className="shrink-0">
+            View Camera Presets
+          </Button>
+        </div>
+      </Section>
+
       <Section dark>
         <Heading
           level={2}

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -52,7 +52,7 @@ const AboutTechPresetsPage: NextPage = () => {
         <Image
           src={leafRightImage1}
           alt=""
-          className="pointer-events-none absolute -top-8 right-0 z-30 hidden h-auto w-1/2 max-w-sm drop-shadow-md select-none lg:block xl:max-w-md"
+          className="pointer-events-none absolute -top-8 right-0 z-10 hidden h-auto w-1/2 max-w-xs drop-shadow-md select-none lg:block xl:max-w-sm"
         />
 
         <Section dark className="py-24">

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -131,7 +131,7 @@ const AboutTechPresetsPage: NextPage = () => {
 
           <div className="mt-6 grid grid-cols-1 items-start gap-6 lg:grid-cols-4">
             {/* Camera List */}
-            <div className="col-span-1 space-y-2">
+            <div className="col-span-1 space-y-2 lg:sticky lg:top-0 lg:pt-2">
               {/* Mobile: Dropdown */}
               <div className="mb-2 block lg:hidden">
                 <label htmlFor="camera-select" className="sr-only">
@@ -174,7 +174,7 @@ const AboutTechPresetsPage: NextPage = () => {
             </div>
 
             {/* Preset List */}
-            <div className="col-span-1 lg:col-span-3">
+            <div className="col-span-1 lg:sticky lg:top-0 lg:col-span-3">
               {selectedCamera && (
                 <Fragment key={selectedCamera}>
                   <Heading
@@ -215,6 +215,7 @@ const AboutTechPresetsPage: NextPage = () => {
                               <div className="flex gap-1">
                                 <CopyToClipboardButton
                                   text={`!ptzload ${selectedCamera.toLowerCase()} ${name}`}
+                                  options={{ initialText: "Copy command" }}
                                 />
                                 <RunCommandButton
                                   command="ptzload"

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -19,6 +19,7 @@ import CopyToClipboardButton from "@/components/shared/actions/CopyToClipboardBu
 import RunCommandButton from "@/components/shared/actions/RunCommandButton";
 
 import IconCheck from "@/icons/IconCheck";
+import IconLoading from "@/icons/IconLoading";
 import IconVideoCamera from "@/icons/IconVideoCamera";
 import IconX from "@/icons/IconX";
 
@@ -106,24 +107,39 @@ const AboutTechPresetsPage: NextPage = () => {
             <div className="w-full lg:w-2/5 lg:px-8">
               <ProvideAuth scopeGroup="chat" className="mb-4" />
 
-              {subscription.isSuccess && (
+              {!subscription.isPaused && (
                 <div
                   className={classes(
                     "mx-1 flex items-center justify-between rounded-xl p-3 text-lg text-alveus-tan",
-                    subscription.data ? "bg-alveus-green" : "bg-red",
+                    subscription.isSuccess &&
+                      (subscription.data ? "bg-alveus-green" : "bg-red"),
+                    subscription.isLoading && "bg-twitch",
+                    subscription.isError && "bg-red",
                   )}
                 >
                   <p>
-                    {subscription.data
-                      ? `@${session?.user?.name} is subscribed at Tier ${subscription.data.tier.replace(/0+$/, "")}`
-                      : `@${session?.user?.name} is not subscribed`}
+                    {subscription.isSuccess &&
+                      (subscription.data
+                        ? `@${session?.user?.name} is subscribed at Tier ${subscription.data.tier.replace(/0+$/, "")}`
+                        : `@${session?.user?.name} is not subscribed`)}
+
+                    {subscription.isLoading &&
+                      "Checking subscription status..."}
+                    {subscription.isError &&
+                      "Failed to check subscription status"}
                   </p>
 
-                  {subscription.data ? (
-                    <IconCheck className="size-6" />
-                  ) : (
-                    <IconX className="size-6" />
+                  {subscription.isSuccess &&
+                    (subscription.data ? (
+                      <IconCheck className="size-6" />
+                    ) : (
+                      <IconX className="size-6" />
+                    ))}
+
+                  {subscription.isLoading && (
+                    <IconLoading className="size-6 animate-spin" />
                   )}
+                  {subscription.isError && <IconX className="size-6" />}
                 </div>
               )}
             </div>

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -1,0 +1,244 @@
+import { type NextPage } from "next";
+import Image from "next/image";
+import { Fragment, useState } from "react";
+
+import presets, { type Camera } from "@/data/tech/presets";
+import { channels, scopeGroups } from "@/data/twitch";
+
+import { classes } from "@/utils/classes";
+import { typeSafeObjectEntries, typeSafeObjectKeys } from "@/utils/helpers";
+import { camelToKebab } from "@/utils/string-case";
+import { trpc } from "@/utils/trpc";
+
+import Heading from "@/components/content/Heading";
+import Link from "@/components/content/Link";
+import Meta from "@/components/content/Meta";
+import Section from "@/components/content/Section";
+import ProvideAuth from "@/components/shared/LoginWithExtraScopes";
+import CopyToClipboardButton from "@/components/shared/actions/CopyToClipboardButton";
+import RunCommandButton from "@/components/shared/actions/RunCommandButton";
+
+import IconCheck from "@/icons/IconCheck";
+import IconVideoCamera from "@/icons/IconVideoCamera";
+import IconX from "@/icons/IconX";
+
+import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
+import leafRightImage1 from "@/assets/floral/leaf-right-1.png";
+
+const AboutTechPresetsPage: NextPage = () => {
+  const { data: session } = trpc.auth.getSession.useQuery();
+  const subscription = trpc.stream.getSubscription.useQuery(undefined, {
+    enabled: scopeGroups.chat.every((scope) =>
+      session?.user?.scopes?.includes(scope),
+    ),
+  });
+
+  const [selectedCamera, setSelectedCamera] = useState<Camera>(
+    typeSafeObjectKeys(presets)[0]!,
+  );
+
+  return (
+    <>
+      <Meta
+        title="Camera Presets at Alveus"
+        description="Control the cameras on the Alveus Sanctuary livestream by loading preset positions. Preview all the available camera presets and run chat commands directly from this page to change the camera views."
+      />
+
+      {/* Nav background */}
+      <div className="-mt-40 hidden h-40 bg-alveus-green-900 lg:block" />
+
+      <div className="relative">
+        <Image
+          src={leafRightImage1}
+          alt=""
+          className="pointer-events-none absolute -top-8 right-0 z-30 hidden h-auto w-1/2 max-w-sm drop-shadow-md select-none lg:block xl:max-w-md"
+        />
+
+        <Section dark className="py-24">
+          <div className="w-full lg:w-3/5">
+            <Heading level={1}>Camera Presets at Alveus</Heading>
+            <p className="text-lg text-balance">
+              Control the cameras on the livestream by loading preset positions
+              for the cameras if you&apos;re subscribed to{" "}
+              <Link href="/live/twitch" external dark>
+                Alveus Sanctuary on Twitch
+              </Link>
+              .
+            </p>
+          </div>
+        </Section>
+      </div>
+
+      {/* Grow the last section to cover the page */}
+      <div className="relative flex grow flex-col">
+        <Image
+          src={leafLeftImage3}
+          alt=""
+          className="pointer-events-none absolute -bottom-24 left-0 z-10 hidden h-auto w-1/2 max-w-48 drop-shadow-md select-none lg:block"
+        />
+
+        <Section className="grow">
+          <div className="flex flex-col gap-y-4 lg:flex-row">
+            <p className="w-full lg:w-3/5">
+              If you&apos;re subscribed, you can run these commands directly
+              from this page by clicking the{" "}
+              <span className="font-semibold text-alveus-green">
+                Run command{" "}
+                <IconVideoCamera className="mb-0.5 inline-block size-4" />
+              </span>{" "}
+              button in each preset card. This will automatically send the
+              command to the{" "}
+              <Link
+                href={`https://twitch.tv/${channels.alveusgg.username}`}
+                external
+              >
+                {channels.alveusgg.username} Twitch chat
+              </Link>{" "}
+              as if you had typed it in the chat yourself. Make sure you have
+              the{" "}
+              <Link href="/live/twitch" external>
+                livestream
+              </Link>{" "}
+              open in another tab to see the camera change as you load the
+              presets.
+            </p>
+
+            <div className="w-full lg:w-2/5 lg:px-8">
+              <ProvideAuth scopeGroup="chat" className="mb-4" />
+
+              {subscription.isSuccess && (
+                <div
+                  className={classes(
+                    "mx-1 flex items-center justify-between rounded-xl p-3 text-lg text-alveus-tan",
+                    subscription.data ? "bg-alveus-green" : "bg-red",
+                  )}
+                >
+                  <p>
+                    {subscription.data
+                      ? `@${session?.user?.name} is subscribed at Tier ${subscription.data.tier.replace(/0+$/, "")}`
+                      : `@${session?.user?.name} is not subscribed`}
+                  </p>
+
+                  {subscription.data ? (
+                    <IconCheck className="size-6" />
+                  ) : (
+                    <IconX className="size-6" />
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-6 grid grid-cols-1 items-start gap-6 lg:grid-cols-4">
+            {/* Camera List */}
+            <div className="col-span-1 space-y-2">
+              {/* Mobile: Dropdown */}
+              <div className="mb-2 block lg:hidden">
+                <label htmlFor="camera-select" className="sr-only">
+                  Select Camera
+                </label>
+                <select
+                  id="camera-select"
+                  value={selectedCamera}
+                  onChange={(e) => setSelectedCamera(e.target.value as Camera)}
+                  className="w-full rounded border border-alveus-green-200 bg-alveus-green-50 px-3 py-2 text-lg font-semibold focus:ring-2 focus:ring-alveus-green focus:outline-none"
+                >
+                  {typeSafeObjectKeys(presets).map((camera) => (
+                    <option key={camera} value={camera}>
+                      {presets[camera].title} ({camera.toLowerCase()})
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Desktop: Button List */}
+              <div className="hidden space-y-2 lg:block">
+                {typeSafeObjectKeys(presets).map((camera) => (
+                  <button
+                    key={camera}
+                    onClick={() => setSelectedCamera(camera)}
+                    className={classes(
+                      "w-full rounded px-3 py-2 text-left text-lg font-semibold",
+                      selectedCamera === camera
+                        ? "bg-alveus-green text-white"
+                        : "bg-alveus-green-50 hover:bg-alveus-green-100",
+                    )}
+                  >
+                    {presets[camera].title}
+                    <span className="text-sm text-alveus-green-400 italic">
+                      {` (${camera.toLowerCase()})`}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Preset List */}
+            <div className="col-span-1 lg:col-span-3">
+              {selectedCamera && (
+                <Fragment key={selectedCamera}>
+                  <Heading
+                    level={3}
+                    className="scroll-mt-14 text-2xl"
+                    id={`presets:${camelToKebab(selectedCamera)}`}
+                  >
+                    {presets[selectedCamera].title}
+                    <span className="text-sm text-alveus-green-400 italic">
+                      {` (${selectedCamera.toLowerCase()})`}
+                    </span>
+                  </Heading>
+
+                  <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+                    {typeSafeObjectEntries(presets[selectedCamera].presets).map(
+                      ([name, preset]) => (
+                        <div
+                          key={name}
+                          className="overflow-hidden rounded-lg border shadow-lg"
+                        >
+                          <div className="group relative aspect-video">
+                            {preset.image ? (
+                              <Image
+                                src={preset.image}
+                                alt={preset.description}
+                                fill
+                                className="aspect-video w-full object-cover transition-transform"
+                              />
+                            ) : (
+                              <div className="flex aspect-video items-center justify-center bg-alveus-green-50 text-xs text-alveus-green-300">
+                                No Image
+                              </div>
+                            )}
+                          </div>
+                          <div className="flex flex-col gap-1 bg-alveus-tan p-2">
+                            <div className="flex items-center justify-between">
+                              <h4 className="text-lg font-semibold">{name}</h4>
+                              <div className="flex gap-1">
+                                <CopyToClipboardButton
+                                  text={`!ptzload ${selectedCamera.toLowerCase()} ${name}`}
+                                />
+                                <RunCommandButton
+                                  command="ptzload"
+                                  args={[selectedCamera.toLowerCase(), name]}
+                                  subOnly
+                                />
+                              </div>
+                            </div>
+                            <p className="text-sm text-alveus-green-600 italic">
+                              {preset.description}
+                            </p>
+                          </div>
+                        </div>
+                      ),
+                    )}
+                  </div>
+                </Fragment>
+              )}
+            </div>
+          </div>
+        </Section>
+      </div>
+    </>
+  );
+};
+
+export default AboutTechPresetsPage;


### PR DESCRIPTION
## Describe your changes

With the change landed in #1249, I think its worthwhile splitting the presets out into a dedicated page that we can link subscribers to, rather than buried at the bottom of the rather daunting commands page.

This also includes a tweak to the auth/subscription check, to show loading/error statues for if Twitch misbehaves.

## Notes for testing your change

Presets page works on desktop + mobile. Tech + commands page link to presets page. All copy worded well and makes sense.
