### PR TITLE
Fix editing rounds checks with custom images

### DIFF
--- a/apps/website/src/server/db/rounds-checks.ts
+++ b/apps/website/src/server/db/rounds-checks.ts
@@ -49,8 +49,8 @@ const existingRoundsCheckSchemaBase = z
   .and(roundsCheckSchemaBase.partial());
 
 export const existingRoundsCheckSchema = z.union([
-  existingRoundsCheckSchemaBase,
   existingRoundsCheckSchemaBase.and(roundsCheckSchemaImage),
+  existingRoundsCheckSchemaBase,
 ]);
 
 export async function createRoundsCheck(


### PR DESCRIPTION
## Describe your changes

Oversight on my part, or maybe a change in Zod since I originally wrote this, the extended schema needs to be in the union before the lesser schema, so that it has a chance to match (otherwise the lesser schema matches first and the extended schema is never tried).

## Notes for testing your change

Can create a new check with and without a custom image, can edit an existing check to add/remove a custom image, can toggle the visibility or change the position of an existing check.
