### PR TITLE
Show & Tell Admin: Indicate unsaved changes and mutation in buttons

### DIFF
--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -73,6 +73,7 @@ import { VideoLinksField } from "../shared/form/VideoLinksField";
 import { DominantColorFieldset } from "./DominantColorFieldset";
 
 type ShowAndTellEntryFormProps = {
+  className?: string;
   isAnonymous?: boolean;
   entry?: PublicShowAndTellEntryWithAttachments & Partial<ShowAndTellEntry>;
   action: "review" | "create" | "update";
@@ -221,6 +222,7 @@ function GiveAnHourInput({
 }
 
 export function ShowAndTellEntryForm({
+  className,
   isAnonymous = false,
   action = "create",
   entry,
@@ -239,7 +241,7 @@ export function ShowAndTellEntryForm({
   const isLoading = create.isPending || update.isPending || review.isPending;
 
   // Only enable unsaved changes warning for admin review action
-  const { markAsChanged, resetChanges, confirmIfUnsaved } =
+  const { hasUnsavedChanges, markAsChanged, resetChanges, confirmIfUnsaved } =
     useFormChangeWarning(action === "review");
 
   const [wantsToTrackGiveAnHour, setWantsToTrackGiveAnHour] = useState(
@@ -610,7 +612,14 @@ export function ShowAndTellEntryForm({
   const wasApproved = entry && getEntityStatus(entry) === "approved";
 
   return (
-    <form className="my-5 flex flex-col gap-5" onSubmit={handleSubmit}>
+    <form
+      className={classes(
+        "flex flex-col gap-5 rounded-xs",
+        className,
+        hasUnsavedChanges && "ring-4 ring-yellow",
+      )}
+      onSubmit={handleSubmit}
+    >
       {action === "update" && wasApproved && (
         <MessageBox variant="warning" className="my-4 flex items-center gap-2">
           <IconWarningTriangle className="size-6 text-yellow-900" />
@@ -625,7 +634,7 @@ export function ShowAndTellEntryForm({
       )}
 
       <div className="flex flex-col gap-5 lg:flex-row lg:gap-20">
-        <div className="flex flex-[3] flex-col gap-5">
+        <div className="flex flex-3 flex-col gap-5">
           <Fieldset legend="About you">
             <TextField
               label="Name"

--- a/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
+++ b/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
@@ -218,6 +218,7 @@ const AdminReviewShowAndTellPage: NextPage<
             <Headline>Review or edit post:</Headline>
             <Panel lightMode>
               <ShowAndTellEntryForm
+                className="-m-4 p-4"
                 action="review"
                 entry={entry}
                 onUpdate={() => getEntry.refetch()}

--- a/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
+++ b/apps/website/src/pages/admin/show-and-tell/review/[entryId]/index.tsx
@@ -25,6 +25,7 @@ import {
 import { ShowAndTellEntryForm } from "@/components/show-and-tell/ShowAndTellEntryForm";
 
 import IconCheckCircle from "@/icons/IconCheckCircle";
+import IconLoading from "@/icons/IconLoading";
 import IconMinus from "@/icons/IconMinus";
 import IconTrash from "@/icons/IconTrash";
 
@@ -131,6 +132,11 @@ const AdminReviewShowAndTellPage: NextPage<
     }
   }, [deleteMutation, entry]);
 
+  const isMutationPending =
+    approveMutation.isPending ||
+    removeApprovalMutation.isPending ||
+    deleteMutation.isPending;
+
   return (
     <>
       <Meta title="Review submission - Admin Show and Tell" />
@@ -169,7 +175,7 @@ const AdminReviewShowAndTellPage: NextPage<
                 Last updated:{" "}
                 <DateTime date={entry.updatedAt} format={{ time: "minutes" }} />
                 <br />
-                {entry.approvedAt && (
+                {entry.approvedAt ? (
                   <>
                     Approved at:{" "}
                     <DateTime
@@ -177,6 +183,8 @@ const AdminReviewShowAndTellPage: NextPage<
                       format={{ time: "minutes" }}
                     />
                   </>
+                ) : (
+                  "Not approved"
                 )}
               </div>
               <div className="flex flex-col gap-2">
@@ -185,9 +193,19 @@ const AdminReviewShowAndTellPage: NextPage<
                     size="small"
                     className={defaultButtonClasses}
                     onClick={handleRemoveApproval}
+                    disabled={isMutationPending}
                   >
-                    <IconMinus className="size-4" />
-                    Remove approval
+                    {removeApprovalMutation.isPending ? (
+                      <>
+                        <IconLoading className="size-4" />
+                        Removing approval …
+                      </>
+                    ) : (
+                      <>
+                        <IconMinus className="size-4" />
+                        Remove approval
+                      </>
+                    )}
                   </Button>
                 )}
                 {status === "pendingApproval" && (
@@ -195,18 +213,38 @@ const AdminReviewShowAndTellPage: NextPage<
                     size="small"
                     className={approveButtonClasses}
                     onClick={handleApprove}
+                    disabled={isMutationPending}
                   >
-                    <IconCheckCircle className="size-4" />
-                    Approve
+                    {approveMutation.isPending ? (
+                      <>
+                        <IconLoading className="size-4" />
+                        Approving …
+                      </>
+                    ) : (
+                      <>
+                        <IconCheckCircle className="size-4" />
+                        Approve
+                      </>
+                    )}
                   </Button>
                 )}
                 <Button
                   size="small"
                   className={dangerButtonClasses}
                   onClick={handleDelete}
+                  disabled={isMutationPending}
                 >
-                  <IconTrash className="size-4" />
-                  Delete
+                  {deleteMutation.isPending ? (
+                    <>
+                      <IconLoading className="size-4" />
+                      Deleting …
+                    </>
+                  ) : (
+                    <>
+                      <IconTrash className="size-4" />
+                      Delete
+                    </>
+                  )}
                 </Button>
               </div>
             </div>

--- a/apps/website/src/pages/show-and-tell/my-posts/[postId]/index.tsx
+++ b/apps/website/src/pages/show-and-tell/my-posts/[postId]/index.tsx
@@ -80,7 +80,11 @@ const EditShowAndTellPage: NextPage = () => {
               </MessageBox>
             )}
             {getMyPost.data && (
-              <ShowAndTellEntryForm action="update" entry={getMyPost.data} />
+              <ShowAndTellEntryForm
+                className="mt-5"
+                action="update"
+                entry={getMyPost.data}
+              />
             )}
           </>
         )}

--- a/apps/website/src/pages/show-and-tell/submit-post.tsx
+++ b/apps/website/src/pages/show-and-tell/submit-post.tsx
@@ -59,7 +59,7 @@ const ShowAndTellSubmitPage: NextPage = () => {
         <Heading level={2}>Your submission</Heading>
 
         {session?.status !== "authenticated" && !isAnonymous && (
-          <div>
+          <>
             <p>
               Please log in if you would like to edit or keep track of your
               posts:
@@ -79,11 +79,15 @@ const ShowAndTellSubmitPage: NextPage = () => {
                 </Button>
               </div>
             </div>
-          </div>
+          </>
         )}
 
         {showForm && (
-          <ShowAndTellEntryForm action="create" isAnonymous={isAnonymous} />
+          <ShowAndTellEntryForm
+            className="mt-5"
+            action="create"
+            isAnonymous={isAnonymous}
+          />
         )}
       </Section>
     </>


### PR DESCRIPTION
## Describe your changes

* In the admin review page, action buttons (Approve, Remove Approval, Delete) now show loading indicators and are disabled while a mutation is pending, preventing duplicate submissions and providing better feedback. 
* The admin review panel now displays "Not approved" if the entry has not been approved yet, improving clarity. 
* The edit form show a yellow ring outline when unsaved changes exist.

## Notes for testing your change

...
