### PR TITLE
Ensure chat commands are lowercased for rounds checks

### DIFF
--- a/apps/website/src/hooks/checks.ts
+++ b/apps/website/src/hooks/checks.ts
@@ -70,7 +70,7 @@ const useChecks = (channels: string[], users?: string[]) => {
     useCallback(
       (message: ChatMessage) => {
         const { text, userInfo } = message;
-        const [command, ...keys] = text.split(" ");
+        const [command, ...keys] = text.toLowerCase().split(" ");
 
         if (command !== "!check") return;
         if (


### PR DESCRIPTION
## Describe your changes

The admin form already enforces our standard slug pattern for the command, so it will always be lowercase, I just missed normalizing the chat commands in the hook to be lowercase as well.

## Notes for testing your change

You can type `!ChEcK sLuG` and it'll work.