### PR TITLE
Use gray background for pixel mural

### DIFF
--- a/apps/website/src/components/institute/Pixels.tsx
+++ b/apps/website/src/components/institute/Pixels.tsx
@@ -122,7 +122,7 @@ const PixelsInternal = ({
         if (controller.signal.aborted || !match) return;
         return pixel;
       }) || [],
-    ).then((filtered) => {
+    ).then(async (filtered) => {
       if (controller.signal.aborted) return;
 
       const filteredPixels = filtered.filter((p): p is Pixel => !!p);
@@ -146,8 +146,9 @@ const PixelsInternal = ({
       }
 
       // Draw the actual pixels
-      filteredPixels.forEach((pixel) => {
-        if (controller.signal.aborted) return;
+      for (let i = 0; i < filteredPixels.length; i++) {
+        const pixel = filteredPixels[i];
+        if (controller.signal.aborted || !pixel) continue;
 
         const data = Uint8ClampedArray.from(atob(pixel.data), (c) =>
           c.charCodeAt(0),
@@ -157,7 +158,11 @@ const PixelsInternal = ({
           pixel.column * PIXEL_SIZE,
           pixel.row * PIXEL_SIZE,
         );
-      });
+
+        if (i % 500 === 0) {
+          await new Promise(requestAnimationFrame);
+        }
+      }
     });
 
     return () => controller.abort();


### PR DESCRIPTION
## Describe your changes

- Changes canvas background to be a medium light gray to highlight white pixels better
- Adds a highlight around filtered pixels (one canvas pixel width, blurred) (blur doesnt work on safari - it still looks decent, but depending on device pixel density might not line up perfectly with device pixels/DOM highlight).

## Notes for testing your change

Check its still performant.
