### PR TITLE
Added support for server-to-server client credentials

### DIFF
--- a/apps/website/__tests__/oauth-token-route.test.ts
+++ b/apps/website/__tests__/oauth-token-route.test.ts
@@ -10,6 +10,7 @@ const {
   mockCompareAuthorizationCode,
   mockHasOAuthSigningKey,
   mockIsAllowedRedirectUri,
+  mockIssueAccessToken,
   mockIssueAccessTokenForUser,
   mockIssueRefreshToken,
   mockVerifyRefreshToken,
@@ -19,6 +20,7 @@ const {
     mockCompareAuthorizationCode: vi.fn(),
     mockHasOAuthSigningKey: vi.fn(),
     mockIsAllowedRedirectUri: vi.fn(),
+    mockIssueAccessToken: vi.fn(),
     mockIssueAccessTokenForUser: vi.fn(),
     mockIssueRefreshToken: vi.fn(),
     mockVerifyRefreshToken: vi.fn(),
@@ -65,6 +67,7 @@ vi.mock("@/server/oauth/tokens", async () => {
   return {
     ...actual,
     OAuthRequestError: actual.OAuthRequestError,
+    issueAccessToken: mockIssueAccessToken,
     issueAccessTokenForUser: mockIssueAccessTokenForUser,
     issueRefreshToken: mockIssueRefreshToken,
     verifyRefreshToken: mockVerifyRefreshToken,
@@ -97,6 +100,7 @@ describe("oauth token route", () => {
     mockCompareAuthorizationCode.mockResolvedValue({ sub: "user-1" });
     mockHasOAuthSigningKey.mockReturnValue(true);
     mockIsAllowedRedirectUri.mockReturnValue(true);
+    mockIssueAccessToken.mockResolvedValue("client-credentials-access-token");
     mockIssueAccessTokenForUser.mockResolvedValue("access-token");
     mockIssueRefreshToken.mockResolvedValue("refresh-token");
     mockVerifyRefreshToken.mockResolvedValue({
@@ -206,6 +210,68 @@ describe("oauth token route", () => {
       error_description: "Refresh token mismatch.",
     });
   });
+
+  test("issues an access token for client_credentials with scope roles", async () => {
+    const response = await POST(
+      createFormRequest({
+        grant_type: "client_credentials",
+        scope: "dashboard forms dashboard",
+      }),
+    );
+    if (!response) {
+      throw new Error("Expected response.");
+    }
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toStrictEqual({
+      access_token: "client-credentials-access-token",
+      expires_in: 600,
+      token_type: "Bearer",
+    });
+    expect(mockIssueAccessToken).toHaveBeenCalledWith({
+      subject: "census-production",
+      clientId: "census-production",
+      roles: ["dashboard", "forms"],
+    });
+    expect(mockIssueRefreshToken).not.toHaveBeenCalled();
+  });
+
+  test("client_credentials with no scope yields empty roles", async () => {
+    const response = await POST(
+      createFormRequest({
+        grant_type: "client_credentials",
+      }),
+    );
+    if (!response) {
+      throw new Error("Expected response.");
+    }
+
+    expect(response.status).toBe(200);
+    expect(mockIssueAccessToken).toHaveBeenCalledWith({
+      subject: "census-production",
+      clientId: "census-production",
+      roles: [],
+    });
+  });
+
+  test("rejects client_credentials with unknown scope values", async () => {
+    const response = await POST(
+      createFormRequest({
+        grant_type: "client_credentials",
+        scope: "dashboard not_a_real_role",
+      }),
+    );
+    if (!response) {
+      throw new Error("Expected response.");
+    }
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toStrictEqual({
+      error: "invalid_scope",
+      error_description: "Unknown or invalid scope: not_a_real_role",
+    });
+    expect(mockIssueAccessToken).not.toHaveBeenCalled();
+  });
 });
 
 describe("oauth authorization server metadata", () => {
@@ -221,7 +287,11 @@ describe("oauth authorization server metadata", () => {
     expect(await response.json()).toMatchObject({
       token_endpoint_auth_methods_supported: ["client_secret_basic"],
       code_challenge_methods_supported: ["S256"],
-      grant_types_supported: ["authorization_code", "refresh_token"],
+      grant_types_supported: [
+        "authorization_code",
+        "refresh_token",
+        "client_credentials",
+      ],
       response_types_supported: ["code"],
     });
   });

--- a/apps/website/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/website/src/app/.well-known/oauth-authorization-server/route.ts
@@ -26,7 +26,11 @@ export async function GET() {
     userinfo_endpoint: OAUTH_USERINFO_ENDPOINT,
     jwks_uri: OAUTH_JWKS_URI,
     response_types_supported: ["code"],
-    grant_types_supported: ["authorization_code", "refresh_token"],
+    grant_types_supported: [
+      "authorization_code",
+      "refresh_token",
+      "client_credentials",
+    ],
     code_challenge_methods_supported: [OAUTH_CODE_CHALLENGE_METHOD],
     token_endpoint_auth_methods_supported: ["client_secret_basic"],
   });

--- a/apps/website/src/app/api/oauth/token/route.ts
+++ b/apps/website/src/app/api/oauth/token/route.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { isValidUserRole } from "@/data/user-roles";
 import {
   authenticateOAuthClient,
   getInvalidClientHeaders,
@@ -14,12 +15,17 @@ import {
 import { hasOAuthSigningKey } from "@/server/oauth/keys";
 import {
   OAuthRequestError,
+  issueAccessToken,
   issueAccessTokenForUser,
   issueRefreshToken,
   verifyRefreshToken,
 } from "@/server/oauth/tokens";
 
-const TokenGrantTypeSchema = z.enum(["authorization_code", "refresh_token"]);
+const TokenGrantTypeSchema = z.enum([
+  "authorization_code",
+  "refresh_token",
+  "client_credentials",
+]);
 
 const AuthorizationCodeGrantSchema = z.object({
   grant_type: z.literal("authorization_code"),
@@ -33,15 +39,24 @@ const RefreshTokenGrantSchema = z.object({
   refresh_token: z.string().min(1),
 });
 
+const ClientCredentialsGrantSchema = z.object({
+  grant_type: z.literal("client_credentials"),
+  scope: z.string().optional(),
+});
+
 const TokenRequestSchema = z.discriminatedUnion("grant_type", [
   AuthorizationCodeGrantSchema,
   RefreshTokenGrantSchema,
+  ClientCredentialsGrantSchema,
 ]);
 
 type AuthorizationCodeGrantRequest = z.infer<
   typeof AuthorizationCodeGrantSchema
 >;
 type RefreshTokenGrantRequest = z.infer<typeof RefreshTokenGrantSchema>;
+type ClientCredentialsGrantRequest = z.infer<
+  typeof ClientCredentialsGrantSchema
+>;
 
 const TOKEN_RESPONSE_HEADERS = {
   "Cache-Control": "no-store",
@@ -81,6 +96,13 @@ function parseTokenRequest(formData: FormData) {
     );
   }
 
+  if (
+    !tokenRequestResult.success &&
+    grantTypeResult.data === "client_credentials"
+  ) {
+    throw new OAuthRequestError(400, "invalid_request", "Invalid request.");
+  }
+
   if (!tokenRequestResult.success) {
     throw new OAuthRequestError(400, "invalid_request", "Invalid request.");
   }
@@ -108,6 +130,51 @@ async function issueTokenPairForUser(userId: string, clientId: string) {
   return {
     ...accessTokenResponse,
     refresh_token: refreshToken,
+  };
+}
+
+function rolesFromOAuthScope(scope: string | undefined): string[] {
+  if (!scope?.trim()) {
+    return [];
+  }
+
+  const requested = scope.trim().split(/\s+/).filter(Boolean);
+  const roles: string[] = [];
+  const seen = new Set<string>();
+
+  for (const token of requested) {
+    if (!isValidUserRole(token)) {
+      throw new OAuthRequestError(
+        400,
+        "invalid_scope",
+        `Unknown or invalid scope: ${token}`,
+      );
+    }
+    if (seen.has(token)) {
+      continue;
+    }
+    seen.add(token);
+    roles.push(token);
+  }
+
+  return roles;
+}
+
+async function handleClientCredentialsGrant(
+  { scope }: ClientCredentialsGrantRequest,
+  client: OAuthClient,
+) {
+  const roles = rolesFromOAuthScope(scope);
+  const access_token = await issueAccessToken({
+    subject: client.clientId,
+    clientId: client.clientId,
+    roles,
+  });
+
+  return {
+    access_token,
+    token_type: OAUTH_TOKEN_TYPE,
+    expires_in: OAUTH_ACCESS_TOKEN_TTL_SECONDS,
   };
 }
 
@@ -182,6 +249,13 @@ export async function POST(request: Request) {
 
     if (tokenRequest.grant_type === "refresh_token") {
       const response = await handleRefreshTokenGrant(tokenRequest, client);
+      return Response.json(response, {
+        headers: TOKEN_RESPONSE_HEADERS,
+      });
+    }
+
+    if (tokenRequest.grant_type === "client_credentials") {
+      const response = await handleClientCredentialsGrant(tokenRequest, client);
       return Response.json(response, {
         headers: TOKEN_RESPONSE_HEADERS,
       });

--- a/apps/website/src/app/api/oauth/token/route.ts
+++ b/apps/website/src/app/api/oauth/token/route.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-import { isValidUserRole } from "@/data/user-roles";
 import {
   authenticateOAuthClient,
   getInvalidClientHeaders,
@@ -20,6 +19,8 @@ import {
   issueRefreshToken,
   verifyRefreshToken,
 } from "@/server/oauth/tokens";
+
+import { isValidUserRole } from "@/data/user-roles";
 
 const TokenGrantTypeSchema = z.enum([
   "authorization_code",


### PR DESCRIPTION

## Describe your changes

Added support for server-to-server client credentials to allow trusted clients to get tokens with roles for APIs protected by the token.

This allows integrated server-to-server permissions instead of the adhoc shared keys we currently use. Specifically this is so the census can call the cam-manager to upgrade clips. 

Scopes == roles. Trusted client can ask for any roles in the token and it's best practice for those to be a limited as possible to achieve that request. Client credentials cannot be used to get a refresh token. The `sub` of the jwt is the client ID.

<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->

...

## Notes for testing your change

...
