### PR TITLE
Map vertical scrolling to horizontal scrolling for pixels

### DIFF
--- a/apps/website/src/components/institute/Pixels.tsx
+++ b/apps/website/src/components/institute/Pixels.tsx
@@ -81,10 +81,10 @@ const Pixels = ({
   ref,
 }: {
   filter?: (pixel: Pixel, signal: AbortSignal) => boolean | Promise<boolean>;
+  onFilter?: (pixel: Pixel[]) => void;
   className?: string;
   canvasClassName?: string;
   ref?: Ref<HTMLDivElement>;
-  onFilter?: (pixel: Pixel[]) => void;
 }) => {
   const canvas = useRef<HTMLCanvasElement>(null);
 

--- a/apps/website/src/pages/institute/pixels.tsx
+++ b/apps/website/src/pages/institute/pixels.tsx
@@ -84,6 +84,28 @@ const InstitutePixelsPage: NextPage = () => {
     });
   }, []);
 
+  const pixelsRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) return;
+      fullscreenRef.current = node;
+
+      // Map vertical scrolling to horizontal scrolling, only when in fullscreen
+      if (!fullscreen) return;
+
+      const onWheel = (e: WheelEvent) => {
+        if (!e.deltaY) return;
+        node.scrollLeft += e.deltaY + e.deltaX;
+        e.preventDefault();
+      };
+
+      node.addEventListener("wheel", onWheel, { passive: false });
+      return () => {
+        node.removeEventListener("wheel", onWheel);
+      };
+    },
+    [fullscreen],
+  );
+
   return (
     <PixelSyncProviderProvider>
       <Meta
@@ -160,7 +182,7 @@ const InstitutePixelsPage: NextPage = () => {
                   ? "max-w-none!"
                   : "shadow-xl ring-4 ring-alveus-green",
               )}
-              ref={fullscreenRef}
+              ref={pixelsRef}
             />
 
             {fullscreen && (


### PR DESCRIPTION
## Describe your changes

Makes the full-screen mode, which was really only intended for mobile, a bit more accessible for desktop users by allowing vertical scrolling on the canvas to be mapped to the horizontal scrolling it needs (without needing to shift scroll, the native control for horizontal scrolling).

## Notes for testing your change

...
