### PR TITLE
Allow filtering by event categories on schedule

### DIFF
--- a/apps/website/src/components/calendar/Schedule.tsx
+++ b/apps/website/src/components/calendar/Schedule.tsx
@@ -1,5 +1,5 @@
 import { Transition } from "@headlessui/react";
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 
 import { standardCategories } from "@/data/calendar-events";
 import { channels, isChannelWithCalendarEvents } from "@/data/twitch";
@@ -73,118 +73,120 @@ export function Schedule() {
   if (!selected) return null;
 
   return (
-    <Calendar
-      events={eventsWithChildren || []}
-      selectedDateTime={selected}
-      loading={events.isPending}
-      onChange={setSelected}
-      className="mt-2 md:mt-6"
-      timeZone={timeZone}
-      setTimeZone={setTimeZone}
-    >
-      <div className="flex justify-between gap-2 italic opacity-50">
-        <p>
-          Events and dates/times are subject to change. Enable notifications to
-          know when streams go live.
-        </p>
-
-        <Transition show={events.isPending}>
-          <p className="animate-pulse transition-opacity duration-300 data-[closed]:animate-none data-[closed]:opacity-0">
-            Loading...
+    <div className="grid grid-cols-1 gap-x-8 gap-y-2 xl:grid-cols-3">
+      <Calendar
+        events={eventsWithChildren || []}
+        selectedDateTime={selected}
+        loading={events.isPending}
+        onChange={setSelected}
+        className="mt-2 md:mt-6 xl:col-span-2"
+        timeZone={timeZone}
+        setTimeZone={setTimeZone}
+      >
+        <div className="flex justify-between gap-2 italic opacity-50">
+          <p>
+            Events and dates/times are subject to change. Enable notifications
+            to know when streams go live.
           </p>
-        </Transition>
-      </div>
 
-      {typeSafeObjectEntries(groupedCategories).map(([group, grouped]) => (
-        <div key={group}>
-          <div className="mb-1 flex flex-wrap items-end justify-end gap-2">
-            <h4 className="mr-auto text-lg font-bold">
-              {sentenceToTitle(group)}
-            </h4>
+          <Transition show={events.isPending}>
+            <p className="animate-pulse transition-opacity duration-300 data-[closed]:animate-none data-[closed]:opacity-0">
+              Loading...
+            </p>
+          </Transition>
+        </div>
+      </Calendar>
 
-            {webcalUrls[group] && (
-              <>
-                <Link
-                  custom
-                  external
-                  className="rounded-lg bg-alveus-green px-2 py-1 text-sm text-alveus-tan transition-colors hover:bg-alveus-green-800"
-                  href={`https://calendar.google.com/calendar/render?cid=${webcalUrls[group]}`}
-                >
-                  Add to Google Calendar
-                  <IconExternal
-                    size="1em"
-                    className="mr-0.5 -mb-0.5 ml-1 inline-block align-baseline"
-                  />
-                </Link>
-                <input
-                  readOnly={true}
-                  type="url"
-                  className="box-content min-w-0 rounded-lg bg-alveus-green-800 p-1 text-center text-sm text-alveus-tan italic outline-hidden"
-                  value={webcalUrls[group]}
-                  onClick={(e) =>
-                    e.currentTarget.setSelectionRange(
-                      0,
-                      e.currentTarget.value.length,
-                    )
-                  }
-                  ref={(input) => {
-                    if (!input) return;
-                    input.style.width = "0";
-                    input.style.width = `${input.scrollWidth}px`;
-                  }}
-                />
-              </>
-            )}
-          </div>
+      <div className="flex flex-col gap-4 xl:pt-32">
+        {typeSafeObjectEntries(groupedCategories).map(([group, grouped]) => (
+          <Fragment key={group}>
+            <div className="flex flex-col gap-2">
+              <h4 className="text-lg font-bold">{sentenceToTitle(group)}</h4>
 
-          <div className="grid grid-cols-1 gap-x-4 gap-y-1 md:grid-cols-2 lg:grid-cols-3">
-            {grouped.map((category) => (
-              <label
-                key={category.name}
-                className="group flex items-center gap-2"
-              >
-                <input
-                  type="checkbox"
-                  checked={categories.has(category.name)}
-                  onChange={(e) => {
-                    const newCategories = new Set(categories);
-                    if (e.currentTarget.checked) {
-                      newCategories.add(category.name);
-                    } else {
-                      newCategories.delete(category.name);
+              {webcalUrls[group] && (
+                <div className="flex flex-wrap gap-2">
+                  <Link
+                    custom
+                    external
+                    className="rounded-lg bg-alveus-green px-2 py-1 text-sm text-alveus-tan transition-colors hover:bg-alveus-green-800"
+                    href={`https://calendar.google.com/calendar/render?cid=${webcalUrls[group]}`}
+                  >
+                    Add to Google Calendar
+                    <IconExternal
+                      size="1em"
+                      className="mr-0.5 -mb-0.5 ml-1 inline-block align-baseline"
+                    />
+                  </Link>
+                  <input
+                    readOnly={true}
+                    type="url"
+                    className="box-content min-w-0 rounded-lg bg-alveus-green-800 p-1 text-center text-sm text-alveus-tan italic outline-hidden"
+                    value={webcalUrls[group]}
+                    onClick={(e) =>
+                      e.currentTarget.setSelectionRange(
+                        0,
+                        e.currentTarget.value.length,
+                      )
                     }
-                    setCategories(newCategories);
-                  }}
-                  className="sr-only"
-                />
-
-                <div
-                  className={classes(
-                    category.color,
-                    "rounded-md border-2 p-1 group-hover:border-black/20",
-                    categories.has(category.name)
-                      ? "border-black/20"
-                      : "border-black/10",
-                  )}
-                >
-                  <div
-                    className={classes(
-                      "h-2 w-2 rounded-full",
-                      categories.has(category.name)
-                        ? "bg-black/25"
-                        : "bg-transparent",
-                    )}
+                    ref={(input) => {
+                      if (!input) return;
+                      input.style.width = "0";
+                      input.style.width = `${input.scrollWidth}px`;
+                    }}
                   />
                 </div>
-                <p className="shrink-0 opacity-75">
-                  <span className="sr-only">Filter by </span>
-                  {category.name}
-                </p>
-              </label>
-            ))}
-          </div>
-        </div>
-      ))}
-    </Calendar>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 gap-x-4 gap-y-1 md:grid-cols-2 xl:grid-cols-1">
+              {grouped.map((category) => (
+                <label
+                  key={category.name}
+                  className="group flex items-center gap-2"
+                >
+                  <input
+                    type="checkbox"
+                    checked={categories.has(category.name)}
+                    onChange={(e) => {
+                      const newCategories = new Set(categories);
+                      if (e.currentTarget.checked) {
+                        newCategories.add(category.name);
+                      } else {
+                        newCategories.delete(category.name);
+                      }
+                      setCategories(newCategories);
+                    }}
+                    className="sr-only"
+                  />
+
+                  <div
+                    className={classes(
+                      category.color,
+                      "rounded-md border-2 p-1 group-hover:border-black/20",
+                      categories.has(category.name)
+                        ? "border-black/20"
+                        : "border-black/10",
+                    )}
+                  >
+                    <div
+                      className={classes(
+                        "h-2 w-2 rounded-full",
+                        categories.has(category.name)
+                          ? "bg-black/25"
+                          : "bg-transparent",
+                      )}
+                    />
+                  </div>
+                  <p className="shrink-0 opacity-75">
+                    <span className="sr-only">Filter by </span>
+                    {category.name}
+                  </p>
+                </label>
+              ))}
+            </div>
+          </Fragment>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/apps/website/src/components/notifications/RecentNotifications.tsx
+++ b/apps/website/src/components/notifications/RecentNotifications.tsx
@@ -1,6 +1,20 @@
+import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
 
 import { NotificationEntry } from "@/components/notifications/NotificationEntry";
+
+const backgrounds = [
+  "bg-alveus-green/40",
+  "bg-alveus-green/38",
+  "bg-alveus-green/36",
+  "bg-alveus-green/34",
+  "bg-alveus-green/32",
+  "bg-alveus-green/30",
+  "bg-alveus-green/28",
+  "bg-alveus-green/26",
+  "bg-alveus-green/24",
+  "bg-alveus-green/22",
+];
 
 export function RecentNotifications({ tags }: { tags: Array<string> }) {
   const recentNotifications =
@@ -11,11 +25,14 @@ export function RecentNotifications({ tags }: { tags: Array<string> }) {
   }
 
   return (
-    <ul className="flex flex-col gap-2">
-      {recentNotifications.data?.map((notification) => (
+    <ul className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+      {recentNotifications.data?.map((notification, idx) => (
         <li
           key={notification.id}
-          className="flex items-center gap-3 rounded-xl bg-alveus-green/30 px-4 py-2 transition-transform hover:scale-102 hover:bg-alveus-green/40"
+          className={classes(
+            backgrounds[idx] ?? "bg-alveus-green/20",
+            "flex items-center gap-3 rounded-xl px-4 py-2 transition-transform hover:scale-102 hover:bg-alveus-green/40",
+          )}
         >
           <NotificationEntry notification={notification} />
         </li>

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -8,25 +8,40 @@ type StandardCategory = {
 };
 
 export const standardCategories: StandardCategory[] = [
-  { name: "Alveus Regular Stream", color: "bg-yellow-200 hover:bg-yellow-300" },
-  { name: "Alveus Special Stream", color: "bg-green-100 hover:bg-green-200" },
+  {
+    name: "Alveus Regular Stream",
+    color: "bg-yellow-200 hover:bg-yellow-300 group-hover:bg-yellow-300",
+  },
+  {
+    name: "Alveus Special Stream",
+    color: "bg-green-100 hover:bg-green-200 group-hover:bg-green-200",
+  },
   {
     name: "Alveus Collaboration Stream",
-    color: "bg-blue-100 hover:bg-blue-50",
+    color: "bg-blue-100 hover:bg-blue-50 group-hover:bg-blue-50",
   },
   {
     name: "Alveus Ambassador Birthday",
-    color: "bg-pink-100 hover:bg-pink-200",
+    color: "bg-pink-100 hover:bg-pink-200 group-hover:bg-pink-200",
   },
-  { name: "Alveus YouTube Video", color: "bg-red-50 hover:bg-red-100" },
-  { name: "Maya Stream", color: "bg-gray-200 hover:bg-gray-300" },
-  { name: "Maya YouTube Video", color: "bg-red-100 hover:bg-red-50" },
+  {
+    name: "Alveus YouTube Video",
+    color: "bg-red-50 hover:bg-red-100 group-hover:bg-red-100",
+  },
+  {
+    name: "Maya Stream",
+    color: "bg-gray-200 hover:bg-gray-300 group-hover:bg-gray-300",
+  },
+  {
+    name: "Maya YouTube Video",
+    color: "bg-red-100 hover:bg-red-50 group-hover:bg-red-50",
+  },
 ] as const;
 
 export const getStandardCategoryColor = (category: string) =>
   standardCategories.find(
     (c) => c.name.toLowerCase() === category.toLowerCase().trim(),
-  )?.color ?? "bg-gray-100 hover:bg-gray-300";
+  )?.color ?? "bg-gray-100 hover:bg-gray-300 group-hover:bg-gray-300";
 
 type FrequentLink = {
   label: string;

--- a/apps/website/src/pages/updates.tsx
+++ b/apps/website/src/pages/updates.tsx
@@ -106,28 +106,26 @@ const UpdatesPage: NextPage = () => {
 
       {/* Grow the last section to cover the page */}
       <Section className="grow">
-        <div className="flex flex-col gap-10 xl:flex-row">
-          <div className="flex flex-1 grow-[2] flex-col gap-8">
-            <section>
-              <Heading level={3} id="schedule" link>
-                Schedule
-              </Heading>
-              <Schedule />
-            </section>
+        <div className="flex flex-col gap-10">
+          <section>
+            <Heading level={3} id="schedule" link>
+              Schedule
+            </Heading>
+            <Schedule />
+          </section>
 
-            <section>
-              <Heading level={3} id="announcements" link>
-                Announcements
-              </Heading>
-              <Announcements />
-            </section>
-          </div>
-
-          <section className="flex-1">
+          <section>
             <Heading level={3} id="recent" link>
               Recent Notifications
             </Heading>
             <RecentNotifications tags={notificationTags} />
+          </section>
+
+          <section>
+            <Heading level={3} id="announcements" link>
+              Announcements
+            </Heading>
+            <Announcements />
           </section>
         </div>
       </Section>


### PR DESCRIPTION
## Describe your changes

We've had all the categories shown below the calendar for a long time now, and they even had a hover state implying they did something, but they didn't...

Well, now they do! They're now checkboxes that allow you to filter the events shown in the calendar. You can select just one category, or multiple, or none at all to show all events.

## Notes for testing your change

Checkboxes can be interacted with as normal to filter events displayed on the calendar.