### PR TITLE
Close lightbox on click outside draggable area and buttons

### DIFF
--- a/apps/website/src/components/content/Carousel.tsx
+++ b/apps/website/src/components/content/Carousel.tsx
@@ -162,7 +162,8 @@ const Carousel = ({
           state === "none" && "hidden",
         )}
         type="button"
-        onClick={() => {
+        onClick={(event) => {
+          event.stopPropagation();
           interacted();
           move("left");
         }}
@@ -184,6 +185,9 @@ const Carousel = ({
         ref={ref}
         onScroll={scrolled}
         onMouseDown={state === "none" ? undefined : drag}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
       >
         {Object.entries(items).map(([key, item]) => (
           <div
@@ -215,7 +219,8 @@ const Carousel = ({
           state === "none" && "hidden",
         )}
         type="button"
-        onClick={() => {
+        onClick={(event) => {
+          event.stopPropagation();
           interacted();
           move("right");
         }}

--- a/apps/website/src/components/content/Lightbox.tsx
+++ b/apps/website/src/components/content/Lightbox.tsx
@@ -44,7 +44,12 @@ const Lightbox = ({ open, onClose, items, className }: LightboxProps) => {
       <DialogBackdrop className="absolute inset-0 bg-black/75" />
 
       <div className="absolute inset-0 p-1 md:p-4 lg:p-8">
-        <DialogPanel className="size-full">
+        <DialogPanel
+          className="size-full"
+          onClick={() => {
+            onClose();
+          }}
+        >
           <Carousel
             items={items}
             auto={null}


### PR DESCRIPTION
## Describe your changes

This will change the lightbox to close on clicks on parts of the panel that are not the draggable carousel or buttons. 

## Notes for testing your change

Make sure clicks and dragging works in all carousels still.