### PR TITLE
Allow images to load from localhost when required

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -25,6 +25,12 @@ function urlOriginAsRemotePattern(url: string): RemotePattern {
   };
 }
 
+const s3Pattern = urlOriginAsRemotePattern(
+  process.env.FILE_STORAGE_CDN_URL ||
+    process.env.FILE_STORAGE_ENDPOINT ||
+    "https://localhost",
+);
+
 const config: NextConfig = {
   reactStrictMode: true,
   images: {
@@ -76,12 +82,10 @@ const config: NextConfig = {
         hostname: "www.alveussanctuary.org",
       },
       // S3 - File Storage
-      urlOriginAsRemotePattern(
-        process.env.FILE_STORAGE_CDN_URL ||
-          process.env.FILE_STORAGE_ENDPOINT ||
-          "https://localhost",
-      ),
+      s3Pattern,
     ],
+    // Allow localhost requests if the S3 pattern requires it
+    dangerouslyAllowLocalIP: s3Pattern.hostname === "localhost",
     // Allow SVGs to be proxied through Next.js
     dangerouslyAllowSVG: true,
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",


### PR DESCRIPTION
## Describe your changes

Tracked down the issue loading images locally to be coming from: 

https://github.com/vercel/next.js/blob/v16.0.0/packages/next/src/server/image-optimizer.ts#L716-L737

There is a new `dangerouslyAllowLocalIP` config setting we can set that bypasses this:

https://github.com/vercel/next.js/blob/v16.0.0/packages/next/src/server/next-server.ts#L782-L795

## Notes for testing your change

Images load on show and tell from minio locally.