### PR TITLE
make show and tell pre-render faster?

### DIFF
--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -157,4 +157,16 @@ export const showAndTellRouter = router({
 
     return extractInfoFromMapFeatures(mapFeatures).postsFromANewLocation;
   }),
+  getInfoFromMapFeatures: publicProcedure.query(async () => {
+    const mapFeatures = await getMapFeatures();
+
+    const { countries, locations, postsFromANewLocation } =
+      extractInfoFromMapFeatures(mapFeatures);
+
+    return {
+      uniqueLocationsCount: locations.size,
+      uniqueCountriesCount: countries.size,
+      postsFromANewLocation,
+    };
+  }),
 });


### PR DESCRIPTION
For https://github.com/alveusgg/alveusgg/issues/1434

## Describe your changes

I'm not sure if this is the correct way to do this. Does it make sense to not query the map data in the pre-render and do it in a trpc query?


## Notes for testing your change


