### PR TITLE
Avoid socials/subs text overlap with PiP layouts

### DIFF
--- a/apps/website/src/pages/stream/overlay.tsx
+++ b/apps/website/src/pages/stream/overlay.tsx
@@ -323,9 +323,19 @@ const OverlayPage: NextPage = () => {
                     // Don't overlap PiP borders with text
                     layout === "pipbl" && "left-1/3",
                     layout === "pipbr" && "right-1/3",
+                    // Don't overlap socials info with text
+                    (layout === "fullscreen" ||
+                      layout === "pipbr" ||
+                      layout.startsWith("pipt")) &&
+                      "pl-80",
+                    // Don't overlap sub count with text
+                    (layout === "fullscreen" ||
+                      layout === "pipbl" ||
+                      layout.startsWith("pipt")) &&
+                      "pr-80",
                     // When we have a fullscreen slot, center the text
                     (layout === "fullscreen" || layout.startsWith("pip")) &&
-                      "text-center",
+                      "pb-2 text-center",
                   )}
                 >
                   {disclaimerText}
@@ -339,6 +349,16 @@ const OverlayPage: NextPage = () => {
                     // Don't overlap PiP borders with text
                     layout === "pipbl" && "left-1/3",
                     layout === "pipbr" && "right-1/3",
+                    // Don't overlap socials info with text
+                    (layout === "fullscreen" ||
+                      layout === "pipbr" ||
+                      layout.startsWith("pipt")) &&
+                      "pl-80",
+                    // Don't overlap sub count with text
+                    (layout === "fullscreen" ||
+                      layout === "pipbl" ||
+                      layout.startsWith("pipt")) &&
+                      "pr-80",
                   )}
                 >
                   {text}


### PR DESCRIPTION
## Describe your changes

Adds yet more special logic to handle the disclaimer + custom text positioning when in the pip layouts.

## Notes for testing your change

Large disclaimer text + custom text do not collide with socials or subs when in pipbl/pipbr.
