### PR TITLE
Add zoom controls to presets page

### DIFF
--- a/apps/website/src/components/shared/actions/RunCommandButton.tsx
+++ b/apps/website/src/components/shared/actions/RunCommandButton.tsx
@@ -1,5 +1,11 @@
 import { useSession } from "next-auth/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import { scopeGroups } from "@/data/twitch";
 
@@ -15,6 +21,7 @@ type Command = RouterInputs["stream"]["runCommand"];
 interface RunCommandButtonProps extends Command {
   subOnly?: boolean;
   tooltip?: string;
+  icon?: ({ className }: { className: string }) => ReactNode;
   className?: string;
 }
 
@@ -23,6 +30,7 @@ const RunCommandButton = ({
   args,
   subOnly = false,
   tooltip = "Run command",
+  icon = IconVideoCamera,
   className,
 }: RunCommandButtonProps) => {
   const { data: session } = useSession();
@@ -82,7 +90,7 @@ const RunCommandButton = ({
   return (
     <ActionButton
       onClick={onClick}
-      icon={IconVideoCamera}
+      icon={icon}
       tooltip={{
         text: statusText ?? tooltip,
         elm: statusText ? undefined : PreviewTooltip,

--- a/apps/website/src/data/presets/garden.ts
+++ b/apps/website/src/data/presets/garden.ts
@@ -81,7 +81,7 @@ const gardenPresets: Record<string, Preset> = {
 
 const garden = {
   title: "Garden",
-  group: "garden",
+  group: "pasture",
   presets: gardenPresets,
 };
 

--- a/apps/website/src/icons/IconZoomIn.tsx
+++ b/apps/website/src/icons/IconZoomIn.tsx
@@ -1,0 +1,18 @@
+import { BaseIcon, type IconProps } from "@/icons/BaseIcon";
+
+// This SVG code is derived from Heroicons (https://heroicons.com)
+// magnifying-glass-plus
+export default function IconZoomIn(props: IconProps) {
+  return (
+    <BaseIcon viewBox="0 0 24 24" {...props}>
+      <path
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607ZM10.5 7.5v6m3-3h-6"
+      />
+    </BaseIcon>
+  );
+}

--- a/apps/website/src/icons/IconZoomOut.tsx
+++ b/apps/website/src/icons/IconZoomOut.tsx
@@ -1,0 +1,18 @@
+import { BaseIcon, type IconProps } from "@/icons/BaseIcon";
+
+// This SVG code is derived from Heroicons (https://heroicons.com)
+// magnifying-glass-minus
+export default function IconZoomOut(props: IconProps) {
+  return (
+    <BaseIcon viewBox="0 0 24 24" {...props}>
+      <path
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607ZM13.5 10.5h-6"
+      />
+    </BaseIcon>
+  );
+}

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -49,6 +49,8 @@ import IconChevronDown from "@/icons/IconChevronDown";
 import IconLoading from "@/icons/IconLoading";
 import IconVideoCamera from "@/icons/IconVideoCamera";
 import IconX from "@/icons/IconX";
+import IconZoomIn from "@/icons/IconZoomIn";
+import IconZoomOut from "@/icons/IconZoomOut";
 
 import leafLeftImage1 from "@/assets/floral/leaf-left-1.png";
 import leafLeftImage3 from "@/assets/floral/leaf-left-3.png";
@@ -505,14 +507,36 @@ const AboutTechPresetsPage: NextPage = () => {
                     </Heading>
 
                     {"presets" in selectedData && (
-                      <Input
-                        type="text"
-                        placeholder="Search presets..."
-                        aria-label="Search presets"
-                        value={searchPresets}
-                        onChange={(e) => setSearchPresets(e.target.value)}
-                        className="grow rounded border border-alveus-green-200 bg-alveus-green-50/75 px-2 py-1 font-semibold shadow-md backdrop-blur-sm focus:ring-2 focus:ring-alveus-green focus:outline-none"
-                      />
+                      <>
+                        {subscription.isSuccess && subscription.data && (
+                          <div className="flex items-center">
+                            <RunCommandButton
+                              command="ptzzoom"
+                              args={[selectedCamera.toLowerCase(), "80"]}
+                              tooltip="Run zoom out command"
+                              icon={IconZoomOut}
+                            />
+
+                            <div className="pointer-events-none -ml-0.5 h-0.5 w-4 rounded bg-alveus-green-400" />
+
+                            <RunCommandButton
+                              command="ptzzoom"
+                              args={[selectedCamera.toLowerCase(), "120"]}
+                              tooltip="Run zoom in command"
+                              icon={IconZoomIn}
+                            />
+                          </div>
+                        )}
+
+                        <Input
+                          type="text"
+                          placeholder="Search presets..."
+                          aria-label="Search presets"
+                          value={searchPresets}
+                          onChange={(e) => setSearchPresets(e.target.value)}
+                          className="grow rounded border border-alveus-green-200 bg-alveus-green-50/75 px-2 py-1 font-semibold shadow-md backdrop-blur-sm focus:ring-2 focus:ring-alveus-green focus:outline-none"
+                        />
+                      </>
                     )}
                   </div>
 

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -428,65 +428,67 @@ const AboutTechPresetsPage: NextPage = () => {
                   className="mb-2 w-full rounded border border-alveus-green-200 bg-alveus-green-50/75 px-2 py-1 font-semibold shadow-md backdrop-blur-sm focus:ring-2 focus:ring-alveus-green focus:outline-none"
                 />
 
-                {typeSafeObjectEntries(groupedCameras).map(([name, group]) => {
-                  const groupEntries =
-                    typeSafeObjectEntries(group).filter(isDefinedEntry);
-                  if (groupEntries.length === 0) return null;
+                {typeSafeObjectEntries(groupedCameras)
+                  .sort(([a], [b]) => a.localeCompare(b))
+                  .map(([name, group]) => {
+                    const groupEntries =
+                      typeSafeObjectEntries(group).filter(isDefinedEntry);
+                    if (groupEntries.length === 0) return null;
 
-                  if (groupEntries.length === 1) {
-                    const [camera, { title, group }] = groupEntries[0]!;
+                    if (groupEntries.length === 1) {
+                      const [camera, { title, group }] = groupEntries[0]!;
+                      return (
+                        <Button
+                          key={camera}
+                          camera={camera}
+                          title={title}
+                          group={group}
+                          onClick={() => setSelectedCamera(camera)}
+                          selected={{
+                            camera: selectedCamera,
+                            group: selectedData.group,
+                          }}
+                        />
+                      );
+                    }
+
                     return (
-                      <Button
-                        key={camera}
-                        camera={camera}
-                        title={title}
-                        group={group}
-                        onClick={() => setSelectedCamera(camera)}
-                        selected={{
-                          camera: selectedCamera,
-                          group: selectedData.group,
-                        }}
-                      />
-                    );
-                  }
-
-                  return (
-                    <Disclosure key={name}>
-                      <DisclosureButton
-                        ref={disclosureRef}
-                        className={classes(
-                          "group flex w-full items-center justify-between rounded px-3 py-2 text-left text-lg font-semibold shadow-md backdrop-blur-sm",
-                          selectedData.group === name
-                            ? "bg-alveus-green/75 text-white"
-                            : "bg-alveus-green-50/75 hover:bg-alveus-green-100/90",
-                        )}
-                      >
-                        <span>
-                          {camelToTitle(name)} Cameras
-                          <span className="text-sm text-alveus-green-400 italic">
-                            {` (${groupEntries.length})`}
+                      <Disclosure key={name}>
+                        <DisclosureButton
+                          ref={disclosureRef}
+                          className={classes(
+                            "group flex w-full items-center justify-between rounded px-3 py-2 text-left text-lg font-semibold shadow-md backdrop-blur-sm",
+                            selectedData.group === name
+                              ? "bg-alveus-green/75 text-white"
+                              : "bg-alveus-green-50/75 hover:bg-alveus-green-100/90",
+                          )}
+                        >
+                          <span>
+                            {camelToTitle(name)} Cameras
+                            <span className="text-sm text-alveus-green-400 italic">
+                              {` (${groupEntries.length})`}
+                            </span>
                           </span>
-                        </span>
-                        <IconChevronDown className="ml-auto size-5 group-data-[open]:-scale-y-100" />
-                      </DisclosureButton>
-                      <DisclosurePanel className="ml-4 flex flex-col gap-1">
-                        {groupEntries.map(([camera, { title, group }]) => (
-                          <Button
-                            key={camera}
-                            camera={camera}
-                            title={title}
-                            group={group}
-                            onClick={() => setSelectedCamera(camera)}
-                            selected={{
-                              camera: selectedCamera,
-                              group: selectedData.group,
-                            }}
-                          />
-                        ))}
-                      </DisclosurePanel>
-                    </Disclosure>
-                  );
-                })}
+                          <IconChevronDown className="ml-auto size-5 group-data-[open]:-scale-y-100" />
+                        </DisclosureButton>
+                        <DisclosurePanel className="ml-4 flex flex-col gap-1">
+                          {groupEntries.map(([camera, { title, group }]) => (
+                            <Button
+                              key={camera}
+                              camera={camera}
+                              title={title}
+                              group={group}
+                              onClick={() => setSelectedCamera(camera)}
+                              selected={{
+                                camera: selectedCamera,
+                                group: selectedData.group,
+                              }}
+                            />
+                          ))}
+                        </DisclosurePanel>
+                      </Disclosure>
+                    );
+                  })}
               </div>
             </div>
 

--- a/apps/website/src/server/trpc/router/stream.ts
+++ b/apps/website/src/server/trpc/router/stream.ts
@@ -25,7 +25,7 @@ import invariant from "@/utils/invariant";
 import { createJWT, signJWT } from "@/utils/jwt";
 
 export const runCommandSchema = z.object({
-  command: z.literal(["ptzload", "swap"]),
+  command: z.literal(["ptzload", "ptzzoom", "swap"]),
   args: z.array(z.string()).optional(),
 });
 


### PR DESCRIPTION
## Describe your changes

Primarily, this adds two new buttons to cameras that have presets defined, for subs only, to quickly run zoom in/out commands from the page (ptzzoom 120/80, respectively).

While I was touching presets-related code, this also moves the garden cam into the pasture group, as they are in the same group in the bot code and can be swapped between by subs.

## Notes for testing your change

Zoom buttons work, garden cam grouped with pasture cams, grouped cams correctly sorted.