### PR TITLE
Fix outline on focus for nav dropdown items

### DIFF
--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -177,7 +177,7 @@ export function DesktopMenu() {
                     {link.title}
                     <IconChevronDown
                       size={16}
-                      className="translate-y-0.5 transition-transform group-data-[active]/button:translate-y-1"
+                      className="translate-y-0.5 transition-transform group-data-active/button:translate-y-1"
                     />
                   </MenuButton>
 
@@ -192,7 +192,7 @@ export function DesktopMenu() {
                           <NavLinkSub
                             href={link.link}
                             isExternal={link.isExternal}
-                            className="w-full min-w-max group-data-[focus]/item:outline-blue-500 group-data-[focus]/item:group-focus-visible/items:outline"
+                            className="w-full min-w-max outline-blue-500 group-data-focus/item:not-hover:outline-2"
                             onClick={close}
                           >
                             {link.title}


### PR DESCRIPTION
## Describe your changes

A headless UI update recently (#1222) changed the behaviour of focus within dropdown menus -- this PR updates our classes relating to that, so that on hover we only show the background, and on focus we only show the online.

## Notes for testing your change

When hovering over an item in a nav dropdown menu, only the background changes.
When using keyboard controls to focus on an item in a nav dropdown menu, only the outline changes.
