### PR TITLE
Remove corepack from README + Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you aren't working on features related to Twitch authentication, you can set 
 ### Local development
 
 1. Install Node.js using a version manager like [`nvm`](https://github.com/nvm-sh/nvm) or [`fnm`](https://github.com/Schniz/fnm). Run `nvm install`/`fnm install` in the project directory to install and `nvm use`/`fnm use` to use the correct Node.js version. Alternatively see [nodejs.org](https://nodejs.org/en/download) for other options to download and install Node.js. You can see what version we need in `package.json` under `engines`.
-2. Use `corepack enable` to use pnpm as the package manager. Corepack is a tool provided with Node.js that makes it easy for you to use the specific package manager we expect.
+2. Install [pnpm](https://pnpm.io/installation) as we use this as our package manager. It will automatically respect the version defined in `package.json` under `packageManager`.
 3. Authenticate with the GitHub Package Registry: `npm login --auth-type=legacy --registry=https://npm.pkg.github.com`
    1. Use your GitHub username (lowercase) as the username when prompted
    2. Create a [GitHub personal access token (classic)](https://github.com/settings/tokens/new) with the `read:packages` scope and use it as the password when prompted

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:24-alpine
-ENV PNPM_HOME="/pnpm"
 ENV CI="true"
+
+## Install pnpm
+ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
 
 ## Copy root files
 WORKDIR /app
@@ -25,7 +28,6 @@ COPY ./apps/chatbot/package.json .
 COPY ./apps/chatbot/.env .
 
 ## Install dependencies
-RUN npm install -g corepack@latest && corepack enable && corepack install
 RUN --mount=type=secret,id=github_token,target=/tmp/github_token \
 		--mount=type=cache,id=pnpm,target=/pnpm/store \
     set -eu; \

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -4,7 +4,10 @@ ENV CI="true"
 ## Install pnpm
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
+RUN wget -qO /tmp/install-pnpm.sh https://get.pnpm.io/install.sh && \
+  echo "9bbfd08ac1bd3001828b7a645ab071d31cbc7a26c92808554dbb6283313121ec  /tmp/install-pnpm.sh" | sha256sum -c - && \
+  ENV="$HOME/.shrc" SHELL="$(which sh)" sh /tmp/install-pnpm.sh && \
+  rm /tmp/install-pnpm.sh
 
 ## Copy root files
 WORKDIR /app

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -4,7 +4,10 @@ ENV CI="true"
 ## Install pnpm
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"
-RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
+RUN wget -qO /tmp/install-pnpm.sh https://get.pnpm.io/install.sh && \
+  echo "44dfbba11a70a9751090894a07f8d64c9f7954cb782dfe39a1f2b2753e1d5eea  /tmp/install-pnpm.sh" | sha256sum -c - && \
+  ENV="$HOME/.shrc" SHELL="$(which sh)" sh /tmp/install-pnpm.sh && \
+  rm /tmp/install-pnpm.sh
 
 ## Copy root files
 WORKDIR /app

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:24-alpine
-ENV PNPM_HOME="/pnpm"
 ENV CI="true"
-ENV PATH="$PNPM_HOME:$PATH"
+
+## Install pnpm
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME/bin:$PATH"
+RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
 
 ## Copy root files
 WORKDIR /app
@@ -25,7 +28,6 @@ COPY ./apps/chatbot/package.json .
 COPY ./apps/chatbot/.env .
 
 ## Install dependencies
-RUN npm install -g corepack@latest && corepack enable && corepack install
 RUN --mount=type=secret,id=github_token,target=/tmp/github_token \
 		--mount=type=cache,id=pnpm,target=/pnpm/store \
     set -eu; \


### PR DESCRIPTION
## Describe your changes

As corepack is going away in future versions of Node.js, and with CI now using `pnpm self-update` (#1774), which does not work when using corepack, I figured it'd be a good time to move away from recommending corepack as the install method for pnpm.

pnpm can self-manage different versions based on `package.json#packageManager`, just like corepack does.

## Notes for testing your change

Chatbot deploys.