### PR TITLE
Fix unsaved changes bug for posts with location

### DIFF
--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -295,10 +295,9 @@ export function ShowAndTellEntryForm({
         if (
           hadInitialLocation &&
           hasLocation &&
-          initialLocation &&
-          initialLocation.latitude === userSelectedLocation.latitude &&
-          initialLocation.longitude === userSelectedLocation.longitude &&
-          initialLocation.location === userSelectedLocation.location
+          initialLocation?.latitude === userSelectedLocation.latitude &&
+          initialLocation?.longitude === userSelectedLocation.longitude &&
+          initialLocation?.location === userSelectedLocation.location
         ) {
           return;
         }


### PR DESCRIPTION
Fix #1607.

Properly check for changes to locations - currently, the initialization is considered a change.
