### PR TITLE
Decoupled persisting donations & pixels

### DIFF
--- a/apps/donations/worker/src/index.ts
+++ b/apps/donations/worker/src/index.ts
@@ -8,14 +8,12 @@ import superjson, { parse } from "superjson";
 import { setSentryTagsMiddleware } from "./utils/middleware";
 import { getSentryConfig } from "./utils/sentry";
 import { forwardWithoutRoutePrefix } from "./utils/url";
-
 export { DonationsManagerDurableObject } from "./managers/donations";
 export { PixelsManagerDurableObject } from "./managers/pixels";
 
 const app = new Hono<{ Bindings: Env }>();
 app.use(logger());
-
-app.all("*", setSentryTagsMiddleware);
+app.use(setSentryTagsMiddleware());
 
 app.all("/donations/*", async (c) => {
   const manager = c.env.DONATIONS_MANAGER.getByName("alveus");
@@ -58,11 +56,13 @@ export default Sentry.withSentry<Env, string>(getSentryConfig, {
     if (batch.queue === "alveus-donations") {
       await api.donations.createDonations.mutate({ donations });
       await env.PIXELS_QUEUE.sendBatch(batch.messages);
+      return;
     }
 
     if (batch.queue === "alveus-pixels") {
       const manager = env.PIXELS_MANAGER.getByName(`alveus-${env.MURAL_ID}`);
       await manager.process(donations);
+      return;
     }
 
     throw new Error(`Unknown queue: ${batch.queue}`);

--- a/apps/donations/worker/src/index.ts
+++ b/apps/donations/worker/src/index.ts
@@ -49,9 +49,17 @@ export default {
     const donations: Donation[] = batch.messages.map((message) =>
       parse(message.body),
     );
-    await api.donations.createDonations.mutate({ donations });
 
-    const manager = env.PIXELS_MANAGER.getByName(`alveus-${env.MURAL_ID}`);
-    await manager.process(donations);
+    if (batch.queue === "alveus-donations") {
+      await api.donations.createDonations.mutate({ donations });
+      await env.PIXELS_QUEUE.sendBatch(batch.messages);
+    }
+
+    if (batch.queue === "alveus-pixels") {
+      const manager = env.PIXELS_MANAGER.getByName(`alveus-${env.MURAL_ID}`);
+      await manager.process(donations);
+    }
+
+    throw new Error(`Unknown queue: ${batch.queue}`);
   },
 } satisfies ExportedHandler<Env, string>;

--- a/apps/donations/worker/src/index.ts
+++ b/apps/donations/worker/src/index.ts
@@ -53,13 +53,13 @@ export default Sentry.withSentry<Env, string>(getSentryConfig, {
       parse(message.body),
     );
 
-    if (batch.queue === "alveus-donations") {
+    if (batch.queue.endsWith("donations")) {
       await api.donations.createDonations.mutate({ donations });
       await env.PIXELS_QUEUE.sendBatch(batch.messages);
       return;
     }
 
-    if (batch.queue === "alveus-pixels") {
+    if (batch.queue.endsWith("pixels")) {
       const manager = env.PIXELS_MANAGER.getByName(`alveus-${env.MURAL_ID}`);
       await manager.process(donations);
       return;

--- a/apps/donations/worker/src/managers/donations.ts
+++ b/apps/donations/worker/src/managers/donations.ts
@@ -1,9 +1,9 @@
 import { Providers } from "@alveusgg/donations-core";
 import { DurableObject } from "cloudflare:workers";
 
+import * as Sentry from "@sentry/cloudflare";
 import { Hono } from "hono";
 import { logger } from "hono/logger";
-import * as Sentry from "@sentry/cloudflare";
 import type { DonationProvider } from "../providers";
 import { PaypalDonationProvider } from "../providers/paypal/paypal";
 import {
@@ -12,8 +12,8 @@ import {
   DurableObjectDonationStorage,
 } from "../providers/storage";
 import { TwitchDonationProvider } from "../providers/twitch/twitch";
-import { getSentryConfig } from "../utils/sentry";
 import { setSentryTagsMiddleware } from "../utils/middleware";
+import { getSentryConfig } from "../utils/sentry";
 
 class DonationsManagerDurableObjectBase extends DurableObject<Env> {
   private router: Hono;
@@ -25,7 +25,7 @@ class DonationsManagerDurableObjectBase extends DurableObject<Env> {
 
     this.router = new Hono()
       .use(logger())
-      .use(setSentryTagsMiddleware)
+      .use(setSentryTagsMiddleware())
       .use(async (c, next) => {
         if (!this.ready) {
           this.ready = this.init();

--- a/apps/donations/worker/src/managers/pixels.ts
+++ b/apps/donations/worker/src/managers/pixels.ts
@@ -2,10 +2,10 @@ import type { Donation, DonationAlert, Pixel } from "@alveusgg/donations-core";
 import { DurableObject } from "cloudflare:workers";
 
 import type { AppRouter } from "@alveusgg/alveusgg-website";
+import * as Sentry from "@sentry/cloudflare";
 import { createTRPCProxyClient, httpLink } from "@trpc/client";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import * as Sentry from "@sentry/cloudflare";
 import { stringify, SuperJSON } from "superjson";
 import { z } from "zod";
 import { SyncProvider } from "../live/SyncProvider";
@@ -54,7 +54,7 @@ class PixelsManagerDurableObjectBase extends DurableObject<Env> {
 
     this.router = new Hono()
       .use(cors())
-      .use(setSentryTagsMiddleware)
+      .use(setSentryTagsMiddleware())
       .use(async (_, next) => {
         await this.ctx.blockConcurrencyWhile(async () => {
           await this.ready();

--- a/apps/donations/worker/src/utils/middleware.ts
+++ b/apps/donations/worker/src/utils/middleware.ts
@@ -1,28 +1,25 @@
-import type { Context } from "hono";
 import * as Sentry from "@sentry/cloudflare";
+import { createMiddleware } from "hono/factory";
 
-export const createSharedKeyMiddleware = (sharedKey: string) => {
-  return async (ctx: Context, next: () => Promise<void>) => {
+export const createSharedKeyMiddleware = (sharedKey: string) =>
+  createMiddleware(async (ctx, next) => {
     const header = ctx.req.header("authorization");
     const [type, key] = header?.split(" ") ?? [];
     if (type !== "ApiKey" || key !== sharedKey) {
       return ctx.json({ error: "Unauthorized" }, 401);
     }
-    return next();
-  };
-};
-
-export const setSentryTagsMiddleware = (
-  ctx: Context,
-  next: () => Promise<void>,
-) => {
-  Sentry.setTags({
-    requestId: crypto.randomUUID(),
-    userAgent: ctx.req.header("user-agent"),
-    ray: ctx.req.header("cf-ray"),
-    country: ctx.req.raw.cf?.country as string | undefined,
-    colo: ctx.req.raw.cf?.colo as string | undefined,
+    await next();
   });
 
-  return next();
-};
+export const setSentryTagsMiddleware = () =>
+  createMiddleware(async (ctx, next) => {
+    Sentry.setTags({
+      requestId: crypto.randomUUID(),
+      userAgent: ctx.req.header("user-agent"),
+      ray: ctx.req.header("cf-ray"),
+      country: ctx.req.raw.cf?.country as string | undefined,
+      colo: ctx.req.raw.cf?.colo as string | undefined,
+    });
+
+    await next();
+  });

--- a/apps/donations/worker/src/utils/sentry.ts
+++ b/apps/donations/worker/src/utils/sentry.ts
@@ -1,6 +1,10 @@
 import type { CloudflareOptions } from "@sentry/cloudflare";
 
 export function getSentryConfig(env: Env): CloudflareOptions {
+  if (!env.SENTRY_DSN) {
+    return { enabled: false };
+  }
+
   return {
     dsn: env.SENTRY_DSN,
     environment: env.SANDBOX ? "preview" : "production",

--- a/apps/donations/worker/src/utils/url.ts
+++ b/apps/donations/worker/src/utils/url.ts
@@ -2,11 +2,9 @@ import type { Context } from "hono";
 import { routePath } from "hono/route";
 
 export function forwardWithoutRoutePrefix(context: Context) {
-  const wildcard = routePath(context, 0);
-  const rootRoute = routePath(context, 1);
-
-  const prefix = rootRoute.replace(wildcard, "");
-  const suffix = context.req.path.replace(prefix, "");
+  const route = routePath(context);
+  const prefix = route.replace(/\/?\*+$/, "");
+  const suffix = context.req.path.slice(prefix.length) || "/";
 
   const url = new URL(context.req.raw.url);
   url.pathname = suffix;

--- a/apps/donations/worker/wrangler.jsonc
+++ b/apps/donations/worker/wrangler.jsonc
@@ -198,11 +198,11 @@
             "binding": "DEAD_LETTER_QUEUE",
           },
           {
-            "queue": "alveus-pixels",
+            "queue": "alveus-preview-pixels",
             "binding": "PIXELS_QUEUE",
           },
           {
-            "queue": "alveus-pixels-dead-letter",
+            "queue": "alveus-preview-pixels-dead-letter",
             "binding": "PIXELS_DEAD_LETTER_QUEUE",
           },
         ],
@@ -214,8 +214,8 @@
             "max_batch_timeout": 5,
           },
           {
-            "queue": "alveus-pixels",
-            "dead_letter_queue": "alveus-pixels-dead-letter",
+            "queue": "alveus-preview-pixels",
+            "dead_letter_queue": "alveus-preview-pixels-dead-letter",
             "max_batch_size": 50,
             "max_batch_timeout": 5,
           },

--- a/apps/donations/worker/wrangler.jsonc
+++ b/apps/donations/worker/wrangler.jsonc
@@ -39,11 +39,25 @@
         "queue": "alveus-donations-dead-letter",
         "binding": "DEAD_LETTER_QUEUE",
       },
+      {
+        "queue": "alveus-pixels",
+        "binding": "PIXELS_QUEUE",
+      },
+      {
+        "queue": "alveus-pixels-dead-letter",
+        "binding": "PIXELS_DEAD_LETTER_QUEUE",
+      },
     ],
     "consumers": [
       {
         "queue": "alveus-donations",
         "dead_letter_queue": "alveus-donations-dead-letter",
+        "max_batch_size": 50,
+        "max_batch_timeout": 1,
+      },
+      {
+        "queue": "alveus-pixels",
+        "dead_letter_queue": "alveus-pixels-dead-letter",
         "max_batch_size": 50,
         "max_batch_timeout": 1,
       },
@@ -110,11 +124,26 @@
             "queue": "alveus-donations-dead-letter",
             "binding": "DEAD_LETTER_QUEUE",
           },
+          {
+            "queue": "alveus-pixels",
+            "binding": "PIXELS_QUEUE",
+          },
+          {
+            "queue": "alveus-pixels-dead-letter",
+            "binding": "PIXELS_DEAD_LETTER_QUEUE",
+          },
         ],
         "consumers": [
           {
             "queue": "alveus-donations",
             "dead_letter_queue": "alveus-donations-dead-letter",
+            "max_batch_size": 50,
+            "max_batch_timeout": 1,
+            "max_concurrency": 1,
+          },
+          {
+            "queue": "alveus-pixels",
+            "dead_letter_queue": "alveus-pixels-dead-letter",
             "max_batch_size": 50,
             "max_batch_timeout": 1,
             "max_concurrency": 1,
@@ -166,11 +195,25 @@
             "queue": "alveus-preview-donations-dead-letter",
             "binding": "DEAD_LETTER_QUEUE",
           },
+          {
+            "queue": "alveus-pixels",
+            "binding": "PIXELS_QUEUE",
+          },
+          {
+            "queue": "alveus-pixels-dead-letter",
+            "binding": "PIXELS_DEAD_LETTER_QUEUE",
+          },
         ],
         "consumers": [
           {
             "queue": "alveus-preview-donations",
             "dead_letter_queue": "alveus-preview-donations-dead-letter",
+            "max_batch_size": 50,
+            "max_batch_timeout": 5,
+          },
+          {
+            "queue": "alveus-pixels",
+            "dead_letter_queue": "alveus-pixels-dead-letter",
             "max_batch_size": 50,
             "max_batch_timeout": 5,
           },

--- a/apps/donations/worker/wrangler.jsonc
+++ b/apps/donations/worker/wrangler.jsonc
@@ -77,6 +77,8 @@
     "SHARED_KEY": "",
     "OPTIONAL_VERCEL_PROTECTION_BYPASS": "",
     "TWITCH_SUBSCRIPTION_SECRET": "",
+    "SENTRY_DSN": "",
+    "SENTRY_RELEASE": "",
   },
 
   "env": {


### PR DESCRIPTION
## Describe your changes

In addition to some sentry follow ups - this is added an extra hop between donations & pixels by adding an additional queue. This is the smallest possible addition to be able to decouple donations & pixels so that campaigns can be ran without earmarking the money for ARRI.

In practice this means pausing the pixel queue and clearing the messages before resuming it. This is 3 clicks on the Cloudflare portal.

<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->

...

## Notes for testing your change

...
