### PR TITLE
Eagerly refresh Twitch tokens for sessions

### DIFF
--- a/apps/website/src/pages/api/auth/[...nextauth].ts
+++ b/apps/website/src/pages/api/auth/[...nextauth].ts
@@ -59,6 +59,7 @@ export const authOptions: NextAuthOptions = {
           id: true,
           access_token: true,
           refresh_token: true,
+          expires_at: true,
           verified_at: true,
           scope: true,
           twitchChannelBroadcaster: {
@@ -90,6 +91,11 @@ export const authOptions: NextAuthOptions = {
               account.id,
               account.access_token,
               account.refresh_token,
+              // Force the refresh if we're within 1hr of expiry
+              !!(
+                account.expires_at &&
+                account.expires_at - Date.now() / 1000 < 60 * 60
+              ),
             );
           } catch (err) {
             if (!(err instanceof ExpiredAccessTokenError)) console.error(err);


### PR DESCRIPTION
## Describe your changes

We're seeing some users report that Twitch API calls on the site are failing, and the logs are indicating this is due to invalid tokens -- I suspect this might be because we only validate tokens once per hour (not when making a Twitch API request), and the user's token has expired since we did the last validation.

## Notes for testing your change

🤷 This is very hard to test locally, but this same force logic already exists in the logic for refreshing tokens tied to channels in the DB.