### PR TITLE
Fix YouTube embeds now requiring referrer to be sent

### DIFF
--- a/apps/website/src/components/content/YouTube.tsx
+++ b/apps/website/src/components/content/YouTube.tsx
@@ -81,7 +81,7 @@ export const YouTubeEmbed = ({ videoId, caption }: EmbedProps) => (
       <iframe
         src={iframeSrc(videoId)}
         title="Video embed"
-        referrerPolicy="no-referrer"
+        referrerPolicy="strict-origin-when-cross-origin"
         allow="fullscreen; encrypted-media"
         sandbox="allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox"
         loading="lazy"


### PR DESCRIPTION
## Describe your changes

Since recently YouTube will complain about an "invalid player configuration" if the `referrerPolicy` on the iframe does not allow the browser to send a referrer to YouTube. The only fix I know is, allowing it. So this changes our embed to allow the browser to send it. 

## Notes for testing your change

Check all youtube embeds work (again).
