### PR TITLE
Show and Tell Admin: Open article preview from edit page

### DIFF
--- a/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
+++ b/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
@@ -1,7 +1,7 @@
 import type { InferGetStaticPropsType, NextPage, NextPageContext } from "next";
 import { getSession } from "next-auth/react";
 import { useRouter } from "next/router";
-import { useCallback, useRef } from "react";
+import { type MouseEventHandler, useCallback, useRef } from "react";
 
 import { getAdminSSP } from "@/server/utils/admin";
 
@@ -18,13 +18,16 @@ import Meta from "@/components/content/Meta";
 import { MessageBox } from "@/components/shared/MessageBox";
 import {
   Button,
+  LinkButton,
   approveButtonClasses,
   dangerButtonClasses,
   defaultButtonClasses,
+  secondaryButtonClasses,
 } from "@/components/shared/form/Button";
 import { ShowAndTellEntryForm } from "@/components/show-and-tell/ShowAndTellEntryForm";
 
 import IconCheckCircle from "@/icons/IconCheckCircle";
+import IconEye from "@/icons/IconEye";
 import IconMinus from "@/icons/IconMinus";
 import IconTrash from "@/icons/IconTrash";
 
@@ -131,6 +134,27 @@ const AdminReviewShowAndTellPage: NextPage<
     }
   }, [deleteMutation, entry]);
 
+  const handlePreview: MouseEventHandler<HTMLAnchorElement> = useCallback(
+    (e) => {
+      if (
+        confirmIfUnsavedRef.current?.(
+          "You have unsaved changes. Preview will show the old version! Continue?",
+        ) === false
+      ) {
+        e.preventDefault();
+        return false;
+      }
+
+      const url =
+        e.currentTarget instanceof HTMLAnchorElement && e.currentTarget.href;
+      if (url) {
+        window.open(url, "preview", "popup=yes,width=800,height=600");
+        e.preventDefault();
+      }
+    },
+    [],
+  );
+
   return (
     <>
       <Meta title="Review submission - Admin Show and Tell" />
@@ -180,6 +204,16 @@ const AdminReviewShowAndTellPage: NextPage<
                 )}
               </div>
               <div className="flex flex-col gap-2">
+                <LinkButton
+                  size="small"
+                  className={secondaryButtonClasses}
+                  href={`/admin/show-and-tell/review/${entry.id}/preview`}
+                  target="_blank"
+                  onClick={handlePreview}
+                >
+                  <IconEye className="size-5" />
+                  Preview
+                </LinkButton>
                 {status === "approved" && (
                   <Button
                     size="small"

--- a/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
+++ b/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
@@ -142,13 +142,15 @@ const AdminReviewShowAndTellPage: NextPage<
         ) === false
       ) {
         e.preventDefault();
-        return false;
+        return;
       }
 
-      const url =
-        e.currentTarget instanceof HTMLAnchorElement && e.currentTarget.href;
-      if (url) {
-        window.open(url, "preview", "popup=yes,width=800,height=600");
+      const popup = window.open(
+        e.currentTarget.href,
+        "preview",
+        "popup=yes,width=800,height=600",
+      );
+      if (popup) {
         e.preventDefault();
       }
     },


### PR DESCRIPTION
## Describe your changes

This pull request enhances the admin review page for Show and Tell entries by adding a preview feature. The main change introduces a "Preview" button that allows admins to preview the entry in a popup window, with a confirmation dialog if there are unsaved changes.

**Preview functionality:**

* Added a `LinkButton` labeled "Preview" with an eye icon (`IconEye`) that opens the entry preview in a popup window. If there are unsaved changes, a confirmation dialog warns the user before proceeding. 

Resolves: #1404
Closes: #1581 

## Notes for testing your change

Check it opens and warns properly