### PR TITLE
Set CI="true" in chatbot Dockerfile

### DIFF
--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -26,7 +26,7 @@ COPY ./apps/chatbot/.env .
 
 ## Install dependencies
 RUN npm install -g corepack@latest && corepack enable && corepack install
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --filter "{.}..." && pnpm prune --prod
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --filter "{.}..."
 
 ## Copy code
 COPY ./apps/chatbot/src/ src/


### PR DESCRIPTION
## Describe your changes

#1604 broke this, oops. Neesd `CI="true"` now to get past a no TTY error from `pnpm install`.

I had to remove `pnpm prune --prod` as it was seemingly pruning production dependencies from the database package that we need. pnpm's guidance says to do a fresh `pnpm install --prod` instead, but our repo is not set up to do that and would fail on trying to build the database package etc.

## Notes for testing your change

Deploy of chatbot works.
