### PR TITLE
Fix overflowing preset names on cards

### DIFF
--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -151,7 +151,7 @@ const Card = ({
     />
     <div className="flex flex-col gap-1 rounded-b-lg bg-alveus-tan p-2">
       <div className="flex items-center justify-between">
-        <h4 className="text-lg font-semibold">{title}</h4>
+        <h4 className="truncate text-lg font-semibold">{title}</h4>
         {command && (
           <div className="flex gap-1">
             <CopyToClipboardButton


### PR DESCRIPTION
## Describe your changes


<img width="800" height="397" alt="image" src="https://github.com/user-attachments/assets/8c8bd4df-8001-4d87-acda-0640ddac8057" />


<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->

...

## Notes for testing your change

...
