### PR TITLE
Normalize file name before upload and fix saves after file uploads in Show & Tell

### DIFF
--- a/apps/website/src/components/admin/notifications/SendNotificationForm.tsx
+++ b/apps/website/src/components/admin/notifications/SendNotificationForm.tsx
@@ -193,6 +193,7 @@ export function SendNotificationForm() {
                         id: props.fileReference.id,
                       })
                     }
+                    disabled={props.disabled}
                   >
                     <IconTrash className="size-5" />
                     Remove

--- a/apps/website/src/components/admin/rounds-checks/RoundsCheckForm.tsx
+++ b/apps/website/src/components/admin/rounds-checks/RoundsCheckForm.tsx
@@ -228,6 +228,7 @@ export function RoundsCheckForm({ action, check }: RoundsCheckFormProps) {
                         id: props.fileReference.id,
                       })
                     }
+                    disabled={props.disabled}
                   >
                     <IconTrash className="size-5" />
                     Remove

--- a/apps/website/src/components/shared/form/ImageUploadAttachment.tsx
+++ b/apps/website/src/components/shared/form/ImageUploadAttachment.tsx
@@ -68,6 +68,7 @@ export function ImageUploadAttachment({
   fileReference: FileReference;
   children?: ReactNode | ReactNode[];
   onClick?: () => void;
+  disabled?: boolean;
 }) {
   return (
     <div className="flex flex-row gap-5 rounded-lg bg-white p-4 shadow-lg">

--- a/apps/website/src/components/shared/form/TextAreaField.tsx
+++ b/apps/website/src/components/shared/form/TextAreaField.tsx
@@ -13,6 +13,7 @@ export type TextAreaFieldProps = Omit<
   inputClassName?: string;
   labelClassName?: string;
   ref?: Ref<HTMLTextAreaElement>;
+  disabled?: boolean;
 };
 
 export const TextAreaField = (props: TextAreaFieldProps) => {

--- a/apps/website/src/components/shared/form/TextAreaField.tsx
+++ b/apps/website/src/components/shared/form/TextAreaField.tsx
@@ -13,7 +13,6 @@ export type TextAreaFieldProps = Omit<
   inputClassName?: string;
   labelClassName?: string;
   ref?: Ref<HTMLTextAreaElement>;
-  disabled?: boolean;
 };
 
 export const TextAreaField = (props: TextAreaFieldProps) => {

--- a/apps/website/src/components/shared/form/UploadAttachmentsField.tsx
+++ b/apps/website/src/components/shared/form/UploadAttachmentsField.tsx
@@ -78,6 +78,7 @@ type FailedUploadFileReference = {
 export type FileUploadRenderProps = {
   key: Key;
   fileReference: FileReference;
+  disabled?: boolean;
 };
 
 type FileUploadingPropsType = {
@@ -89,6 +90,7 @@ type FileUploadingPropsType = {
   label?: string;
   allowedFileTypes?: readonly string[];
   multiple?: boolean;
+  disabled?: boolean;
   maxNumber?: number;
   maxFileSize?: number;
   renderAttachment?: (props: FileUploadRenderProps) => ReactNode;
@@ -203,6 +205,7 @@ export const UploadAttachmentsField = ({
   upload,
   label = "Attachments",
   multiple = true,
+  disabled = false,
   maxNumber,
   maxFileSize,
   allowedFileTypes,
@@ -359,12 +362,17 @@ export const UploadAttachmentsField = ({
         onChange={onInputChange}
         className="hidden"
         id={id}
+        disabled={disabled}
       />
       <div>
         {RenderAttachment && files.length > 0 && (
           <div className={attachmentsClassName}>
             {files.map((file) => (
-              <RenderAttachment key={file.id} fileReference={file} />
+              <RenderAttachment
+                key={file.id}
+                fileReference={file}
+                disabled={disabled}
+              />
             ))}
           </div>
         )}
@@ -373,6 +381,7 @@ export const UploadAttachmentsField = ({
           className={isDragging ? "bg-red-300" : defaultButtonClasses}
           onClick={onFileUpload}
           {...dragProps}
+          disabled={disabled}
         >
           <IconUploadFiles className="size-5" />
           Click or Drop here

--- a/apps/website/src/components/shared/form/UploadAttachmentsField.tsx
+++ b/apps/website/src/components/shared/form/UploadAttachmentsField.tsx
@@ -181,6 +181,22 @@ async function handleImageResize(
   };
 }
 
+function normalizeFileName(fileName: string, maxLength = 30) {
+  const lastDotIndex = fileName.lastIndexOf(".");
+  const hasExtension = lastDotIndex !== -1;
+  const extension = hasExtension ? fileName.substring(lastDotIndex) : "";
+  const nameWithoutExtension = hasExtension
+    ? fileName.substring(0, lastDotIndex)
+    : fileName;
+  // Normalize to NFKD, remove diacritics, then filter safe chars
+  const normalized = nameWithoutExtension
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "");
+  const safeName =
+    normalized.replace(/[^a-zA-Z0-9-_]/g, "").substring(0, maxLength) || "file";
+  return `${safeName}${extension}`;
+}
+
 export const UploadAttachmentsField = ({
   files,
   dispatch,
@@ -233,9 +249,14 @@ export const UploadAttachmentsField = ({
       const file = filesToAdd[i];
       if (!file) continue;
 
+      // Rename file to only include safe characters (up to 30) and preserve the file extension
+      const renamedFile = new File([file], normalizeFileName(file.name), {
+        type: file.type,
+      });
+
       // Run through the image converter to convert the file to a jpeg if it's a heic, avif or heif file
       // returns the original file if conversion not needed
-      const fileToUpload = await convertImage(file);
+      const fileToUpload = await convertImage(renamedFile);
 
       if (!fileToUpload) continue;
 

--- a/apps/website/src/components/shared/form/UploadAttachmentsField.tsx
+++ b/apps/website/src/components/shared/form/UploadAttachmentsField.tsx
@@ -15,6 +15,7 @@ import {
   getFileEndingForImageMimeType,
   getImageMimeType,
   isImageMimeType,
+  normalizeFileName,
 } from "@/utils/files";
 import { imageConverter } from "@/utils/image-converter";
 import {
@@ -181,22 +182,6 @@ async function handleImageResize(
     extractColor: resized.extractColor,
     fileToUpload: new File([resized.blob], fileName, { type }),
   };
-}
-
-function normalizeFileName(fileName: string, maxLength = 30) {
-  const lastDotIndex = fileName.lastIndexOf(".");
-  const hasExtension = lastDotIndex !== -1;
-  const extension = hasExtension ? fileName.substring(lastDotIndex) : "";
-  const nameWithoutExtension = hasExtension
-    ? fileName.substring(0, lastDotIndex)
-    : fileName;
-  // Normalize to NFKD, remove diacritics, then filter safe chars
-  const normalized = nameWithoutExtension
-    .normalize("NFKD")
-    .replace(/[\u0300-\u036f]/g, "");
-  const safeName =
-    normalized.replace(/[^a-zA-Z0-9-_]/g, "").substring(0, maxLength) || "file";
-  return `${safeName}${extension}`;
 }
 
 export const UploadAttachmentsField = ({
@@ -380,7 +365,7 @@ export const UploadAttachmentsField = ({
           type="button"
           className={isDragging ? "bg-red-300" : defaultButtonClasses}
           onClick={onFileUpload}
-          {...dragProps}
+          {...(disabled ? {} : dragProps)}
           disabled={disabled}
         >
           <IconUploadFiles className="size-5" />

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -141,7 +141,7 @@ function ImageAttachment({
         label={<strong className="font-bold">Caption</strong>}
         maxLength={200}
         defaultValue={initialData?.caption}
-        disabled={disabled}
+        isDisabled={disabled}
       />
 
       <Disclosure as="div" className="my-4" defaultOpen={hasAlt}>
@@ -181,7 +181,7 @@ function ImageAttachment({
             maxLength={300}
             defaultValue={initialData?.alternativeText}
             onChange={(val) => setHasAlt(!!val)}
-            disabled={disabled}
+            isDisabled={disabled}
           />
         </DisclosurePanel>
       </Disclosure>

--- a/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntryForm.tsx
@@ -20,6 +20,7 @@ import type { ImageAttachment, ShowAndTellEntry } from "@alveusgg/database";
 
 import type {
   PublicShowAndTellEntryWithAttachments,
+  ShowAndTellEntryAttachments,
   ShowAndTellSubmitInput,
 } from "@/server/db/show-and-tell";
 
@@ -103,6 +104,7 @@ function ImageAttachment({
   fileReference,
   onClick,
   children,
+  disabled = false,
   ...props
 }: Omit<ComponentProps<typeof ImageUploadAttachment>, "onClick"> &
   Pick<ShowAndTellEntryFormProps, "entry"> & {
@@ -132,12 +134,14 @@ function ImageAttachment({
       {...props}
       onClick={handlePreviewClick}
       fileReference={fileReference}
+      disabled={disabled}
     >
       <TextAreaField
         name={`image[${fileReference.id}][caption]`}
         label={<strong className="font-bold">Caption</strong>}
         maxLength={200}
         defaultValue={initialData?.caption}
+        disabled={disabled}
       />
 
       <Disclosure as="div" className="my-4" defaultOpen={hasAlt}>
@@ -177,6 +181,7 @@ function ImageAttachment({
             maxLength={300}
             defaultValue={initialData?.alternativeText}
             onChange={(val) => setHasAlt(!!val)}
+            disabled={disabled}
           />
         </DisclosurePanel>
       </Disclosure>
@@ -220,6 +225,27 @@ function GiveAnHourInput({
     />
   );
 }
+
+const mapSavedAttachments = (
+  attachments: ShowAndTellEntryAttachments,
+): LocalAttachment[] =>
+  attachments.map((att) => {
+    if (att.attachmentType === "image" && att.imageAttachment) {
+      return {
+        type: "image",
+        file: makeSavedFileRef(att.imageAttachment),
+      };
+    }
+
+    if (att.attachmentType === "video" && att.linkAttachment) {
+      return {
+        type: "video",
+        url: att.linkAttachment.url,
+      };
+    }
+
+    throw new Error("Unknown attachment type");
+  });
 
 export function ShowAndTellEntryForm({
   className,
@@ -294,25 +320,8 @@ export function ShowAndTellEntryForm({
     [markAsChanged],
   );
 
-  const [attachments, setAttachments] = useState<LocalAttachment[]>(
-    () =>
-      entry?.attachments.map((att) => {
-        if (att.attachmentType === "image" && att.imageAttachment) {
-          return {
-            type: "image",
-            file: makeSavedFileRef(att.imageAttachment),
-          };
-        }
-
-        if (att.attachmentType === "video" && att.linkAttachment) {
-          return {
-            type: "video",
-            url: att.linkAttachment.url,
-          };
-        }
-
-        throw new Error("Unknown attachment type");
-      }) || [],
+  const [attachments, setAttachments] = useState<LocalAttachment[]>(() =>
+    entry ? mapSavedAttachments(entry.attachments) : [],
   );
   const swapAttachments = useCallback(
     (fromIdx: number, toIdx: number) => {
@@ -561,12 +570,16 @@ export function ShowAndTellEntryForm({
       update.mutate(
         { ...data, id: entry.id },
         {
-          onSuccess: () => {
+          onSuccess: (updatedEntry) => {
             resetChanges();
             setSuccessMessage("Entry updated successfully!");
             onUpdate?.();
+            if (updatedEntry) {
+              setAttachments(mapSavedAttachments(updatedEntry.attachments));
+            }
           },
           onError: (err) => {
+            setSuccessMessage(null);
             setError(err.message);
             onUpdate?.();
           },
@@ -581,12 +594,16 @@ export function ShowAndTellEntryForm({
           notePublic: (formData.get("notePublic") as string) ?? "",
         },
         {
-          onSuccess: () => {
+          onSuccess: (updatedEntry) => {
             resetChanges();
             setSuccessMessage("Entry updated successfully!");
             onUpdate?.();
+            if (updatedEntry) {
+              setAttachments(mapSavedAttachments(updatedEntry.attachments));
+            }
           },
           onError: (err) => {
+            setSuccessMessage(null);
             setError(err.message);
             onUpdate?.();
           },
@@ -610,6 +627,8 @@ export function ShowAndTellEntryForm({
   }
 
   const wasApproved = entry && getEntityStatus(entry) === "approved";
+
+  const isMutationPending = update.isPending || review.isPending;
 
   return (
     <form
@@ -675,7 +694,7 @@ export function ShowAndTellEntryForm({
             />
           </Fieldset>
         </div>
-        <div className="flex flex-[2] flex-col gap-5">
+        <div className="flex flex-2 flex-col gap-5">
           <Fieldset legend="Attachments">
             <VideoLinksField
               name="videoUrls"
@@ -692,6 +711,7 @@ export function ShowAndTellEntryForm({
               maxNumber={MAX_IMAGES}
               allowedFileTypes={imageMimeTypes}
               resizeImageOptions={resizeImageOptions}
+              disabled={isMutationPending}
             />
 
             <ul className="mt-4 flex flex-col gap-2 lg:mt-8">
@@ -701,7 +721,7 @@ export function ShowAndTellEntryForm({
                     <Button
                       size="small"
                       width="auto"
-                      disabled={idx === 0}
+                      disabled={isMutationPending || idx === 0}
                       onClick={() => swapAttachments(idx, idx - 1)}
                     >
                       <IconArrowUp className="size-5" />
@@ -710,7 +730,9 @@ export function ShowAndTellEntryForm({
                     <Button
                       size="small"
                       width="auto"
-                      disabled={idx === attachments.length - 1}
+                      disabled={
+                        isMutationPending || idx === attachments.length - 1
+                      }
                       onClick={() => swapAttachments(idx, idx + 1)}
                     >
                       <IconArrowDown className="size-5" />
@@ -722,6 +744,7 @@ export function ShowAndTellEntryForm({
                       onClick={() =>
                         setAttachments((prev) => prev.filter((a) => a !== att))
                       }
+                      disabled={isMutationPending}
                     >
                       <IconTrash className="size-5" />
                       Remove
@@ -736,6 +759,7 @@ export function ShowAndTellEntryForm({
                         entry={entry}
                         fileReference={att.file}
                         onClick={openModal}
+                        disabled={isMutationPending}
                       >
                         {buttons}
                       </ImageAttachment>

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -373,6 +373,10 @@ export async function getUserPosts(authorUserId: string, postId?: string) {
   });
 }
 
+export async function getUserPost(authorUserId: string, postId: string) {
+  return getUserPosts(authorUserId, postId).then((posts) => posts[0] ?? null);
+}
+
 export async function getPostsCount() {
   return prisma.showAndTellEntry.count({
     where: getPostFilter("approved"),

--- a/apps/website/src/server/trpc/router/admin/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/admin/show-and-tell.ts
@@ -35,10 +35,10 @@ export const adminShowAndTellRouter = router({
 
   review: permittedProcedure
     .input(showAndTellReviewInputSchema)
-    .mutation(
-      async ({ ctx, input }) =>
-        await updatePost(ctx.res, input, undefined, true),
-    ),
+    .mutation(async ({ ctx, input }) => {
+      await updatePost(ctx.res, input, undefined, true);
+      return getAdminPost(input.id);
+    }),
 
   approve: permittedProcedure
     .input(z.cuid())

--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -9,6 +9,7 @@ import {
   getMapFeatures,
   getPublicPostById,
   getPublicPosts,
+  getUserPost,
   getUserPosts,
   getVolunteeringMinutes,
   showAndTellCreateInputSchema,
@@ -84,8 +85,7 @@ export const showAndTellRouter = router({
     .input(showAndTellUpdateInputSchema)
     .mutation(async ({ ctx, input }) => {
       await updatePost(ctx.res, input, ctx.session.user.id);
-      const entry = await getUserPosts(ctx.session.user.id, input.id);
-      return entry?.[0];
+      return getUserPost(ctx.session.user.id, input.id);
     }),
 
   getMyEntries: protectedProcedure.query(({ ctx }) =>
@@ -94,18 +94,12 @@ export const showAndTellRouter = router({
 
   getMyEntry: protectedProcedure
     .input(z.cuid())
-    .query(({ ctx, input }) =>
-      getUserPosts(ctx.session.user.id, input).then(
-        (posts) => posts[0] ?? null,
-      ),
-    ),
+    .query(({ ctx, input }) => getUserPost(ctx.session.user.id, input)),
 
   delete: protectedProcedure
     .input(z.cuid())
     .mutation(async ({ ctx, input }) => {
-      const post = await getUserPosts(ctx.session.user.id, input).then(
-        (posts) => posts[0] ?? null,
-      );
+      const post = await getUserPost(ctx.session.user.id, input);
       if (!post) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Post not found" });
       }

--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -82,10 +82,11 @@ export const showAndTellRouter = router({
 
   update: protectedProcedure
     .input(showAndTellUpdateInputSchema)
-    .mutation(
-      async ({ ctx, input }) =>
-        await updatePost(ctx.res, input, ctx.session.user.id),
-    ),
+    .mutation(async ({ ctx, input }) => {
+      await updatePost(ctx.res, input, ctx.session.user.id);
+      const entry = await getUserPosts(ctx.session.user.id, input.id);
+      return entry?.[0];
+    }),
 
   getMyEntries: protectedProcedure.query(({ ctx }) =>
     getUserPosts(ctx.session.user.id),

--- a/apps/website/src/utils/files.ts
+++ b/apps/website/src/utils/files.ts
@@ -28,3 +28,25 @@ export const fileToBase64 = (file: File): Promise<string> => {
     reader.readAsDataURL(file);
   });
 };
+function normalizeFileNamePart(str: string) {
+  return str
+    .normalize("NFKD") // Normalize to NFKD
+    .replace(/[\u0300-\u036f]/g, "") // remove diacritics
+    .replace(/[^a-zA-Z0-9-_]/g, "");
+}
+
+export function normalizeFileName(fileName: string, maxLength = 30) {
+  const lastDotIndex = fileName.lastIndexOf(".");
+  const hasExtension = lastDotIndex !== -1;
+  const extension = hasExtension && fileName.substring(lastDotIndex);
+  const nameWithoutExtension = hasExtension
+    ? fileName.substring(0, lastDotIndex)
+    : fileName;
+  const safeName = normalizeFileNamePart(nameWithoutExtension).substring(
+    0,
+    maxLength,
+  );
+  const safeExtension =
+    extension && normalizeFileNamePart(extension).substring(0, 4);
+  return `${safeName}${safeExtension || ""}`;
+}

--- a/apps/website/src/utils/files.ts
+++ b/apps/website/src/utils/files.ts
@@ -28,11 +28,13 @@ export const fileToBase64 = (file: File): Promise<string> => {
     reader.readAsDataURL(file);
   });
 };
+
 function normalizeFileNamePart(str: string) {
   return str
     .normalize("NFKD") // Normalize to NFKD
     .replace(/[\u0300-\u036f]/g, "") // remove diacritics
-    .replace(/[^a-zA-Z0-9-_]/g, "");
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]/g, "");
 }
 
 export function normalizeFileName(fileName: string, maxLength = 30) {
@@ -48,5 +50,5 @@ export function normalizeFileName(fileName: string, maxLength = 30) {
   );
   const safeExtension =
     extension && normalizeFileNamePart(extension).substring(0, 4);
-  return `${safeName}${safeExtension || ""}`;
+  return `${safeName || "file"}${safeExtension ? `.${safeExtension}` : ""}`;
 }


### PR DESCRIPTION
## Describe your changes

This pull request introduces several improvements and bug fixes relating to file upload handling, attachment management, and form UX in the Show & Tell entry workflow. The main enhancements include safer file name normalization for uploads, improved state management for attachments after mutations, and better UX by disabling form controls during pending mutations. 

**File upload and attachment handling:**

* Added a `normalizeFileName` function to ensure uploaded files have safe, normalized names with only allowed characters and a maximum length, preserving extensions. This helps prevent issues with problematic file names. 
* Extended the `UploadAttachmentsField` and related components to accept a `disabled` prop, ensuring that file upload UI elements and actions can be disabled when necessary (e.g., during form submission).

**Show & Tell entry form improvements:**

* Refactored attachment state initialization and update logic by extracting a `mapSavedAttachments` helper, ensuring attachment state is always in sync with the latest entry data after mutations.
* Disabled all attachment-related controls (upload, reordering, and removal) while mutations (update or review) are pending, preventing user actions that could cause inconsistent state or errors. 

**API and backend changes:**

* Updated the Show & Tell update and review TRPC mutations to return the updated entry after performing the mutation, enabling the frontend to refresh its local state accurately.

These changes collectively improve reliability, user experience, and maintainability in the Show & Tell entry workflow.

Resolves: #1928

## Notes for testing your change

...
