### PR TITLE
Remove cycle time offset for logo/QR

### DIFF
--- a/apps/website/src/components/overlay/Event.tsx
+++ b/apps/website/src/components/overlay/Event.tsx
@@ -42,7 +42,7 @@ const Socials = ({ className, ...props }: HTMLProps<HTMLDivElement>) => (
           [],
         )}
         // We want to be back on the logo before the parent cycle switches
-        interval={cycleTime / 3 + 1}
+        interval={cycleTime / 3}
       />
     </div>
 


### PR DESCRIPTION
## Describe your changes

Forgot to remove this in #1669 now that we're keeping this rendered all the time.

## Notes for testing your change

...
