### PR TITLE
Allow progress bar to be dark or light

### DIFF
--- a/apps/website/src/components/content/Progress.tsx
+++ b/apps/website/src/components/content/Progress.tsx
@@ -1,18 +1,37 @@
 import { classes } from "@/utils/classes";
 
 const barClasses =
-  "absolute inset-y-0 left-0 min-w-10 rounded-full border-4 border-alveus-green-900 transition-all duration-[2s] ease-in-out";
+  "absolute inset-y-0 left-0 min-w-10 rounded-full border-4 transition-all duration-[2s] ease-in-out";
 
-const Progress = ({ progress }: { progress: number }) => (
-  <div className="relative my-1 h-10 w-full rounded-full bg-alveus-green-900 shadow-lg">
+const Progress = ({
+  progress,
+  dark = false,
+  className,
+}: {
+  progress: number;
+  dark?: boolean;
+  className?: string;
+}) => (
+  <div
+    className={classes(
+      "relative my-1 h-10 w-full rounded-full shadow-lg",
+      dark ? "bg-alveus-green-900" : "bg-alveus-green-100",
+      className,
+    )}
+  >
     <div
-      className={classes(barClasses, "bg-alveus-green")}
+      className={classes(
+        barClasses,
+        dark ? "border-alveus-green-900" : "border-alveus-green-100",
+        "bg-alveus-green",
+      )}
       style={{ width: `${progress}%` }}
     />
 
     <div
       className={classes(
         barClasses,
+        dark ? "border-alveus-green-900" : "border-alveus-green-100",
         "bg-alveus-tan bg-gradient-to-r from-blue-800 to-green-600",
         progress === 0 ? "opacity-0" : "animate-pulse-slow",
       )}

--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -127,7 +127,7 @@ export const GiveAnHourProgress = ({
         />
       )}
 
-      <Progress progress={progress} />
+      <Progress progress={progress} dark />
 
       {text === "after" && (
         <GiveAnHourProgressText


### PR DESCRIPTION
## Describe your changes

Allows for the progress bar to be rendered with a dark UI, as is done on the Give an Hour progress bar, or a new light variant.

## Notes for testing your change

Give an Hour progress bar continues to look the same.