### PR TITLE
Short-circuit Cycle when there are no items

### DIFF
--- a/apps/website/src/components/overlay/Cycle.tsx
+++ b/apps/website/src/components/overlay/Cycle.tsx
@@ -28,6 +28,11 @@ const Cycle = ({
   const next = useCallback(
     (check = false) => {
       setIndex((prev) => {
+        // If we have no items, stay where we are
+        if (items.length === 0) {
+          return prev;
+        }
+
         // If check is true, only advance if the current ref is null
         // However, if the current index is beyond the items length, we must advance
         if (check && prev < items.length) {


### PR DESCRIPTION
## Describe your changes

Avoids `(prev + 1) % 0` which'll be `NaN`, causing it to end up in an infinite loop.

## Notes for testing your change

`/stream/overlay?hide=socials&hide=event` no longer locks up after 60s.