### PR TITLE
Normalize PayPal donation emails

### DIFF
--- a/apps/donations/worker/src/providers/paypal/paypal.ts
+++ b/apps/donations/worker/src/providers/paypal/paypal.ts
@@ -73,7 +73,7 @@ export class PaypalDonationProvider implements DonationProvider {
       note: payload.data.memo,
       donatedBy: {
         primary: "firstName",
-        email: payload.data.payer_email,
+        email: payload.data.payer_email.trim().toLowerCase(),
         firstName: payload.data.first_name,
         lastName: payload.data.last_name,
       },


### PR DESCRIPTION
## Describe your changes

We can use `SELECT email FROM (SELECT donatedBy->>'$.email' AS email, LOWER(TRIM(donatedBy->>'$.email')) AS email_normalized FROM Donation) AS Donation_email WHERE email <> email_normalized;` to check how many existing donations have emails that need normalizing.

We can then use `UPDATE Donation SET JSON_REPLACE(donatedBy, '$.email', LOWER(TRIM(donatedBy->>'$.email'))) WHERE donatedBy->>'$.email' <> LOWER(TRIM(donatedBy->>'$.email'));` to update all those donations to have normalized emails.

We'll also need to update the metadata stored for any pixels tied to those donations, updating the hashed email to be the hashed normalized email?

## Notes for testing your change

...
