### PR TITLE
Add focused control mode for presets page

### DIFF
--- a/apps/website/src/hooks/storage.ts
+++ b/apps/website/src/hooks/storage.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ZodType } from "zod";
+
+import { safeJSONParse } from "@/utils/helpers";
+
+const useLocalStorage = <T>(key: string, schema: ZodType<T>, initial: T) => {
+  const [stored, setStored] = useState<T>(initial);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const item = localStorage.getItem(key);
+      if (item) {
+        const parsed = safeJSONParse(item);
+        const result = schema.safeParse(parsed);
+        if (result.success) {
+          setStored(result.data);
+        }
+      }
+    }
+  }, [key, schema]);
+
+  const setValue = useCallback(
+    (value: T | ((val: T) => T)) => {
+      setStored((prev) => {
+        const valueToStore = value instanceof Function ? value(prev) : value;
+        if (typeof window !== "undefined") {
+          localStorage.setItem(key, JSON.stringify(valueToStore));
+        }
+        return valueToStore;
+      });
+    },
+    [key],
+  );
+
+  return [stored, setValue] as const;
+};
+
+export default useLocalStorage;


### PR DESCRIPTION
## Describe your changes

Adds a new toggle to enable a focused mode for the page, making the controls section full-screen (non-native), hiding all other elements on the page (and also hiding the instructions), giving those who know what they're doing more screen real estate for the controls themselves.

_As an aside, I really need to break this page up into components, this file is becoming a mess to work in._

## Notes for testing your change

Focused mode + sidebar width persist correctly to local storage, both enabled + disabled.