### PR TITLE
Add missing tooltip middleware to fix overflow

### DIFF
--- a/apps/website/src/hooks/tooltip.tsx
+++ b/apps/website/src/hooks/tooltip.tsx
@@ -44,7 +44,7 @@ const useTooltip = ({
     onOpenChange: setIsOpen,
     whileElementsMounted: autoUpdate,
     placement: placement,
-    middleware: [flip(), shift(), offset(offsetOpts)],
+    middleware: [offset(offsetOpts), flip(), shift()],
   });
 
   const { getReferenceProps, getFloatingProps } = useInteractions([


### PR DESCRIPTION
## Describe your changes

Fixes the issue noted at the end of #1738, by ensuring the tooltip automatically flips + shifts to remain within the viewport always.

## Notes for testing your change

Check that the overflow doesn't occur on tooltips on the presets page.
