### PR TITLE
Update security policy link

### DIFF
--- a/apps/website/public/.well-known/security.txt
+++ b/apps/website/public/.well-known/security.txt
@@ -1,4 +1,4 @@
 Contact: mailto:opensource@alveussanctuary.org
-Policy: https://github.com/alveusgg/alveusgg/blob/main/SECURITY.md
-Expires: 2025-01-31T04:00:00.000Z
+Policy: https://github.com/alveusgg/alveusgg/security/policy
+Expires: 2026-01-31T04:00:00.000Z
 Preferred-Languages: en


### PR DESCRIPTION
## Describe your changes

Resolves #1274.

Update security policy link, as previous link was broken (404), and bump expiry date to `2026-01-31T04:00:00.000Z`. Let me know if I should bump the expiry date to something different instead.

## Notes for testing your change

Compare http://localhost:3000/.well-known/security.txt with https://www.alveussanctuary.org/.well-known/security.txt
