### PR TITLE
Show command previews in tooltips for presets page

### DIFF
--- a/apps/website/src/components/shared/actions/ActionButton.tsx
+++ b/apps/website/src/components/shared/actions/ActionButton.tsx
@@ -7,25 +7,34 @@ type ActionButtonProps = {
   icon: ({ className }: { className: string }) => ReactNode;
   tooltip: {
     text: string;
-    force: boolean;
+    elm?: ({
+      className,
+      children,
+    }: {
+      className: string;
+      children: string;
+    }) => ReactNode;
+    force?: boolean;
   };
 };
 
-const ActionButton = ({ onClick, icon: Icon, tooltip }: ActionButtonProps) => (
-  <div className="group relative inline-block">
-    <span
-      className={classes(
-        "pointer-events-none absolute top-1/2 right-full z-10 -translate-y-1/2 rounded-md bg-alveus-green-900 px-1 text-nowrap text-white transition-opacity",
-        tooltip.force ? "opacity-100" : "opacity-0",
-        "group-hover:opacity-100",
-      )}
-    >
-      {tooltip.text}
-    </span>
-    <button onClick={onClick} title={tooltip.text}>
-      <Icon className="m-1 inline size-5 cursor-pointer text-alveus-green-400 group-hover:text-black" />
-    </button>
-  </div>
-);
+const ActionButton = ({ onClick, icon: Icon, tooltip }: ActionButtonProps) => {
+  const Tooltip = tooltip.elm ?? "div";
+  return (
+    <div className="group relative inline-block">
+      <Tooltip
+        className={classes(
+          "pointer-events-none absolute top-1/2 left-0 z-10 -translate-x-full -translate-y-1/2 rounded-md bg-alveus-green-900 px-1 py-0.5 leading-tight text-nowrap text-white transition-opacity",
+          tooltip.force ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+        )}
+      >
+        {tooltip.text}
+      </Tooltip>
+      <button onClick={onClick} title={tooltip.text}>
+        <Icon className="m-1 inline size-5 cursor-pointer text-alveus-green-400 transition-colors group-hover:text-black" />
+      </button>
+    </div>
+  );
+};
 
 export default ActionButton;

--- a/apps/website/src/components/shared/actions/ActionButton.tsx
+++ b/apps/website/src/components/shared/actions/ActionButton.tsx
@@ -5,19 +5,13 @@ import { classes } from "@/utils/classes";
 type ActionButtonProps = {
   onClick: () => void;
   icon: ({ className }: { className: string }) => ReactNode;
-  alt: string;
   tooltip: {
     text: string;
     force: boolean;
   };
 };
 
