### PR TITLE
Add orgs page to about in nav

### DIFF
--- a/apps/website/src/data/navigation.ts
+++ b/apps/website/src/data/navigation.ts
@@ -78,6 +78,10 @@ export const mainNavStructure: NavStructure = {
         title: "Board of Directors",
         link: "/about/board-of-directors",
       },
+      ngoCollabs: {
+        title: "NGO Collaborations",
+        link: "/about/orgs",
+      },
       annualReports: {
         title: "Annual Reports",
         link: "/about/annual-reports",

--- a/apps/website/src/pages/about/alveus.tsx
+++ b/apps/website/src/pages/about/alveus.tsx
@@ -811,14 +811,14 @@ const AboutAlveusPage: NextPage = () => {
         />
 
         <p className="mt-8 text-center text-lg text-balance">
-          We also partner with various organizations to amplify their efforts
-          and share their important work with our audience, furthering our
-          mission of conservation and education.
+          We also collaborate with various organizations to amplify their
+          efforts and share their important work with our audience, furthering
+          our mission of conservation and education.
         </p>
 
         <p className="mt-2 text-center text-lg">
           <Link href="/about/orgs">
-            Explore some of our partnerships
+            Explore some of our NGO collaborations
             <IconArrowRight size={16} className="ml-1 inline-block" />
           </Link>
         </p>

--- a/apps/website/src/pages/about/orgs.tsx
+++ b/apps/website/src/pages/about/orgs.tsx
@@ -420,8 +420,8 @@ const AboutOrgsPage: NextPage = () => {
   return (
     <>
       <Meta
-        title="Partnering with Organizations"
-        description="Beyond our educational collaborations with content creators, Maya Higa and Alveus Sanctuary partner with various organizations to further our mission of conservation and education."
+        title="Collaborating with Organizations"
+        description="Beyond our educational collaborations with content creators, Maya Higa and Alveus Sanctuary collaborate with various organizations to further our mission of conservation and education."
       />
 
       {/* Nav background */}
@@ -436,17 +436,17 @@ const AboutOrgsPage: NextPage = () => {
 
         <Section dark>
           <div className="w-full lg:w-4/5 lg:py-8">
-            <Heading>Partnering with Organizations</Heading>
+            <Heading>Collaborating with Organizations</Heading>
 
             <p className="text-lg text-balance">
               Beyond our{" "}
               <Link href="/collaborations" dark>
                 educational collaborations
               </Link>{" "}
-              with content creators, Maya Higa and Alveus Sanctuary partner with
-              various organizations to further our mission of conservation and
-              education. These partnerships allow us to amplify their efforts
-              and share their important work with our audience.
+              with content creators, Maya Higa and Alveus Sanctuary collaborate
+              with various organizations to further our mission of conservation
+              and education. These collaborations allow us to amplify their
+              efforts and share their important work with our audience.
             </p>
           </div>
         </Section>

--- a/apps/website/src/pages/collaborations.tsx
+++ b/apps/website/src/pages/collaborations.tsx
@@ -393,14 +393,14 @@ const CollaborationsPage: NextPage = () => {
 
             <div className="w-full lg:w-1/3 lg:pl-2">
               <p className="text-lg text-balance">
-                We also partner with various organizations to amplify their
+                We also collaborate with various organizations to amplify their
                 efforts and share their important work with our audience,
                 furthering our mission of conservation and education.
               </p>
 
               <p className="mt-2 text-lg">
                 <Link href="/about/orgs" dark>
-                  Explore some of our partnerships
+                  Explore some of our NGO collaborations
                   <IconArrowRight size={16} className="ml-1 inline-block" />
                 </Link>
               </p>


### PR DESCRIPTION
## Describe your changes

Adds the new orgs page to the About dropdown in the navigation, as NGO Collaborations (copy per Alveus).

To align the page with this link name, the copy in relation to the page itself has been updated to swap "partner" with "collaborate" throughout.

## Notes for testing your change

All "partner" (etc) wording replaced with "collaborate" in reference to the orgs page. NGO Collaborations link under About in the nav, links to the orgs page.