### PR TITLE
Delay clip details overlay as workaround to visibility check

### DIFF
--- a/apps/website/src/pages/stream/clips.tsx
+++ b/apps/website/src/pages/stream/clips.tsx
@@ -146,13 +146,13 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
     setRandomClips(shuffled);
   }, [clips]);
 
-  // Iterate through clips, showing details as an overlay initially for each
-  const [details, setDetails] = useState(true);
+  // Iterate through clips
+  const [details, setDetails] = useState<"overlay" | "below">();
   const [idx, setIdx] = useState<number>(0);
   const clip = randomClips[idx];
   const increment = useCallback(() => {
     setIdx((idx) => (idx + 1) % clips.length);
-    setDetails(true);
+    setDetails(undefined);
   }, [clips.length]);
 
   // As a fallback, set a timer for 150% of the duration of the clip
@@ -183,8 +183,15 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
       clip.duration * 1000 + 2 * 1000, // Fudge factor of 2 seconds for clip loading
     );
 
+    // After 1s overlay the clip details, and 10s later place them below the clip
     if (detailsTimer.current) clearTimeout(detailsTimer.current);
-    detailsTimer.current = setTimeout(() => setDetails(false), 10 * 1000);
+    detailsTimer.current = setTimeout(() => {
+      setDetails("overlay");
+
+      detailsTimer.current = setTimeout(() => {
+        setDetails("below");
+      }, 10000);
+    }, 1000);
   }, [clip, increment]);
 
   // If the clip fails to load, show another after 2 seconds
@@ -216,7 +223,7 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
           <div className="relative flex aspect-video w-full items-center justify-center">
             <div className="absolute -inset-2 -z-10 rounded-xl bg-alveus-green shadow-lg" />
 
-            <Transition show={details}>
+            <Transition show={details === "overlay"}>
               <div className="absolute top-2 left-2 rounded-lg bg-black/25 px-4 py-2 text-white backdrop-blur-sm transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-300">
                 <h1 className="text-5xl">
                   {clip.title}
@@ -243,7 +250,7 @@ const ClipsPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
               className="size-full rounded-lg"
             />
 
-            <Transition show={!details}>
+            <Transition show={details === "below"}>
               {/* data-[leave]:duration-0 to ensure the next clip's details aren't show */}
               <div className="absolute -bottom-4 left-0 flex translate-y-full items-center gap-2 rounded-lg bg-black/25 px-2 py-1 text-white transition-opacity data-[closed]:opacity-0 data-[enter]:duration-700 data-[leave]:duration-0">
                 <p className="text-lg">{clip.title}</p>


### PR DESCRIPTION
## Describe your changes

Twitch has introduced some new "abuse" prevention to the clips player, seemingly in Chromium only, that can detect when the player is obscured. When it detects this, it refuses to autoplay until the player is "visible".

Our clip details overlay was tripping this, causing the clip to only autoplay once the details disappeared after 10s. In testing, it looks like if we delay rendering this until after the player has done its initial load, it doesn't interfere with autoplay.

_As an aside, we have flagged this to Twitch as this seems like quite a weird detection to add in such a breaking way. And at the same time, have also once again asked them for a better way to do a rotating player like this without relying on timers._

## Notes for testing your change

Make sure to test in Chrome as this only seems to break in prod there.
