### PR TITLE
Bump pnpm from 10.28.0 to 10.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   },
   "engines": {
     "node": ">=24.11.0",
-    "pnpm": "^10.28.0"
+    "pnpm": "^10.28.1"
   },
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.28.1",
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",


### PR DESCRIPTION
Generated via `pnpm self-update`.

Check this workflow's logs at https://github.com/alveusgg/alveusgg/actions/runs/21341974104.