### PR TITLE
Store VoDs in notifications + add bot API route for recent streams

### DIFF
--- a/apps/chatbot/src/bot/commands/notification.ts
+++ b/apps/chatbot/src/bot/commands/notification.ts
@@ -20,6 +20,7 @@ type PendingNotification = {
   text?: string;
   linkUrl?: string;
   imageUrl?: string;
+  vodUrl?: string;
   title: string;
   expiresAt: number;
   isPush: boolean;
@@ -58,6 +59,10 @@ const options = createOptions({
   image: {
     type: "url",
     help: "Set the image URL",
+  },
+  vod: {
+    type: "url",
+    help: "Set the VoD URL",
   },
 });
 
@@ -119,6 +124,7 @@ function renderPendingNotification(notification: PendingNotification) {
     notification.text,
     notification.linkUrl,
     notification.imageUrl ? "has image" : null,
+    notification.vodUrl ? "has VoD" : null,
     notification.isPush ? "will push" : null,
     notification.isDiscord ? "will post in discord" : null,
   ]
@@ -183,6 +189,7 @@ export async function createNotificationCommands() {
       isPush: !optionValues["no-push"],
       isDiscord: !optionValues["no-discord"],
       imageUrl: optionValues.image,
+      vodUrl: optionValues.vod,
     });
     pendingNotifications.set(broadcasterId, pendingNotification);
 
@@ -249,6 +256,7 @@ export async function createNotificationCommands() {
       isPush: !optionValues["no-push"],
       isDiscord: !optionValues["no-discord"],
       imageUrl: optionValues.image,
+      vodUrl: optionValues.vod,
     });
     pendingNotifications.set(broadcasterId, pendingNotification);
 
