### PR TITLE
Fix form default submit button label

### DIFF
--- a/apps/website/src/components/admin/forms/FormForm.tsx
+++ b/apps/website/src/components/admin/forms/FormForm.tsx
@@ -13,8 +13,8 @@ import {
   utcToInputValueDatetimeLocal,
 } from "@/utils/datetime-local";
 import {
-  PLACEHOLDER_ASK_MARKETING_EMAILS_LABEL,
-  PLACEHOLDER_SUBMIT_BUTTON_TEXT,
+  DEFAULT_ASK_MARKETING_EMAILS_LABEL,
+  DEFAULT_SUBMIT_BUTTON_TEXT,
   calcFormConfig,
 } from "@/utils/forms";
 import { SLUG_PATTERN, convertToSlug } from "@/utils/slugs";
@@ -172,7 +172,7 @@ export function FormForm({ action, form }: FormFormProps) {
         <TextField
           label="Checkbox label asking user to allow marketing emails"
           name="askMarketingEmailsLabel"
-          placeholder={PLACEHOLDER_ASK_MARKETING_EMAILS_LABEL}
+          placeholder={DEFAULT_ASK_MARKETING_EMAILS_LABEL}
           defaultValue={defaultConfig.askMarketingEmailsLabel}
           isDisabled={!askMarketingEmails}
         />
@@ -233,7 +233,7 @@ export function FormForm({ action, form }: FormFormProps) {
         <TextField
           label="Submit button text"
           name="submitButtonText"
-          placeholder={PLACEHOLDER_SUBMIT_BUTTON_TEXT}
+          placeholder={DEFAULT_SUBMIT_BUTTON_TEXT}
           className="max-w-[200px]"
           defaultValue={defaultConfig.submitButtonText}
         />

--- a/apps/website/src/components/forms/ConsentFieldset.tsx
+++ b/apps/website/src/components/forms/ConsentFieldset.tsx
@@ -1,4 +1,4 @@
-import { PLACEHOLDER_ASK_MARKETING_EMAILS_LABEL } from "@/utils/forms";
+import { DEFAULT_ASK_MARKETING_EMAILS_LABEL } from "@/utils/forms";
 
 import Link from "@/components/content/Link";
 import { CheckboxField } from "@/components/shared/form/CheckboxField";
@@ -26,7 +26,7 @@ export function ConsentFieldset({
 
       {askMarketingEmails && (
         <CheckboxField name="allowMarketingEmails" value="yes">
-          {askMarketingEmailsLabel || PLACEHOLDER_ASK_MARKETING_EMAILS_LABEL}
+          {askMarketingEmailsLabel || DEFAULT_ASK_MARKETING_EMAILS_LABEL}
         </CheckboxField>
       )}
     </Fieldset>

--- a/apps/website/src/components/forms/EntryForm.tsx
+++ b/apps/website/src/components/forms/EntryForm.tsx
@@ -4,7 +4,7 @@ import { type FormEvent, useCallback } from "react";
 import type { Form } from "@alveusgg/database";
 
 import { getCountryName } from "@/utils/countries";
-import { calcFormConfig } from "@/utils/forms";
+import { DEFAULT_SUBMIT_BUTTON_TEXT, calcFormConfig } from "@/utils/forms";
 import { trpc } from "@/utils/trpc";
 
 import Heading from "@/components/content/Heading";
@@ -230,7 +230,7 @@ export const EntryForm = ({
 
             <div className="mt-7">
               <Button type="submit" disabled={enterForm.isPending}>
-                {config.submitButtonText || "Enter to Win"}
+                {config.submitButtonText || DEFAULT_SUBMIT_BUTTON_TEXT}
               </Button>
             </div>
           </Section>

--- a/apps/website/src/utils/forms.ts
+++ b/apps/website/src/utils/forms.ts
@@ -4,8 +4,8 @@ export type CalculatedFormConfig = z.infer<typeof formConfigSchema> & {
   hasRules: boolean;
 };
 
-export const PLACEHOLDER_SUBMIT_BUTTON_TEXT = "Submit";
-export const PLACEHOLDER_ASK_MARKETING_EMAILS_LABEL =
+export const DEFAULT_SUBMIT_BUTTON_TEXT = "Submit";
+export const DEFAULT_ASK_MARKETING_EMAILS_LABEL =
   "Additionally, I am happy for Alveus Sanctuary Inc. to use my email for direct marketing relating to the sanctuary, including from its partners, such as for news, fundraisers, and other promotions.";
 
 export const formConfigSchema = z.object({


### PR DESCRIPTION
## Describe your changes

Fixes the default submit button label actually being used if no value is set, instead of falling back to "Enter to Win". This also renames the constants for default values to `DEFAULT_` (instead of `PLACEHOLDER_` to make it obvious, it is being used as the default.

## Notes for testing your change

...
