### PR TITLE
Allow long target links for short links

### DIFF
--- a/apps/database/prisma/schema.prisma
+++ b/apps/database/prisma/schema.prisma
@@ -264,7 +264,7 @@ model ShortLinks {
   id    String @id @default(cuid())
   label String
   slug  String @unique
-  link  String
+  link  String @db.Text
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Describe your changes

Some target URLs we want to have for short links are too long to fit in the default VarChar(191) column type.

## Notes for testing your change

...
