### PR TITLE
Use custom token for private sync

### DIFF
--- a/.github/workflows/sync-from-public.yml
+++ b/.github/workflows/sync-from-public.yml
@@ -5,10 +5,6 @@ on:
     - cron: "0 * * * *" # hourly
   workflow_dispatch:
 
-permissions:
-  actions: write
-  contents: write
-
 jobs:
   sync:
     if: github.repository == 'alveusgg/alveusgg-private'
@@ -19,6 +15,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
+          token: ${{ secrets.GH_SYNC_TOKEN }}
 
       - name: Fetch public repo and push
         run: |


### PR DESCRIPTION
## Describe your changes

We still run into issues when workflow files update in this repo and fail to sync to the private repo -- #1729 did not solve the issue, so instead, we'll use a custom bot token that we know has the correct access.

## Notes for testing your change

Token created: https://github.com/settings/personal-access-tokens/13571100 https://github.com/alveusgg/alveusgg-private/settings/secrets/actions
