### PR TITLE
Fix Show-And-Tell Modal Dialog closing if document is clicked anywhere

### DIFF
--- a/apps/website/src/components/show-and-tell/CommunityMap.tsx
+++ b/apps/website/src/components/show-and-tell/CommunityMap.tsx
@@ -13,7 +13,7 @@ import { MessageBox } from "@/components/shared/MessageBox";
 import { ShowAndTellEntry } from "@/components/show-and-tell/ShowAndTellEntry";
 
 import Section from "../content/Section";
-import { ModalDialog } from "../shared/ModalDialog";
+import { ModalBlockProvider, ModalDialog } from "../shared/ModalDialog";
 
 import "maplibre-gl/dist/maplibre-gl.css";
 
@@ -165,7 +165,7 @@ export function CommunityMap({
   );
 
   return (
-    <>
+    <ModalBlockProvider>
       <div
         id="mapVisualizerContainer"
         className="alveus-community-map h-[60vh] max-h-[800px] w-full overflow-hidden rounded-xl border-4 border-alveus-green bg-gray-400 shadow-2xl"
@@ -196,6 +196,6 @@ export function CommunityMap({
           )}
         </Section>
       </ModalDialog>
-    </>
+    </ModalBlockProvider>
   );
 }

--- a/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/ShowAndTellGallery.tsx
@@ -19,6 +19,7 @@ import {
 import { useConsent } from "@/hooks/consent";
 
 import Carousel from "@/components/content/Carousel";
+import { useModalBlock } from "@/components/shared/ModalDialog";
 import { VideoItem } from "@/components/show-and-tell/gallery/VideoItem";
 
 import IconInformationCircle from "@/icons/IconInformationCircle";
@@ -34,6 +35,7 @@ export function ShowAndTellGallery({
   imageAttachments: Array<ImageAttachmentWithFileStorageObject>;
   videoAttachments: Array<LinkAttachment>;
 }) {
+  const { blockOuterModal, unblockOuterModal } = useModalBlock();
   const { update: updateConsent } = useConsent();
 
   const lightboxRef = useRef<PhotoSwipeLightbox>(null);
@@ -124,6 +126,7 @@ export function ShowAndTellGallery({
         isButton: false,
         appendTo: "root",
         onInit: (el, pswp) => {
+          if (!blockOuterModal || !unblockOuterModal) return;
           pswp.on("change", () => {
             let captionText = "";
             const caption =
@@ -133,6 +136,12 @@ export function ShowAndTellGallery({
               captionText = caption.textContent || "";
             }
             el.textContent = captionText;
+          });
+          pswp.on("openingAnimationStart", () => {
+            blockOuterModal();
+          });
+          pswp.on("close", () => {
+            unblockOuterModal();
           });
         },
       });
@@ -144,7 +153,14 @@ export function ShowAndTellGallery({
     return () => {
       lightbox.destroy();
     };
-  }, [lightboxParentRef, isPresentationView, photoswipeId, updateConsent]);
+  }, [
+    lightboxParentRef,
+    isPresentationView,
+    photoswipeId,
+    updateConsent,
+    blockOuterModal,
+    unblockOuterModal,
+  ]);
 
   const openLightBox = useCallback(
     (index: number) => {


### PR DESCRIPTION
Added a <ModalBlockProvider> and useModalBlock() using react contexts to ensure this can be toggled from within child components.

## Describe your changes

resolves #1306

Added functionality to disable closing a `<ModalDialog>`, which resolved the previous faulty behaviour of the lightbox nested inside of a `<ModalDialog>` where clicking anywhere on the screen closed the wrapping `<ModalDialog>` since the click target was not within the modal itself.

I decided to go for a ContextProvider wrapper using `createContext()` to avoid multi-layer down-passing of callback functions.

## Notes for testing your change

I am new to this repository and I hope the quality of my code meets common standards here. If there is anything wrong / against common practice here, please let me know how and why instead of just rejecting the PR. Thank you :)
