### PR TITLE
Allow Giving Block options as props

### DIFF
--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -5,7 +5,10 @@ import {
   theGivingBlockConfig,
 } from "@/data/the-giving-block";
 
-const TheGivingBlockEmbed = (props: Partial<TheGivingBlockConfig>) => {
+const TheGivingBlockEmbed = ({
+  className,
+  ...props
+}: { className?: string } & Partial<TheGivingBlockConfig>) => {
   const id = useId();
   const ref = useRef<HTMLDivElement>(null);
 
@@ -38,7 +41,7 @@ const TheGivingBlockEmbed = (props: Partial<TheGivingBlockConfig>) => {
     };
   }, [props, id]);
 
-  return <div ref={ref} />;
+  return <div ref={ref} className={className} />;
 };
 
 export default TheGivingBlockEmbed;

--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -1,29 +1,44 @@
-import { useEffect, useId } from "react";
+import { useEffect, useId, useRef } from "react";
 
-import { theGivingBlockConfig } from "@/data/the-giving-block";
+import {
+  type TheGivingBlockConfig,
+  theGivingBlockConfig,
+} from "@/data/the-giving-block";
 
-const TheGivingBlockEmbed = () => {
+const TheGivingBlockEmbed = (props: Partial<TheGivingBlockConfig>) => {
   const id = useId();
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    const div = ref.current;
+    if (!div) return;
+
+    // Create a new injection target for the widget
+    const target = document.createElement("div");
+    target.id = `tgb-widget-${id}`;
+    div.appendChild(target);
+
+    // Set global options for the widget
     Reflect.deleteProperty(window, "widgetOptions");
     Reflect.deleteProperty(window, "tgbWidgetOptions");
     window.tgbWidgetOptions = {
       ...theGivingBlockConfig,
+      ...props,
       scriptId: `tgb-widget-${id}`,
     };
 
+    // Inject the script to load the widget
     const script = document.createElement("script");
     script.async = true;
     script.src = `https://widget.thegivingblock.com/widget/script.js#${id}`;
-    document.body.appendChild(script);
+    div.appendChild(script);
 
     return () => {
-      script.parentNode?.removeChild(script);
+      div.innerHTML = "";
     };
-  }, [id]);
+  }, [props, id]);
 
-  return <div id={`tgb-widget-${id}`} />;
+  return <div ref={ref} />;
 };
 
 export default TheGivingBlockEmbed;

--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -39,7 +39,8 @@ const TheGivingBlockEmbed = ({
     return () => {
       div.innerHTML = "";
     };
-  }, [props, id]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, JSON.stringify(props)]);
 
   return <div ref={ref} className={className} />;
 };

--- a/apps/website/src/pages/donate.tsx
+++ b/apps/website/src/pages/donate.tsx
@@ -153,7 +153,7 @@ const DonatePage: NextPage = () => {
           {!consent.givingBlock && <DonateItem link={givingBlock} />}
 
           <Consent item="donation widget" consent="givingBlock">
-            <TheGivingBlockEmbed />
+            <TheGivingBlockEmbed className="flex w-full justify-center" />
           </Consent>
         </div>
 


### PR DESCRIPTION
## Describe your changes

Allows for us to pass through overrides to the default Giving Block embed options as props on the component, so we could change the button order for a specific use-case, or pass a campaign ID etc.

Reworked this component yet again, following on from #1497, as it now needs to also handle re-rendering while still mounted, which was causing React errors when the JSX div had been replaced by the embed, so we now have a persistent JSX div that we then add a replaceable div to via DOM manipulation.

## Notes for testing your change

Using the dev server with hot-reloading, render the donate page with the embed. Then, add `donationFlow="crypto,card,stock,daf"` to change the button order, and observe that the widget reloads itself without issue.