### PR TITLE
Fix schema for fetching YouTube live

### DIFF
--- a/apps/website/src/server/apis/youtube.ts
+++ b/apps/website/src/server/apis/youtube.ts
@@ -105,24 +105,16 @@ const SearchSchema = z.object({
         channelTitle: z.string(),
         publishedAt: z.iso.datetime(),
         thumbnails: z.record(
-          z.union([
-            z.literal("default"),
-            z.literal("medium"),
-            z.literal("high"),
-            z.literal("standard"),
-            z.literal("maxres"),
-          ]),
-          z.object({
-            url: z.url(),
-            width: z.number(),
-            height: z.number(),
-          }),
+          z.literal(["default", "medium", "high", "standard", "maxres"]),
+          z
+            .object({
+              url: z.url(),
+              width: z.number(),
+              height: z.number(),
+            })
+            .optional(),
         ),
-        liveBroadcastContent: z.union([
-          z.literal("none"),
-          z.literal("upcoming"),
-          z.literal("live"),
-        ]),
+        liveBroadcastContent: z.literal(["none", "upcoming", "live"]),
       }),
     }),
   ),


### PR DESCRIPTION
## Describe your changes

Fixes an error observed in production:

```
Error getting YouTube live Error [ZodError]: [
  {
    "expected": "object",
    "code": "invalid_type",
    "path": [
      "items",
      0,
      "snippet",
      "thumbnails",
      "standard"
    ],
    "message": "Invalid input: expected object, received undefined"
  },
  {
    "expected": "object",
    "code": "invalid_type",
    "path": [
      "items",
      0,
      "snippet",
      "thumbnails",
      "maxres"
    ],
    "message": "Invalid input: expected object, received undefined"
  }
]
```

https://developers.google.com/youtube/v3/docs/search#properties indicates these keys should always map to an object, but clearly they don't.

## Notes for testing your change

/live/youtube/chat works.
