### PR TITLE
Ensure Giving Block embed renders on repeat navigations

### DIFF
--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -18,7 +18,9 @@ const TheGivingBlockEmbed = () => {
     script.src = `https://widget.thegivingblock.com/widget/script.js#${id}`;
     document.body.appendChild(script);
 
-    return () => script.remove();
+    return () => {
+      script.parentNode?.removeChild(script);
+    };
   }, [id]);
 
   return <div id={`tgb-widget-${id}`} />;

--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -8,7 +8,10 @@ const TheGivingBlockEmbed = () => {
   useEffect(() => {
     Reflect.deleteProperty(window, "widgetOptions");
     Reflect.deleteProperty(window, "tgbWidgetOptions");
-    window.tgbWidgetOptions = theGivingBlockConfig;
+    window.tgbWidgetOptions = {
+      ...theGivingBlockConfig,
+      scriptId: `tgb-widget-${id}`,
+    };
 
     const script = document.createElement("script");
     script.async = true;
@@ -18,7 +21,7 @@ const TheGivingBlockEmbed = () => {
     return () => script.remove();
   }, [id]);
 
-  return <div id="tgb-widget-script" />;
+  return <div id={`tgb-widget-${id}`} />;
 };
 
 export default TheGivingBlockEmbed;

--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -1,22 +1,22 @@
-import Script from "next/script";
-import { useEffect } from "react";
+import { useEffect, useId } from "react";
 
 import { theGivingBlockConfig } from "@/data/the-giving-block";
 
 const TheGivingBlockEmbed = () => {
+  const id = useId();
+
   useEffect(() => {
     window.tgbWidgetOptions = theGivingBlockConfig;
-  }, []);
 
-  return (
-    <>
-      <div id="tgb-widget-script"></div>
-      <Script
-        src="https://widget.thegivingblock.com/widget/script.js"
-        async={true}
-      ></Script>
-    </>
-  );
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = `https://widget.thegivingblock.com/widget/script.js#${id}`;
+    document.body.appendChild(script);
+
+    return () => script.remove();
+  }, [id]);
+
+  return <div id="tgb-widget-script" />;
 };
 
 export default TheGivingBlockEmbed;

--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -6,6 +6,8 @@ const TheGivingBlockEmbed = () => {
   const id = useId();
 
   useEffect(() => {
+    Reflect.deleteProperty(window, "widgetOptions");
+    Reflect.deleteProperty(window, "tgbWidgetOptions");
     window.tgbWidgetOptions = theGivingBlockConfig;
 
     const script = document.createElement("script");

--- a/apps/website/src/data/the-giving-block.ts
+++ b/apps/website/src/data/the-giving-block.ts
@@ -2,8 +2,6 @@ export type TheGivingBlockConfig = {
   id: string;
   apiUserUuid: string;
   domain: string;
-  buttonId: string;
-  scriptId: string;
   uiVersion: string;
   donationFlow: string;
   fundraiserId: string;
@@ -14,8 +12,6 @@ export const theGivingBlockConfig = {
   id: "861772907",
   apiUserUuid: "e6cf7d18-41b6-4a6c-954a-338578fd90b0",
   domain: "https://widget.thegivingblock.com",
-  buttonId: "tgb-widget-button",
-  scriptId: "tgb-widget-script",
   uiVersion: "2",
   donationFlow: "card,crypto,stock,daf",
   fundraiserId: "",

--- a/apps/website/src/types/globals.d.ts
+++ b/apps/website/src/types/globals.d.ts
@@ -7,6 +7,6 @@ declare global {
     Twitch: any;
 
     // The Giving Block Donation Widget
-    tgbWidgetOptions: TheGivingBlockConfig;
+    tgbWidgetOptions: TheGivingBlockConfig & { scriptId: string };
   }
 }


### PR DESCRIPTION
## Describe your changes

Fixes the issue where if you loaded the Giving Block embed on the Donate page, then used the navigation to access another page, before going back to the Donate page (all client side navigations), the Giving Block embed would not render.

The fix was two parts here:

1. Managing the script in the DOM ourselves, so that a fresh script tag is written to the DOM each time the component loads, causing the script to re-run (Next.js was "kindly" de-duplicating their script component into a single DOM script)
2. Giving Block's script prefers using `window.widgetOptions` rather than `window.tgbWidgetOptions`, which is fine, except that once their script runs they reset _both_ to empty arrays. So, any future runs of their script will always use `window.widgetOptions` (still an empty array) instead of our options in `window.tgbWidgetOptions`, so we need to make sure we remove both those properties from `window` each render.

## Notes for testing your change

Load the Giving Block embed on the Donate page, then use the navigation to access another page, then go back to the Donate page (all client side navigations), and observe that the Giving Block embed still renders.