@@ -286,6 +294,7 @@ export async function createNotificationCommands() {
       isDiscord: pendingNotification.isDiscord,
       isPush: pendingNotification.isPush,
       imageUrl: pendingNotification.imageUrl,
+      vodUrl: pendingNotification.vodUrl,
     })
       .then(() => {
         reply("poggSpin sent notification");

--- a/apps/chatbot/src/website-api/notifications.ts
+++ b/apps/chatbot/src/website-api/notifications.ts
@@ -15,6 +15,7 @@ const notificationSchema = z.object({
   title: z.string().optional(),
   linkUrl: z.url().optional(),
   imageUrl: z.url().optional(),
+  vodUrl: z.url().optional(),
   scheduledStartAt: dateSchema.optional(),
   scheduledEndAt: dateSchema.optional(),
   isPush: z.boolean().optional(),

--- a/apps/database/prisma/schema.prisma
+++ b/apps/database/prisma/schema.prisma
@@ -143,6 +143,7 @@ model Notification {
   title            String?
   linkUrl          String?
   imageUrl         String?
+  vodUrl           String?
   tag              String?
   urgency          NotificationUrgency @default(NORMAL)
   isPush           Boolean             @default(false)

--- a/apps/website/src/app/api/stream/recent/route.ts
+++ b/apps/website/src/app/api/stream/recent/route.ts
@@ -1,0 +1,42 @@
+import { DateTime } from "luxon";
+
+import { prisma } from "@alveusgg/database";
+
+// API for chat bot
+export async function GET() {
+  try {
+    // Get the three most recent stream notifications that have a VoD URL
+    const recent = await prisma.notification.findMany({
+      where: {
+        tag: "stream",
+        vodUrl: {
+          not: null,
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+      take: 3,
+    });
+
+    // Format the notifications into a string
+    return new Response(
+      recent
+        .map(
+          (notification) =>
+            `${notification.title} (${DateTime.fromJSDate(notification.createdAt).toFormat("MMMM d")}): ${notification.vodUrl}`,
+        )
+        .join(" | "),
+      {
+        headers: {
+          // Response can be cached for 1 minute
+          "Cache-Control": "max-age=60, s-maxage=60, must-revalidate",
+          "X-Generated-At": new Date().toISOString(),
+        },
+      },
+    );
+  } catch (err) {
+    console.error("Error getting recent streams", err);
+    return new Response("Recent streams not available", { status: 500 });
+  }
+}

--- a/apps/website/src/components/admin/notifications/SendNotificationForm.tsx
+++ b/apps/website/src/components/admin/notifications/SendNotificationForm.tsx
@@ -88,6 +88,7 @@ export function SendNotificationForm() {
         scheduledStartAt,
         scheduledEndAt,
         imageUrl,
+        vodUrl: String(data.get("vodUrl")) || undefined,
         fileStorageObjectId,
         isPush: channels.includes("push"),
         isDiscord: channels.includes("discord"),
@@ -182,6 +183,16 @@ export function SendNotificationForm() {
             renderAttachment={({ fileReference, ...props }) => (
               <ImageUploadAttachment {...props} fileReference={fileReference} />
             )}
+          />
+
+          <TextField
+            label="VoD"
+            name="vodUrl"
+            inputMode="url"
+            type="vodUrl"
+            showResetButton={true}
+            pattern="https?://.*"
+            inputClassName="font-mono"
           />
 
           <Fieldset legend="Announcement details">

--- a/apps/website/src/pages/api/notifications/create-notification.ts
+++ b/apps/website/src/pages/api/notifications/create-notification.ts
@@ -17,6 +17,7 @@ const notificationSchema = z.object({
   title: z.string().optional(),
   linkUrl: z.url().optional(),
   imageUrl: z.url().optional(),
+  vodUrl: z.url().optional(),
   scheduledStartAt: dateSchema.optional(),
   scheduledEndAt: dateSchema.optional(),
   isPush: z.boolean().optional(),

--- a/apps/website/src/server/notifications.ts
+++ b/apps/website/src/server/notifications.ts
@@ -23,6 +23,7 @@ type CreateNotificationData = {
   linkUrl?: string;
   title?: string;
   imageUrl?: string;
+  vodUrl?: string;
   scheduledStartAt?: Date | null;
   scheduledEndAt?: Date | null;
   isPush?: boolean;
@@ -61,6 +62,7 @@ export async function createNotification(data: CreateNotificationData) {
       message: data.text || "",
       linkUrl: data.linkUrl,
       imageUrl: data.imageUrl || null,
+      vodUrl: data.vodUrl || null,
       tag: data.tag,
       urgency: tagConfig.urgency,
       scheduledStartAt: data.scheduledStartAt || null,
@@ -90,6 +92,7 @@ export async function copyNotification(notificationId: string) {
     title: oldNotification.title || defaultTitle,
     imageUrl: oldNotification.imageUrl || undefined,
     linkUrl: oldNotification.linkUrl || undefined,
+    vodUrl: oldNotification.vodUrl || undefined,
     text: oldNotification.message,
     scheduledEndAt: oldNotification.scheduledEndAt,
     scheduledStartAt: oldNotification.scheduledStartAt,

--- a/apps/website/src/server/trpc/router/admin/notifications.ts
+++ b/apps/website/src/server/trpc/router/admin/notifications.ts
@@ -50,6 +50,7 @@ export const adminNotificationsRouter = router({
         title: z.string(),
         linkUrl: z.union([z.literal(""), z.string().trim().url()]).optional(),
         imageUrl: z.url().optional(),
+        vodUrl: z.url().optional(),
         scheduledStartAt: localDatetimeAsDateSchema.optional(),
         scheduledEndAt: localDatetimeAsDateSchema.optional(),
         fileStorageObjectId: z.cuid().optional(),


### PR DESCRIPTION
## Describe your changes

Allows for VoD URLs to be stored as part of creating a notification, which can be added to the notification command automation in Twitch chat for regular streams.

Adds a new API endpoint for use in the Twitch chat bot to show recent streams based on the new VoD URLs being included in the notifications being sent.

## Notes for testing your change

Notifications can continue to be sent as normal. VoD URL can optionally be included via the web UI or chat command. Endpoint shows most recent notifications with a VoD URL.