-const ActionButton = ({
-  onClick,
-  icon: Icon,
-  alt,
-  tooltip,
-}: ActionButtonProps) => (
+const ActionButton = ({ onClick, icon: Icon, tooltip }: ActionButtonProps) => (
   <div className="group relative inline-block">
     <span
       className={classes(
@@ -28,7 +22,7 @@ const ActionButton = ({
     >
       {tooltip.text}
     </span>
-    <button onClick={onClick} title={alt}>
+    <button onClick={onClick} title={tooltip.text}>
       <Icon className="m-1 inline size-5 cursor-pointer text-alveus-green-400 group-hover:text-black" />
     </button>
   </div>

--- a/apps/website/src/components/shared/actions/ActionPreviewTooltip.tsx
+++ b/apps/website/src/components/shared/actions/ActionPreviewTooltip.tsx
@@ -1,0 +1,19 @@
+import { classes } from "@/utils/classes";
+
+const getActionPreviewTooltip = (preview: string) => {
+  const ActionPreviewTooltip = ({
+    className,
+    children,
+  }: {
+    className: string;
+    children: string;
+  }) => (
+    <div className={classes(className, "flex flex-col")}>
+      <span>{children}</span>
+      <span className="font-mono text-xs text-alveus-green-300">{preview}</span>
+    </div>
+  );
+  return ActionPreviewTooltip;
+};
+
+export default getActionPreviewTooltip;

--- a/apps/website/src/components/shared/actions/CopyToClipboardButton.tsx
+++ b/apps/website/src/components/shared/actions/CopyToClipboardButton.tsx
@@ -27,7 +27,6 @@ const CopyToClipboardButton = ({
     <ActionButton
       onClick={onClick}
       icon={IconClipboard}
-      alt="Copy to clipboard"
       tooltip={{ text: statusText, force: status !== undefined }}
     />
   );

--- a/apps/website/src/components/shared/actions/CopyToClipboardButton.tsx
+++ b/apps/website/src/components/shared/actions/CopyToClipboardButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import {
   type CopyToClipboardOptions,
@@ -8,26 +8,36 @@ import {
 import IconClipboard from "@/icons/IconClipboard";
 
 import ActionButton from "./ActionButton";
+import getActionPreviewTooltip from "./ActionPreviewTooltip";
 
 type CopyToClipboardButtonProps = {
   text: string;
+  preview?: boolean;
   options?: CopyToClipboardOptions;
 };
 
 const CopyToClipboardButton = ({
   text,
+  preview = false,
   options,
 }: CopyToClipboardButtonProps) => {
   const { copy, status, statusText } = useCopyToClipboard(options);
+
   const onClick = useCallback(async () => {
     await copy(text);
   }, [copy, text]);
+
+  const PreviewTooltip = useMemo(() => getActionPreviewTooltip(text), [text]);
 
   return (
     <ActionButton
       onClick={onClick}
       icon={IconClipboard}
-      tooltip={{ text: statusText, force: status !== undefined }}
+      tooltip={{
+        text: statusText,
+        elm: preview && !status ? PreviewTooltip : undefined,
+        force: status !== undefined,
+      }}
     />
   );
 };

--- a/apps/website/src/components/shared/actions/RunCommandButton.tsx
+++ b/apps/website/src/components/shared/actions/RunCommandButton.tsx
@@ -6,30 +6,12 @@ import type { runCommandSchema } from "@/server/trpc/router/stream";
 
 import { scopeGroups } from "@/data/twitch";
 
-import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
 
 import IconVideoCamera from "@/icons/IconVideoCamera";
 
 import ActionButton from "./ActionButton";
-
-const getCommandTooltip = (command: string, args?: string[]) => {
-  const CommandTooltip = ({
-    className,
-    children,
-  }: {
-    className: string;
-    children: string;
-  }) => (
-    <div className={classes(className, "flex flex-col")}>
-      <span>{children}</span>
-      <span className="font-mono text-xs text-alveus-green-300">
-        !{[command, ...(args ?? [])].join(" ")}
-      </span>
-    </div>
-  );
-  return CommandTooltip;
-};
+import getActionPreviewTooltip from "./ActionPreviewTooltip";
 
 interface RunCommandButtonProps extends z.infer<typeof runCommandSchema> {
   subOnly?: boolean;
@@ -87,8 +69,8 @@ const RunCommandButton = ({
     }
   }, [status]);
 
-  const CommandTooltip = useMemo(
-    () => getCommandTooltip(command, args),
+  const PreviewTooltip = useMemo(
+    () => getActionPreviewTooltip(`!${[command, ...(args ?? [])].join(" ")}`),
     [command, args],
   );
 
@@ -100,7 +82,7 @@ const RunCommandButton = ({
       icon={IconVideoCamera}
       tooltip={{
         text: statusText ?? "Run command",
-        elm: statusText ? undefined : CommandTooltip,
+        elm: statusText ? undefined : PreviewTooltip,
         force: !!statusText,
       }}
     />

--- a/apps/website/src/components/shared/actions/RunCommandButton.tsx
+++ b/apps/website/src/components/shared/actions/RunCommandButton.tsx
@@ -1,16 +1,35 @@
 import { useSession } from "next-auth/react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { z } from "zod";
 
 import type { runCommandSchema } from "@/server/trpc/router/stream";
 
 import { scopeGroups } from "@/data/twitch";
 
+import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
 
 import IconVideoCamera from "@/icons/IconVideoCamera";
 
 import ActionButton from "./ActionButton";
+
+const getCommandTooltip = (command: string, args?: string[]) => {
+  const CommandTooltip = ({
+    className,
+    children,
+  }: {
+    className: string;
+    children: string;
+  }) => (
+    <div className={classes(className, "flex flex-col")}>
+      <span>{children}</span>
+      <span className="font-mono text-xs text-alveus-green-300">
+        !{[command, ...(args ?? [])].join(" ")}
+      </span>
+    </div>
+  );
+  return CommandTooltip;
+};
 
 interface RunCommandButtonProps extends z.infer<typeof runCommandSchema> {
   subOnly?: boolean;
@@ -68,13 +87,22 @@ const RunCommandButton = ({
     }
   }, [status]);
 
+  const CommandTooltip = useMemo(
+    () => getCommandTooltip(command, args),
+    [command, args],
+  );
+
   if (!hasScopes || (subOnly && !subscription.data)) return null;
 
   return (
     <ActionButton
       onClick={onClick}
       icon={IconVideoCamera}
-      tooltip={{ text: statusText ?? "Run command", force: !!statusText }}
+      tooltip={{
+        text: statusText ?? "Run command",
+        elm: statusText ? undefined : CommandTooltip,
+        force: !!statusText,
+      }}
     />
   );
 };

--- a/apps/website/src/components/shared/actions/RunCommandButton.tsx
+++ b/apps/website/src/components/shared/actions/RunCommandButton.tsx
@@ -74,7 +74,6 @@ const RunCommandButton = ({
     <ActionButton
       onClick={onClick}
       icon={IconVideoCamera}
-      alt="Run command"
       tooltip={{ text: statusText ?? "Run command", force: !!statusText }}
     />
   );

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -232,6 +232,7 @@ const AboutTechPresetsPage: NextPage = () => {
                                 <CopyToClipboardButton
                                   text={`!ptzload ${selectedCamera.toLowerCase()} ${name}`}
                                   options={{ initialText: "Copy command" }}
+                                  preview
                                 />
                                 <RunCommandButton
                                   command="ptzload"

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -209,9 +209,9 @@ const AboutTechPresetsPage: NextPage = () => {
                       ([name, preset]) => (
                         <div
                           key={name}
-                          className="overflow-hidden rounded-lg border shadow-lg"
+                          className="rounded-lg border border-alveus-green-900 shadow-lg"
                         >
-                          <div className="group relative aspect-video">
+                          <div className="group relative aspect-video overflow-hidden rounded-t-lg">
                             {preset.image ? (
                               <Image
                                 src={preset.image}
@@ -225,7 +225,7 @@ const AboutTechPresetsPage: NextPage = () => {
                               </div>
                             )}
                           </div>
-                          <div className="flex flex-col gap-1 bg-alveus-tan p-2">
+                          <div className="flex flex-col gap-1 rounded-b-lg bg-alveus-tan p-2">
                             <div className="flex items-center justify-between">
                               <h4 className="text-lg font-semibold">{name}</h4>
                               <div className="flex gap-1">


### PR DESCRIPTION
## Describe your changes

Explicitly show the user what command will be run/copied when they click a button within a preset card.

## Notes for testing your change

Commands are correct, tooltips render correctly.
