### PR TITLE
Add Facebook to socials in nav

### DIFF
--- a/apps/website/src/components/shared/data/socials.tsx
+++ b/apps/website/src/components/shared/data/socials.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/utils/helpers";
 
 import IconBluesky from "@/icons/IconBluesky";
+import IconFacebook from "@/icons/IconFacebook";
 import IconInstagram from "@/icons/IconInstagram";
 import IconTikTok from "@/icons/IconTikTok";
 import IconTwitch from "@/icons/IconTwitch";
@@ -19,6 +20,7 @@ const icons = {
   instagram: IconInstagram,
   twitter: IconTwitter,
   bluesky: IconBluesky,
+  facebook: IconFacebook,
   tiktok: IconTikTok,
   youtube: IconYouTube,
 } as const satisfies Record<keyof typeof socials, ComponentType>;

--- a/apps/website/src/data/socials.ts
+++ b/apps/website/src/data/socials.ts
@@ -20,6 +20,10 @@ const socials = {
     link: "https://bsky.app/profile/alveussanctuary.org",
     title: "Bluesky",
   },
+  facebook: {
+    link: "https://www.facebook.com/AlveusSanctuary",
+    title: "Facebook",
+  },
   tiktok: {
     link: "https://www.tiktok.com/@alveussanctuary",
     title: "TikTok",


### PR DESCRIPTION
## Describe your changes

Alveus now has an active Facebook page, so we should link it from the standard locations on the site with all the social profiles.

## Notes for testing your change

Facebook added in nav + footer + redirect, links works.
