### PR TITLE
Move Show and Tell images following mouse when zoomed

### DIFF
--- a/apps/website/src/components/show-and-tell/gallery/ImageItem.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/ImageItem.tsx
@@ -87,7 +87,7 @@ export const ImageItemEmbed = ({ imageAttachment }: ImageItemEmbedProps) => {
       setTransformOrigin(`${x}% ${y}%`);
       setIsZoomed(true);
     } else {
-      setTransformOrigin("center");
+      // Don't reset transformOrigin to avoid snapping to center during zoom-out
       setIsZoomed(false);
     }
   };

--- a/apps/website/src/components/show-and-tell/gallery/ImageItem.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/ImageItem.tsx
@@ -92,6 +92,16 @@ export const ImageItemEmbed = ({ imageAttachment }: ImageItemEmbedProps) => {
     }
   };
 
+  const handleImageMouseMove = (e: MouseEvent<HTMLImageElement>) => {
+    if (!isZoomed || state !== "loaded") return;
+
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = ((e.clientX - rect.left) / rect.width) * 100;
+    const y = ((e.clientY - rect.top) / rect.height) * 100;
+
+    setTransformOrigin(`${x}% ${y}%`);
+  };
+
   const aspectRatio = `${imageAttachment.fileStorageObject?.imageMetadata?.width || 1920} / ${imageAttachment.fileStorageObject?.imageMetadata?.height || 1080}`;
 
   return (
@@ -128,6 +138,7 @@ export const ImageItemEmbed = ({ imageAttachment }: ImageItemEmbedProps) => {
             onLoad={() => setState("loaded")}
             onError={() => setState("error")}
             onClick={handleImageClick}
+            onMouseMove={handleImageMouseMove}
           />
         </div>
 


### PR DESCRIPTION
## Describe your changes

Building off #1390, while we're zoomed in, automatically adjust the transform origin as the mouse moves to allow for intuitive exploring of the whole image. Also, fixes the snapping to center issue noted in that PR.

## Notes for testing your change

Click to zoom in, move mouse to explore whole zoomed in image, moving mouse outside the bounds etc. does not cause any weird issues, click to zoom out zooms out at the final location without snapping to center.
