### PR TITLE
Support custom image uploads for rounds checks

### DIFF
--- a/apps/database/prisma/schema.prisma
+++ b/apps/database/prisma/schema.prisma
@@ -443,6 +443,7 @@ model FileStorageObject {
 
   imageAttachment ImageAttachment?
   imageMetadata   ImageMetadata?
+  roundsCheck     RoundsCheck?
 
   @@index([expiresAt, deletedAt], name: "FileStorageObject_cleanup")
   @@index([expiresAt], name: "FileStorageObject_expiresAt")
@@ -483,10 +484,13 @@ model TwitchChannel {
 }
 
 model RoundsCheck {
-  id         String  @id @default(cuid())
-  name       String
-  command    String  @unique
-  ambassador String
-  order      Int
-  hidden     Boolean @default(false)
+  id                  String  @id @default(cuid())
+  name                String
+  command             String  @unique
+  ambassador          String?
+  fileStorageObjectId String? @unique
+  order               Int
+  hidden              Boolean @default(false)
+
+  fileStorageObject FileStorageObject? @relation(fields: [fileStorageObjectId], references: [id], onDelete: Cascade)
 }

--- a/apps/website/src/components/admin/rounds-checks/RoundsCheckForm.tsx
+++ b/apps/website/src/components/admin/rounds-checks/RoundsCheckForm.tsx
@@ -2,21 +2,39 @@ import { useRouter } from "next/router";
 import { type FormEvent, useCallback, useState } from "react";
 
 import ambassadors from "@alveusgg/data/build/ambassadors/core";
-import { isActiveAmbassadorEntry } from "@alveusgg/data/build/ambassadors/filters";
+import {
+  type ActiveAmbassadorKey,
+  isActiveAmbassadorEntry,
+  isActiveAmbassadorKey,
+} from "@alveusgg/data/build/ambassadors/filters";
 
 import type { RoundsCheck } from "@alveusgg/database";
 
-import type { RoundsCheckSchema } from "@/server/db/rounds-checks";
-
+import { type ImageMimeType, imageMimeTypes } from "@/utils/files";
 import { typeSafeObjectEntries } from "@/utils/helpers";
 import { SLUG_PATTERN, convertToSlug } from "@/utils/slugs";
-import { trpc } from "@/utils/trpc";
+import { type RouterInputs, trpc } from "@/utils/trpc";
+
+import useFileUpload from "@/hooks/files/upload";
 
 import { MessageBox } from "@/components/shared/MessageBox";
 import { Button, defaultButtonClasses } from "@/components/shared/form/Button";
 import { Fieldset } from "@/components/shared/form/Fieldset";
+import { ImageUploadAttachment } from "@/components/shared/form/ImageUploadAttachment";
 import { SelectBoxField } from "@/components/shared/form/SelectBoxField";
 import { TextField } from "@/components/shared/form/TextField";
+import {
+  UploadAttachmentsField,
+  useUploadAttachmentsData,
+} from "@/components/shared/form/UploadAttachmentsField";
+
+const resizeImageOptions = {
+  maxWidth: 512,
+  maxHeight: 512,
+  quality: 90,
+};
+
+type RoundsCheckSchema = RouterInputs["adminRoundsChecks"]["createRoundsCheck"];
 
 type RoundsCheckFormProps = {
   action: "create" | "edit";
@@ -25,10 +43,25 @@ type RoundsCheckFormProps = {
 
 export function RoundsCheckForm({ action, check }: RoundsCheckFormProps) {
   const router = useRouter();
-  const submit = trpc.adminRoundsChecks.createOrEditRoundsCheck.useMutation();
+  const create = trpc.adminRoundsChecks.createRoundsCheck.useMutation();
+  const edit = trpc.adminRoundsChecks.editRoundsCheck.useMutation();
+  const createFileUpload =
+    trpc.adminRoundsChecks.createFileUpload.useMutation();
+
+  const upload = useFileUpload<ImageMimeType>(
+    (signature) => createFileUpload.mutateAsync(signature),
+    { allowedFileTypes: imageMimeTypes },
+  );
+
+  const imageAttachmentData = useUploadAttachmentsData();
+  const imageFile = imageAttachmentData.files[0];
 
   const [name, setName] = useState(check?.name || "");
-  const [ambassador, setAmbassador] = useState(check?.ambassador || "");
+  const [imageType, setImageType] = useState<ActiveAmbassadorKey | "custom">(
+    check?.ambassador && isActiveAmbassadorKey(check.ambassador)
+      ? check.ambassador
+      : "custom",
+  );
 
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
@@ -36,11 +69,28 @@ export function RoundsCheckForm({ action, check }: RoundsCheckFormProps) {
 
       const formData = new FormData(event.currentTarget);
 
+      const imageData =
+        imageType === "custom"
+          ? {
+              ambassador: null,
+              fileStorageObjectId:
+                imageFile?.status === "upload.done"
+                  ? imageFile.fileStorageObjectId
+                  : (check?.fileStorageObjectId ?? ""),
+            }
+          : {
+              ambassador: imageType,
+              fileStorageObjectId: null,
+            };
+      if (!imageData.ambassador && !imageData.fileStorageObjectId) {
+        return;
+      }
+
       const mutationData: RoundsCheckSchema = {
         name: String(formData.get("name")),
         command: convertToSlug(String(formData.get("name"))),
-        ambassador: String(formData.get("ambassador")),
         hidden: check?.hidden ?? false,
+        ...imageData,
       };
 
       const command =
@@ -51,33 +101,29 @@ export function RoundsCheckForm({ action, check }: RoundsCheckFormProps) {
 
       if (action === "edit") {
         if (!check) return;
-        submit.mutate({
-          action: "edit",
+        edit.mutate({
           id: check.id,
           ...mutationData,
         });
       } else {
-        submit.mutate(
-          { action: "create", ...mutationData },
-          {
-            onSuccess: async () => {
-              await router.push("/admin/rounds-checks");
-            },
+        create.mutate(mutationData, {
+          onSuccess: async () => {
+            await router.push("/admin/rounds-checks");
           },
-        );
+        });
       }
     },
-    [action, check, router, submit],
+    [imageType, imageFile, action, check, router, create, edit],
   );
 
   return (
     <form className="flex flex-col gap-10" onSubmit={handleSubmit}>
-      {submit.error && (
+      {(create.error || edit.error) && (
         <MessageBox variant="failure">
-          <pre>{submit.error.message}</pre>
+          <pre>{(create.error || edit.error)?.message}</pre>
         </MessageBox>
       )}
-      {submit.isSuccess && (
+      {edit.isSuccess && (
         <MessageBox variant="success">Rounds check updated!</MessageBox>
       )}
 
@@ -105,20 +151,42 @@ export function RoundsCheckForm({ action, check }: RoundsCheckFormProps) {
         />
 
         <SelectBoxField
-          label="Ambassador (image)"
-          name="ambassador"
+          label="Image"
+          name="image"
           required
-          value={ambassador}
-          onChange={(event) => setAmbassador(event.target.value)}
+          value={imageType}
+          onChange={(event) =>
+            setImageType(event.target.value as ActiveAmbassadorKey | "custom")
+          }
         >
-          {typeSafeObjectEntries(ambassadors)
-            .filter(isActiveAmbassadorEntry)
-            .map(([key, { name }]) => (
-              <option key={key} value={key}>
-                {name}
-              </option>
-            ))}
+          <optgroup>
+            <option value="custom">Custom upload</option>
+          </optgroup>
+          <optgroup>
+            {typeSafeObjectEntries(ambassadors)
+              .filter(isActiveAmbassadorEntry)
+              .map(([key, { name }]) => (
+                <option key={key} value={key}>
+                  {name}
+                </option>
+              ))}
+          </optgroup>
         </SelectBoxField>
+
+        {imageType === "custom" && (
+          <UploadAttachmentsField
+            label=""
+            {...imageAttachmentData}
+            maxNumber={1}
+            multiple={false}
+            upload={upload}
+            allowedFileTypes={imageMimeTypes}
+            resizeImageOptions={resizeImageOptions}
+            renderAttachment={({ fileReference, ...props }) => (
+              <ImageUploadAttachment {...props} fileReference={fileReference} />
+            )}
+          />
+        )}
       </Fieldset>
 
       <Button type="submit" className={defaultButtonClasses}>

--- a/apps/website/src/components/admin/rounds-checks/RoundsChecks.tsx
+++ b/apps/website/src/components/admin/rounds-checks/RoundsChecks.tsx
@@ -35,11 +35,10 @@ function RoundsCheck({ check, onError, onUpdate, first, last }: CheckProps) {
     onError: (error) => onError(error.message),
     onSettled: () => onUpdate(),
   });
-  const editMutation =
-    trpc.adminRoundsChecks.createOrEditRoundsCheck.useMutation({
-      onError: (error) => onError(error.message),
-      onSettled: () => onUpdate(),
-    });
+  const editMutation = trpc.adminRoundsChecks.editRoundsCheck.useMutation({
+    onError: (error) => onError(error.message),
+    onSettled: () => onUpdate(),
+  });
   const moveMutation = trpc.adminRoundsChecks.moveRoundsCheck.useMutation({
     onError: (error) => onError(error.message),
     onSettled: () => onUpdate(),
@@ -115,7 +114,6 @@ function RoundsCheck({ check, onError, onUpdate, first, last }: CheckProps) {
             title={`${check.hidden ? "Show" : "Hide"} check`}
             onClick={() =>
               editMutation.mutate({
-                action: "edit",
                 id: check.id,
                 hidden: !check.hidden,
               })

--- a/apps/website/src/components/overlay/Checks.tsx
+++ b/apps/website/src/components/overlay/Checks.tsx
@@ -33,9 +33,11 @@ const Check = ({
       <div className="relative size-20">
         <Image
           src={check.icon.src}
+          width={80}
+          height={80}
           alt=""
           className={classes(
-            "size-full rounded-full border-4 object-cover",
+            "size-full rounded-full border-4 bg-alveus-green object-cover",
             check.status
               ? "border-green-400 brightness-50 saturate-50"
               : "border-white",

--- a/apps/website/src/server/db/rounds-checks.ts
+++ b/apps/website/src/server/db/rounds-checks.ts
@@ -1,26 +1,57 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
+import {
+  type ActiveAmbassadorKey,
+  isActiveAmbassadorKey,
+} from "@alveusgg/data/build/ambassadors/filters";
+
 import { prisma } from "@alveusgg/database";
+
+import {
+  checkAndFixUploadedImageFileStorageObject,
+  deleteFileStorageObject,
+} from "@/server/utils/file-storage";
 
 import { SLUG_REGEX } from "@/utils/slugs";
 
-export const MAX_VISIBLE_ROUNDS_CHECKS = 12;
+const MAX_VISIBLE_ROUNDS_CHECKS = 12;
 
-export const roundsCheckSchema = z.object({
+const roundsCheckSchemaBase = z.object({
   name: z.string().min(1),
   command: z.string().regex(SLUG_REGEX),
-  ambassador: z.string(),
   hidden: z.boolean(),
 });
 
+const roundsCheckSchemaImage = z.union([
+  z.object({
+    ambassador: z.custom<ActiveAmbassadorKey>(
+      (value) => typeof value === "string" && isActiveAmbassadorKey(value),
+      "must be a valid active ambassador key",
+    ),
+    fileStorageObjectId: z.null(),
+  }),
+  z.object({
+    ambassador: z.null(),
+    fileStorageObjectId: z.cuid(),
+  }),
+]);
+
+export const roundsCheckSchema = roundsCheckSchemaBase.and(
+  roundsCheckSchemaImage,
+);
 export type RoundsCheckSchema = z.infer<typeof roundsCheckSchema>;
 
-export const existingRoundsCheckSchema = z
+const existingRoundsCheckSchemaBase = z
   .object({
     id: z.cuid(),
   })
-  .merge(roundsCheckSchema.partial());
+  .and(roundsCheckSchemaBase.partial());
+
+export const existingRoundsCheckSchema = z.union([
+  existingRoundsCheckSchemaBase,
+  existingRoundsCheckSchemaBase.and(roundsCheckSchemaImage),
+]);
 
 export async function createRoundsCheck(
   input: z.infer<typeof roundsCheckSchema>,
@@ -33,6 +64,18 @@ export async function createRoundsCheck(
       code: "BAD_REQUEST",
       message: "Command already exists",
     });
+
+  if (input.fileStorageObjectId) {
+    const { error } = await checkAndFixUploadedImageFileStorageObject(
+      input.fileStorageObjectId,
+    );
+    if (error) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `Error checking file storage object: ${error}`,
+      });
+    }
+  }
 
   if (input.hidden === false) {
     const existingRoundsChecksVisible = await prisma.roundsCheck.aggregate({
@@ -57,9 +100,16 @@ export async function createRoundsCheck(
 export async function editRoundsCheck(
   input: z.infer<typeof existingRoundsCheckSchema>,
 ) {
-  if (typeof input.command === "string") {
+  const { id, ...data } = input;
+
+  const existingRoundsCheck = await prisma.roundsCheck.findUnique({
+    where: { id },
+  });
+  if (!existingRoundsCheck) throw new TRPCError({ code: "NOT_FOUND" });
+
+  if (typeof data.command === "string") {
     const existingRoundsCheckWithCommand = await prisma.roundsCheck.findFirst({
-      where: { command: input.command, id: { not: input.id } },
+      where: { command: data.command, id: { not: id } },
     });
     if (existingRoundsCheckWithCommand)
       throw new TRPCError({
@@ -68,9 +118,9 @@ export async function editRoundsCheck(
       });
   }
 
-  if (input.hidden === false) {
+  if (data.hidden === false) {
     const existingRoundsChecksVisible = await prisma.roundsCheck.aggregate({
-      where: { hidden: false, id: { not: input.id } },
+      where: { hidden: false, id: { not: id } },
       _count: true,
     });
     if (existingRoundsChecksVisible._count >= MAX_VISIBLE_ROUNDS_CHECKS)
@@ -80,7 +130,29 @@ export async function editRoundsCheck(
       });
   }
 
-  const { id, ...data } = input;
+  if ("fileStorageObjectId" in data) {
+    // If there was previously a file storage object, and it has now changed,
+    // we need to remove it from storage.
+    if (
+      existingRoundsCheck.fileStorageObjectId &&
+      existingRoundsCheck.fileStorageObjectId !== data.fileStorageObjectId
+    ) {
+      await deleteFileStorageObject(existingRoundsCheck.fileStorageObjectId);
+    }
+
+    if (data.fileStorageObjectId) {
+      const { error } = await checkAndFixUploadedImageFileStorageObject(
+        data.fileStorageObjectId,
+      );
+      if (error) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Error checking file storage object: ${error}`,
+        });
+      }
+    }
+  }
+
   return await prisma.roundsCheck.update({
     where: { id },
     data,

--- a/apps/website/src/server/trpc/router/admin/rounds-checks.ts
+++ b/apps/website/src/server/trpc/router/admin/rounds-checks.ts
@@ -1,4 +1,7 @@
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+
+import { env } from "@/env";
 
 import {
   createRoundsCheck,
@@ -12,37 +15,29 @@ import {
   protectedProcedure,
   router,
 } from "@/server/trpc/trpc";
+import {
+  createFileStorageUpload,
+  deleteFileStorageObject,
+} from "@/server/utils/file-storage";
 
 import { permissions } from "@/data/permissions";
+
+import { imageMimeTypes } from "@/utils/files";
+
+const uploadPrefix = "rounds-checks/";
 
 const permittedProcedure = protectedProcedure.use(
   createCheckPermissionMiddleware(permissions.manageRoundsChecks),
 );
 
 export const adminRoundsChecksRouter = router({
-  createOrEditRoundsCheck: permittedProcedure
-    .input(
-      z.discriminatedUnion("action", [
-        z.object({ action: z.literal("create") }).merge(roundsCheckSchema),
-        z
-          .object({ action: z.literal("edit") })
-          .merge(existingRoundsCheckSchema),
-      ]),
-    )
-    .mutation(async ({ input }) => {
-      switch (input.action) {
-        case "create": {
-          const { action: _, ...data } = input;
-          await createRoundsCheck(data);
-          break;
-        }
-        case "edit": {
-          const { action: _, ...data } = input;
-          await editRoundsCheck(data);
-          break;
-        }
-      }
-    }),
+  createRoundsCheck: permittedProcedure
+    .input(roundsCheckSchema)
+    .mutation(({ input }) => createRoundsCheck(input)),
+
+  editRoundsCheck: permittedProcedure
+    .input(existingRoundsCheckSchema)
+    .mutation(({ input }) => editRoundsCheck(input)),
 
   moveRoundsCheck: permittedProcedure
     .input(
@@ -58,6 +53,19 @@ export const adminRoundsChecksRouter = router({
   deleteRoundsCheck: permittedProcedure
     .input(z.cuid())
     .mutation(async ({ ctx, input: id }) => {
+      const roundsCheck = await ctx.prisma.roundsCheck.findUnique({
+        where: { id },
+      });
+      if (!roundsCheck) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Rounds check not found",
+        });
+      }
+
+      if (roundsCheck.fileStorageObjectId) {
+        await deleteFileStorageObject(roundsCheck.fileStorageObjectId);
+      }
       await ctx.prisma.roundsCheck.delete({ where: { id: id } });
     }),
 
@@ -70,4 +78,40 @@ export const adminRoundsChecksRouter = router({
   getRoundsChecks: permittedProcedure.query(({ ctx }) =>
     ctx.prisma.roundsCheck.findMany({ orderBy: { order: "asc" } }),
   ),
+
+  createFileUpload: permittedProcedure
+    .input(
+      z.object({
+        fileName: z.string(),
+        fileType: z.literal(imageMimeTypes),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const { uploadUrl, viewUrl, fileStorageObject } =
+        await createFileStorageUpload({
+          fileName: input.fileName,
+          fileType: input.fileType,
+          prefix: uploadPrefix,
+        });
+
+      if (env.NODE_ENV === "development") {
+        /*
+         * To enable uploads to DO Spaces in development, we need to proxy the request
+         * through the Next.js server. This is because the DO Spaces endpoint is not
+         * accessible without ssl, and Next.js does not support ssl in development.
+         */
+
+        return {
+          viewUrl: String(viewUrl),
+          uploadUrl: `/api/file-upload${uploadUrl.pathname}${uploadUrl.search}`,
+          fileStorageObjectId: fileStorageObject.id,
+        };
+      }
+
+      return {
+        viewUrl: String(viewUrl),
+        uploadUrl: String(uploadUrl),
+        fileStorageObjectId: fileStorageObject.id,
+      };
+    }),
 });


### PR DESCRIPTION
## Describe your changes

We may want to have rounds checks with images that aren't ambassadors, so this adds support for this via the same upload mechanism that we use elsewhere in the app.

## Notes for testing your change

- Creating a new check with an image works
- Updating the name/command of a check that has an image works
  - Check image persisted
- Uploading a new image to a check that already has an image works
  - Check in S3 provider (localhost:9001 locally) that the old image was removed
- Switching a check with an image to an ambassador works
  - Check in S3 provider (localhost:9001 locally) that the old image was removed
- Switching a check set to an ambassador to a custom image works
