### PR TITLE
Replace &nbsp; with space in quill output

### DIFF
--- a/apps/website/src/components/shared/form/RichTextField.tsx
+++ b/apps/website/src/components/shared/form/RichTextField.tsx
@@ -71,7 +71,8 @@ export function RichTextField({ defaultValue, ...props }: FormFieldProps) {
     // Only call onChange after user has actually interacted with the editor
     // Not when the value is being set programmatically
     if (hasUserInteractedRef.current && props.onChange) {
-      props.onChange(newValue);
+      // FIXME: https://github.com/VaguelySerious/react-quill/issues/52
+      props.onChange(newValue.replaceAll("&nbsp;", " "));
     }
   };
 


### PR DESCRIPTION
## Describe your changes

Workaround to https://github.com/VaguelySerious/react-quill/issues/52 / https://github.com/slab/quill/issues/4509

Will need to run `UPDATE ShowAndTellEntry SET text = REPLACE(text, '&nbsp;', ' ');` against the DB to fix existing posts.

## Notes for testing your change

With a log added locally:

```patch
diff --git a/apps/website/src/components/shared/form/RichTextField.tsx b/apps/website/src/components/shared/form/RichTextField.tsx
index 2c351b11..9326dc38 100644
--- a/apps/website/src/components/shared/form/RichTextField.tsx
+++ b/apps/website/src/components/shared/form/RichTextField.tsx
@@ -72,6 +72,7 @@ export function RichTextField({ defaultValue, ...props }: FormFieldProps) {
     // Not when the value is being set programmatically
     if (hasUserInteractedRef.current && props.onChange) {
       // FIXME: https://github.com/VaguelySerious/react-quill/issues/52
+      console.log("RichTextField: triggering onChange", newValue, newValue.replaceAll("&nbsp;", " "));
       props.onChange(newValue.replaceAll("&nbsp;", " "));
     }
   };
```

You can see that all spaces are coming back as `&nbsp;` from Quill, and this correctly replaces them all with regular spaces.