### PR TITLE
Support Neon CRM Donations in Donation Manager and Pixels

### DIFF
--- a/apps/donations/core/src/index.ts
+++ b/apps/donations/core/src/index.ts
@@ -12,6 +12,7 @@ const OptionalDonatorSchema = z.object({
   firstName: z.string().optional(),
   lastName: z.string().optional(),
   username: z.string().optional(),
+  displayName: z.string().optional(),
 });
 
 const DonatorEmailPrimary = OptionalDonatorSchema.extend({
@@ -31,16 +32,26 @@ const DonatorUsernamePrimary = OptionalDonatorSchema.extend({
   primary: z.literal("username"),
   username: z.string(),
 });
+const DonatorDisplayNamePrimary = OptionalDonatorSchema.extend({
+  primary: z.literal("displayName"),
+  displayName: z.string(),
+});
 
 export const DonatorSchema = z.union([
   DonatorEmailPrimary,
   DonatorFirstNamePrimary,
   DonatorLastNamePrimary,
   DonatorUsernamePrimary,
+  DonatorDisplayNamePrimary,
 ]);
 export type Donator = z.infer<typeof DonatorSchema>;
 
-export const Providers = z.literal(["twitch", "paypal", "thegivingblock"]);
+export const Providers = z.literal([
+  "twitch",
+  "paypal",
+  "thegivingblock",
+  "neon",
+]);
 export type Providers = z.infer<typeof Providers>;
 
 export const CoreDonationSchema = z.object({
@@ -92,10 +103,24 @@ export const PaypalDonationSchema = CoreDonationSchema.extend({
 });
 export type PaypalDonation = z.infer<typeof PaypalDonationSchema>;
 
+const NeonDonationMetadataSchema = z.object({
+  neonCampaignId: z.string().optional(),
+  neonCampaignName: z.string().optional(),
+  neonFundId: z.string().optional(),
+  neonFundName: z.string().optional(),
+});
+
+export const NeonDonationSchema = CoreDonationSchema.extend({
+  provider: z.literal("neon"),
+  providerMetadata: NeonDonationMetadataSchema,
+});
+export type NeonDonation = z.infer<typeof NeonDonationSchema>;
+
 export const DonationSchema = z.discriminatedUnion("provider", [
   TwitchDonationSchema,
   PaypalDonationSchema,
   TheGivingBlockDonationSchema,
+  NeonDonationSchema,
 ]);
 
 export type Donation = z.infer<typeof DonationSchema>;

--- a/apps/donations/neon-crm-api/api.ts
+++ b/apps/donations/neon-crm-api/api.ts
@@ -1,0 +1,87 @@
+import type { ZodType } from "zod";
+import type { Options as AllOptions } from "./env.js";
+
+export type Options = Pick<AllOptions, "organizationId" | "apiKey" | "baseUrl">;
+
+type ApiMethod = "GET" | "POST" | "PUT" | "DELETE";
+
+const apiHeaders = ({
+  organizationId,
+  apiKey,
+}: Pick<Options, "organizationId" | "apiKey">) => ({
+  authorization: `Basic ${btoa(`${organizationId}:${apiKey}`)}`,
+  accept: "application/json",
+});
+
+export const url = (strings: TemplateStringsArray, ...values: Array<string>) =>
+  strings.reduce(
+    (acc, str, i) =>
+      acc + str + (i < values.length ? encodeURIComponent(values[i]) : ""),
+    "",
+  );
+
+const fetch = async (
+  options: Options,
+  path: string,
+  method: ApiMethod = "GET",
+  body?: unknown,
+) => {
+  const request: RequestInit & { headers: Record<string, string> } = {
+    method,
+    headers: apiHeaders(options),
+  };
+
+  if (body) {
+    request.headers["content-type"] = "application/json";
+    request.body = JSON.stringify(body);
+  }
+
+  return global.fetch(options.baseUrl + path, request);
+};
+
+export const fetchOk = async (
+  options: Options,
+  path: string,
+  method: ApiMethod = "GET",
+  body?: unknown,
+) => {
+  try {
+    const response = await fetch(options, path, method, body);
+    return response.ok;
+  } catch (error) {
+    console.error("Error fetching data from Neon CRM API", {
+      path,
+      error,
+    });
+    return false;
+  }
+};
+
+export const fetchWithSchema = async <ResponseSchema extends ZodType>(
+  options: Options,
+  path: string,
+  schema: ResponseSchema,
+  method?: ApiMethod,
+  body?: unknown,
+) => {
+  try {
+    const response = await fetch(options, path, method, body);
+    if (!response.ok) return false;
+    const data = await response.json();
+    const parsed = await schema.safeParseAsync(data);
+    if (parsed.error) {
+      console.error("Error parsing data from Neon CRM API", {
+        path,
+        error: parsed.error,
+      });
+      return false;
+    }
+    return parsed.data;
+  } catch (error) {
+    console.error("Error fetching data from Neon CRM API", {
+      path,
+      error,
+    });
+    return false;
+  }
+};

--- a/apps/donations/neon-crm-api/api.ts
+++ b/apps/donations/neon-crm-api/api.ts
@@ -1,9 +1,20 @@
-import type { ZodType } from "zod";
+import type { z, ZodError, ZodType } from "zod";
 import type { Options as AllOptions } from "./env.js";
 
 export type Options = Pick<AllOptions, "organizationId" | "apiKey" | "baseUrl">;
 
 type ApiMethod = "GET" | "POST" | "PUT" | "DELETE";
+
+type FetchSuccess<T = unknown> = { ok: true; data: T };
+type FetchNetworkError = { ok: false; errorType: "network"; error: string };
+type FetchRequestError = { ok: false; errorType: "request"; error: string };
+type FetchParseError = { ok: false; errorType: "parse"; error: ZodError };
+
+type FetchResult<T = unknown> =
+  | FetchSuccess<T>
+  | FetchNetworkError
+  | FetchRequestError
+  | FetchParseError;
 
 const apiHeaders = ({
   organizationId,
@@ -44,16 +55,26 @@ export const fetchOk = async (
   path: string,
   method: ApiMethod = "GET",
   body?: unknown,
-) => {
+): Promise<FetchResult> => {
   try {
     const response = await fetch(options, path, method, body);
-    return response.ok;
+    return response.ok
+      ? { ok: true, data: null }
+      : {
+          ok: false,
+          errorType: "request",
+          error: `Request failed with status ${response.status}`,
+        };
   } catch (error) {
     console.error("Error fetching data from Neon CRM API", {
       path,
       error,
     });
-    return false;
+    return {
+      ok: false,
+      errorType: "network",
+      error: "Error fetching data from Neon CRM API",
+    };
   }
 };
 
@@ -63,10 +84,17 @@ export const fetchWithSchema = async <ResponseSchema extends ZodType>(
   schema: ResponseSchema,
   method?: ApiMethod,
   body?: unknown,
-) => {
+): Promise<FetchResult<z.output<ResponseSchema>>> => {
   try {
     const response = await fetch(options, path, method, body);
-    if (!response.ok) return false;
+    if (!response.ok) {
+      return {
+        ok: false,
+        errorType: "request",
+        error: `Request failed with status ${response.status}`,
+      };
+    }
+
     const data = await response.json();
     const parsed = await schema.safeParseAsync(data);
     if (parsed.error) {
@@ -74,14 +102,25 @@ export const fetchWithSchema = async <ResponseSchema extends ZodType>(
         path,
         error: parsed.error,
       });
-      return false;
+      return {
+        ok: false,
+        errorType: "parse",
+        error: parsed.error,
+      };
     }
-    return parsed.data;
+    return {
+      ok: true,
+      data: parsed.data,
+    };
   } catch (error) {
     console.error("Error fetching data from Neon CRM API", {
       path,
       error,
     });
-    return false;
+    return {
+      ok: false,
+      errorType: "network",
+      error: "Error fetching data from Neon CRM API",
+    };
   }
 };

--- a/apps/donations/neon-crm-api/env.ts
+++ b/apps/donations/neon-crm-api/env.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+export const serverEnv = {
+  NEON_CRM_BASE_URL: z.httpUrl().refine((url) => url.endsWith("/"), {
+    error:
+      "NEON_CRM_BASE_URL must be a valid http(s) URL with a trailing slash",
+  }),
+  NEON_CRM_ORG_ID: z.string(),
+  NEON_CRM_API_KEY: z.string(),
+  NEON_CRM_WEBHOOK_USERNAME: z.string().optional(),
+  NEON_CRM_WEBHOOK_PASSWORD: z.string().optional(),
+} as const;
+
+export type Env = z.output<typeof _EnvSchema>;
+const _EnvSchema = z.object(serverEnv);
+
+export type Options = ReturnType<typeof envToOptions>;
+
+export const envToOptions = (env: Env) =>
+  ({
+    baseUrl: env.NEON_CRM_BASE_URL,
+    apiKey: env.NEON_CRM_API_KEY,
+    organizationId: env.NEON_CRM_ORG_ID,
+    basicAuthUsername: env.NEON_CRM_WEBHOOK_USERNAME,
+    basicAuthPassword: env.NEON_CRM_WEBHOOK_PASSWORD,
+  }) as const;
+
+export const buildBasicAuth = (
+  options: Pick<Options, "basicAuthUsername" | "basicAuthPassword">,
+) =>
+  ({
+    userName: options.basicAuthUsername ?? "",
+    password: options.basicAuthPassword ?? "",
+  }) as const;

--- a/apps/donations/neon-crm-api/eslint.config.js
+++ b/apps/donations/neon-crm-api/eslint.config.js
@@ -1,0 +1,68 @@
+// @ts-check
+import eslint from "@eslint/js";
+import prettiereslint from "eslint-config-prettier";
+import { flatConfigs as importXPluginConfigs } from "eslint-plugin-import-x";
+import globals from "globals";
+import tseslint, { configs as tseslintConfigs } from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    name: "eslint/recommended",
+    ...eslint.configs.recommended,
+  },
+  ...tseslintConfigs.recommended,
+  {
+    name: "typescript-eslint/tsconfig",
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+      globals: {
+        ...globals.node,
+      },
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: true,
+    },
+  },
+  importXPluginConfigs.recommended,
+  importXPluginConfigs.typescript,
+  {
+    name: "import-x/custom",
+    settings: {
+      "import-x/resolver": {
+        typescript: {
+          project: import.meta.dirname,
+        },
+        node: {
+          extensions: [".js", ".jsx", ".ts", ".tsx"],
+        },
+      },
+    },
+  },
+  {
+    name: "prettier/config",
+    ...prettiereslint,
+  },
+  {
+    name: "custom/rules",
+    rules: {
+      "no-empty": [
+        "error",
+        {
+          allowEmptyCatch: true,
+        },
+      ],
+      "@typescript-eslint/consistent-type-imports": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn", // or "error"
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+);

--- a/apps/donations/neon-crm-api/index.ts
+++ b/apps/donations/neon-crm-api/index.ts
@@ -1,0 +1,55 @@
+import {
+  type CreateWebhookInput,
+  type RecordId,
+  type UpdateCustomFieldInput,
+  AccountResponse,
+  CreateWebhookResponse,
+  CustomFieldResponse,
+  WebhookResponse,
+  WebhooksResponse,
+} from "./schema.js";
+import { type Options, url, fetchOk, fetchWithSchema } from "./api.js";
+
+export {
+  type RecordId,
+  AccountResponse,
+  CreateWebhookResponse,
+  CustomFieldResponse,
+  WebhookResponse,
+  WebhooksResponse,
+} from "./schema.js";
+
+export const updateCustomField = (
+  options: Options,
+  id: RecordId,
+  change: UpdateCustomFieldInput,
+) => fetchOk(options, url`customFields/${id}`, "PUT", change);
+
+export const getCustomField = (options: Options, id: RecordId) =>
+  fetchWithSchema(options, url`customFields/${id}`, CustomFieldResponse);
+
+export const getAccount = (options: Options, id: RecordId) =>
+  fetchWithSchema(options, url`accounts/${id}`, AccountResponse);
+
+export const getWebhook = (options: Options, id: RecordId) =>
+  fetchWithSchema(options, url`webhooks/${id}`, WebhookResponse);
+
+export const getWebhooks = (options: Options) =>
+  fetchWithSchema(options, "webhooks", WebhooksResponse);
+
+export const createWebhook = (
+  options: Options,
+  input: Required<
+    Pick<CreateWebhookInput, "httpBasic" | "url" | "name" | "trigger">
+  > &
+    Partial<Pick<CreateWebhookInput, "customParameters" | "triggerSelfImport">>,
+) =>
+  fetchWithSchema(options, "webhooks", CreateWebhookResponse, "POST", {
+    contentType: "application/json",
+    triggerSelfImport: input.triggerSelfImport ?? false,
+    trigger: input.trigger,
+    name: input.name,
+    url: input.url,
+    httpBasic: input.httpBasic,
+    customParameters: input.customParameters ?? [],
+  } satisfies CreateWebhookInput);

--- a/apps/donations/neon-crm-api/package.json
+++ b/apps/donations/neon-crm-api/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@alveusgg/neon-crm-api",
+  "private": true,
+  "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./env": "./env.ts",
+    "./schema": "./schema.ts",
+    "./webhooks": "./webhooks.ts"
+  },
+  "scripts": {
+    "types": "tsc --noEmit",
+    "lint": "eslint . --max-warnings 0"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.2",
+    "@types/node": "^24.12.0",
+    "eslint": "^9.39.2",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-plugin-import-x": "^4.16.2",
+    "globals": "^17.5.0",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.0"
+  }
+}

--- a/apps/donations/neon-crm-api/schema.ts
+++ b/apps/donations/neon-crm-api/schema.ts
@@ -1,0 +1,365 @@
+import { z } from "zod";
+
+const idMin = 0;
+const idMax = 20;
+
+const nameMin = 0;
+const nameMax = 255;
+
+const Status = z.enum(["ACTIVE", "INACTIVE"]);
+
+const YesNoBoolean = z.enum(["Yes", "No"]).transform((val) => val === "Yes");
+
+const ConsentStatus = z.enum(["GIVEN", "DECLINED", "NOT_ASKED"]);
+
+const DataType = z.enum([
+  "Whole_Number",
+  "Decimal",
+  "Currency",
+  "Date",
+  "Time",
+  "Boolean",
+  "Text",
+  "Email",
+  "Phone",
+  "Area_Code",
+  "Name",
+  "Integer",
+  "Float",
+  "Amount",
+]);
+
+const Component = z.enum([
+  "Account",
+  "Donation",
+  "Event",
+  "Attendee",
+  "Individual",
+  "Company",
+  "Activity",
+  "Membership",
+  "Product",
+  "Prospect",
+  "Grant",
+]);
+
+const DisplayType = z.enum([
+  "Checkbox",
+  "Dropdown",
+  "OneLineText",
+  "MultiLineText",
+  "Password",
+  "Radio",
+  "File",
+  "Account",
+]);
+
+const PhoneType = z.enum(["Home", "Work", "Mobile", "Other"]);
+
+const DateTimeSchema = z.iso
+  .datetime({ offset: true })
+  .transform((val) => new Date(val));
+
+const DateSchema = z.iso.date().transform((val) => new Date(val));
+
+export type RecordId = z.input<typeof RecordId>;
+
+export const RecordId = z
+  .string()
+  .min(idMin)
+  .max(idMax)
+  .refine(
+    (val) => {
+      const num = Number(val);
+      return Number.isInteger(num) && num >= 0;
+    },
+    {
+      message: "Must be a stringified, positive integer",
+    },
+  );
+
+export type RecordName = z.input<typeof RecordName>;
+
+export const RecordName = z.string().min(nameMin).max(nameMax);
+
+const NameValuePair = z.object({
+  name: RecordName.nullable(),
+  value: z.string().nullable(),
+});
+
+const IdNamePairBase = z.object({
+  id: RecordId.nullable(),
+  name: RecordName.nullable(),
+});
+const IdNamePair = IdNamePairBase.extend({ status: Status.nullable() });
+
+const CodeNamePairBase = z.object({
+  code: z.string(),
+  name: RecordName,
+});
+const CodeNamePair = CodeNamePairBase.extend({ status: Status.nullable() });
+
+const CustomFieldOptionInput = z.object({
+  id: RecordId.optional(),
+  name: RecordName.optional(),
+  visibleOnPublicForms: z.boolean().optional(),
+  visibleOnConstituentForms: z.boolean().optional(),
+});
+
+const CustomFieldOptionResponse = z.object({
+  id: RecordId,
+  name: RecordName,
+  visibleOnPublicForms: z.boolean(),
+  visibleOnConstituentForms: z.boolean(),
+});
+
+const AccountType = z.enum(["Any", "Individual", "Company"]);
+
+const AccountSettings = z.object({ accountType: AccountType.optional() });
+
+export type UpdateCustomFieldInput = z.input<typeof UpdateCustomFieldBody>;
+
+export const UpdateCustomFieldBody = z.object({
+  name: RecordName,
+  status: Status,
+  displayName: z.string(),
+  displayType: DisplayType,
+  component: Component,
+
+  groupId: RecordId.optional(),
+  dataType: DataType.optional(),
+  constituentReadOnly: z.boolean().optional(),
+  optionValues: z.array(CustomFieldOptionInput).optional(),
+  accountSettings: AccountSettings.optional(),
+});
+
+export const CustomFieldResponse = z.object({
+  id: RecordId,
+  name: RecordName,
+  status: Status,
+  displayName: z.string(),
+  groupId: RecordId.nullable(),
+  displayType: DisplayType,
+  dataType: DataType.nullable(),
+  constituentReadOnly: z.boolean(),
+  component: Component,
+  optionValues: z.array(CustomFieldOptionResponse).nullable(),
+  accountSettings: AccountSettings.nullable(),
+});
+
+const CustomFieldData = z.union([
+  IdNamePairBase.extend({ optionValues: z.array(IdNamePairBase) }),
+  IdNamePairBase.extend({ value: z.string() }),
+]);
+
+const Timestamps = z.object({
+  createdBy: z.string(),
+  createdDateTime: DateTimeSchema,
+  lastModifiedBy: z.string(),
+  lastModifiedDateTime: DateTimeSchema,
+});
+
+const webhookPayloadBase = {
+  eventTimestamp: DateTimeSchema,
+  organizationId: z.string(),
+  customParameters: z.record(z.string(), z.string()).optional(),
+};
+
+export type DonationWebhookPayload = z.output<typeof DonationWebhookPayload>;
+
+export const DonationWebhookPayload = z.object({
+  ...webhookPayloadBase,
+  eventTrigger: z.literal("createDonation"),
+  data: z.object({
+    id: RecordId,
+    accountId: RecordId,
+    amount: z.number().positive(),
+    campaign: IdNamePairBase,
+    fund: IdNamePairBase,
+    timestamps: Timestamps,
+    date: DateSchema,
+    anonymousType: YesNoBoolean,
+    donationCustomFields: z.array(CustomFieldData).optional(),
+    donorCoveredFeeFlag: z.boolean(),
+    payLater: z.boolean(),
+  }),
+});
+
+export const WebhookPayload = z.discriminatedUnion("eventTrigger", [
+  DonationWebhookPayload,
+]);
+
+const AddressBase = z.object({
+  addressId: RecordId,
+  type: IdNamePair,
+  addressLine1: z.string(),
+  addressLine2: z.string(),
+  addressLine3: z.string(),
+  addressLine4: z.string(),
+  city: z.string(),
+  stateProvince: CodeNamePair.nullable(),
+  country: IdNamePair.nullable(),
+  territory: z.string().nullable(),
+  county: z.string().nullable(),
+  zipCode: z.string().nullable(),
+  zipCodeSuffix: z.string().nullable(),
+  phone1: z.string().nullable(),
+  phone1Type: PhoneType.nullable(),
+  phone2: z.string().nullable(),
+  phone2Type: PhoneType.nullable(),
+  phone3: z.string().nullable(),
+  phone3Type: PhoneType.nullable(),
+  fax: z.string().nullable(),
+  faxType: PhoneType.nullable(),
+});
+
+const ShippingAddress = AddressBase.extend({
+  shippingCompanyName: z.string(),
+  shippingDeliverTo: z.string(),
+});
+
+const Address = AddressBase.extend({
+  startDate: DateSchema.nullable(),
+  endDate: DateSchema.nullable(),
+  isPrimaryAddress: z.boolean(),
+  validAddress: z.boolean(),
+});
+
+const DateOfBirth = z.object({
+  day: z.coerce.number().int().min(1).max(31).nullable(),
+  month: z.coerce.number().int().min(1).max(12).nullable(),
+  year: z.coerce
+    .number()
+    .int()
+    .min(1900)
+    .max(new Date().getFullYear())
+    .nullable(),
+});
+
+const Contact = z.object({
+  accountId: RecordId.nullable(),
+  contactId: RecordId.nullable(),
+  firstName: z.string().nullable(),
+  middleName: z.string().nullable(),
+  lastName: z.string().nullable(),
+  prefix: z.string().nullable(),
+  suffix: z.string().nullable(),
+  salutation: z.string().nullable(),
+  preferredName: z.string().nullable(),
+  dob: DateOfBirth.nullable(),
+  gender: CodeNamePair.nullable(),
+  email1: z.string().nullable(),
+  email2: z.string().nullable(),
+  email3: z.string().nullable(),
+  deceased: z.boolean(),
+  department: z.string().nullable(),
+  title: z.string().nullable(),
+  primaryContact: z.boolean().nullable(),
+  currentEmployer: z.boolean().nullable(),
+  startDate: DateTimeSchema.nullable(),
+  endDate: DateTimeSchema.nullable(),
+  addresses: z.array(Address),
+});
+
+const GenerosityIndicator = z.object({
+  indicator: z.number(),
+  affinity: z.number().int(),
+  recency: z.number().int(),
+  frequency: z.number().int(),
+  monetaryValue: z.number().int(),
+});
+
+const SharedAccountData = z.object({
+  accountId: RecordId,
+  noSolicitation: z.boolean(),
+  login: z
+    .object({
+      username: z.string(),
+    })
+    .nullable(),
+  url: z.string().nullable(),
+  timestamps: Timestamps,
+  consent: z
+    .object({
+      email: ConsentStatus.nullable(),
+      phone: ConsentStatus.nullable(),
+      mail: ConsentStatus.nullable(),
+      sms: ConsentStatus.nullable(),
+      dataSharing: ConsentStatus.nullable(),
+    })
+    .nullable(),
+  accountCustomFields: z.array(CustomFieldData),
+  source: IdNamePair.nullable(),
+  primaryContact: Contact,
+  sendSystemEmail: z.boolean(),
+  email1OptOut: z.boolean().nullable(),
+  origin: z
+    .object({
+      originDetail: z.string(),
+      originCategory: z.string(),
+    })
+    .nullable(),
+  accountCurrentMembershipStatus: z.string().nullable(),
+  generosityIndicator: GenerosityIndicator.nullable(),
+  sendTextOptIn: z.boolean(),
+  smsNumber: z.string(),
+  restrictFromWindfallSync: z.boolean(),
+});
+
+const IndividualAccount = SharedAccountData.extend({
+  company: IdNamePair.nullable(),
+  facebookPage: z.string().nullable(),
+  instagramPage: z.string().nullable(),
+  linkedinPage: z.string().nullable(),
+  twitterPage: z.string().nullable(),
+  individualTypes: z.array(IdNamePair),
+});
+
+const CompanyAccount = SharedAccountData.extend({
+  name: z.string(),
+  primaryContactAccountId: RecordId.nullable(),
+  companyTypes: z.array(IdNamePair),
+  shippingAddresses: z.array(ShippingAddress),
+});
+
+export type AccountResponse = z.output<typeof AccountResponse>;
+export const AccountResponse = z.object({
+  individualAccount: IndividualAccount.nullable(),
+  companyAccount: CompanyAccount.nullable(),
+});
+
+export type CreateWebhookInput = z.input<typeof CreateWebhookInputBody>;
+
+export const CreateWebhookInputBody = z.object({
+  name: RecordName,
+  url: z.httpUrl(),
+  trigger: z.enum(["CREATE_DONATION"]),
+  contentType: z.literal("application/json"),
+  triggerSelfImport: z.boolean(),
+  httpBasic: z.object({
+    userName: z.string(),
+    password: z.string(),
+  }),
+  customParameters: z.array(NameValuePair),
+});
+
+export const CreateWebhookResponse = z.object({
+  id: RecordId,
+});
+
+export type WebhookResponse = z.output<typeof WebhookResponse>;
+export const WebhookResponse = z.object({
+  id: RecordId,
+  name: RecordName,
+  url: z.httpUrl(),
+  trigger: z.enum(["CREATE_DONATION"]),
+  contentType: z.string(),
+  triggerSelfImport: z.boolean(),
+  httpBasic: z.object({
+    userName: z.string(),
+  }),
+  customParameters: z.array(NameValuePair).nullable(),
+});
+
+export type WebhooksResponse = z.output<typeof WebhooksResponse>;
+export const WebhooksResponse = z.array(WebhookResponse);

--- a/apps/donations/neon-crm-api/tsconfig.json
+++ b/apps/donations/neon-crm-api/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2021",
+    /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["es2021"],
+    /* Specify what module code is generated. */
+    "module": "es2022",
+    /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "bundler",
+    /* Enable importing .json files */
+    "resolveJsonModule": true,
+    /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    "allowJs": true,
+    /* Enable error reporting in type-checked JavaScript files. */
+    "checkJs": false,
+    /* Disable emitting files from a compilation. */
+    "noEmit": true,
+    /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "isolatedModules": true,
+    /* Allow 'import x from y' when a module doesn't have a default export. */
+    "allowSyntheticDefaultImports": true,
+    /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true,
+    /* Enable all strict type-checking options. */
+    "strict": true,
+    /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true,
+    "types": ["@types/node"]
+  }
+}

--- a/apps/donations/neon-crm-api/webhooks.ts
+++ b/apps/donations/neon-crm-api/webhooks.ts
@@ -57,8 +57,8 @@ export async function setupWebhook(
 ) {
   const existingWebhooks = await getWebhooks(options);
   const webhookSetUp =
-    existingWebhooks &&
-    existingWebhooks.some((webhook) =>
+    existingWebhooks.ok &&
+    existingWebhooks.data.some((webhook) =>
       isMatchingWebhookSubscription(webhook, trigger, url, options),
     );
 

--- a/apps/donations/neon-crm-api/webhooks.ts
+++ b/apps/donations/neon-crm-api/webhooks.ts
@@ -1,0 +1,78 @@
+import {
+  type WebhookResponse,
+  type WebhookPayload,
+  DonationWebhookPayload,
+} from "./schema.js";
+import { type Options, buildBasicAuth } from "./env.js";
+import { createWebhook, getWebhooks } from "./index.js";
+
+export type { DonationWebhookPayload } from "./schema.js";
+
+type WebhookOptions = Pick<Options, "organizationId">;
+
+type WebhookTypeSchemas = (typeof WebhookPayload.def.options)[number];
+
+export const parseWebhook = async <Schema extends WebhookTypeSchemas>(
+  options: WebhookOptions,
+  body: unknown,
+  schema: Schema,
+) => {
+  const payload = await schema.safeParseAsync(body);
+  if (!payload.success) {
+    console.error("Failed to parse Neon webhook payload", {
+      error: payload.error,
+    });
+    return false;
+  }
+
+  if (payload.data.organizationId !== options.organizationId) {
+    console.error(
+      `Ignoring webhook from ${payload.data.organizationId} because it is not the allowed organization id (${options.organizationId}).`,
+    );
+    return false;
+  }
+
+  return payload.data;
+};
+
+export const parseDonationWebhook = async (
+  options: WebhookOptions,
+  body: unknown,
+) => parseWebhook(options, body, DonationWebhookPayload);
+
+const isMatchingWebhookSubscription = (
+  webhook: WebhookResponse,
+  trigger: WebhookResponse["trigger"],
+  url: string,
+  options: Pick<Options, "basicAuthUsername">,
+) =>
+  webhook.url === url &&
+  webhook.trigger === trigger &&
+  webhook.httpBasic.userName === options.basicAuthUsername;
+
+export async function setupWebhook(
+  url: string,
+  trigger: WebhookResponse["trigger"],
+  options: Options,
+) {
+  const existingWebhooks = await getWebhooks(options);
+  const webhookSetUp =
+    existingWebhooks &&
+    existingWebhooks.some((webhook) =>
+      isMatchingWebhookSubscription(webhook, trigger, url, options),
+    );
+
+  if (webhookSetUp) {
+    return;
+  }
+
+  const created = await createWebhook(options, {
+    name: url,
+    url,
+    trigger,
+    httpBasic: buildBasicAuth(options),
+  });
+  if (!created) {
+    throw new Error("Failed to create Neon webhook");
+  }
+}

--- a/apps/donations/worker/.env.example
+++ b/apps/donations/worker/.env.example
@@ -11,6 +11,17 @@ TWITCH_CHARITY_NAME="Alveus Sanctuary"
 # PayPal integration
 PAYPAL_BUSINESS_EMAIL=donate@alveussanctuary.org
 
+# Neon CRM integration
+NEON_CRM_BASE_URL=https://api.neoncrm.com/v2/
+NEON_CRM_ORG_ID=alveussanctuary
+NEON_CRM_API_KEY=
+
+NEON_CRM_WEBHOOK_USERNAME=neon
+NEON_CRM_WEBHOOK_PASSWORD=
+
+NEON_DONATION_DISPLAY_NAME_CUSTOM_FIELD_ID=95
+NEON_PIXEL_CAMPAIGN_ID=2
+
 # This is both the way to identify pixels in the database/TRPC calls, and also a key for the PixelManager Durable Objects.
 MURAL_ID=two
 

--- a/apps/donations/worker/package.json
+++ b/apps/donations/worker/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@alveusgg/alveusgg-website": "workspace:*",
     "@alveusgg/donations-core": "workspace:*",
+    "@alveusgg/neon-crm-api": "workspace:*",
     "@sentry/cloudflare": "^10.50.0",
     "@trpc/client": "^11.9.0",
     "@trpc/server": "^11.9.0",

--- a/apps/donations/worker/src/managers/donations.ts
+++ b/apps/donations/worker/src/managers/donations.ts
@@ -16,12 +16,6 @@ import { TwitchDonationProvider } from "../providers/twitch/twitch";
 import { setSentryTagsMiddleware } from "../utils/middleware";
 import { getSentryConfig } from "../utils/sentry";
 
-declare module "hono" {
-  interface ContextVariableMap {
-    donationProvider: DonationProvider;
-  }
-}
-
 class DonationsManagerDurableObjectBase extends DurableObject<Env> {
   private router: Hono;
   private providers?: Partial<Record<Providers, DonationProvider>>;
@@ -40,11 +34,7 @@ class DonationsManagerDurableObjectBase extends DurableObject<Env> {
         await this.ready;
         return next();
       })
-      .use("/:providerId/live", async (c, next) => {
-        if (c.req.method !== "POST") {
-          return next();
-        }
-
+      .post("/:providerId/live", async (c) => {
         if (!this.providers) {
           throw new Error(
             "This should be impossible. Init is called in prior middleware.",
@@ -55,18 +45,13 @@ class DonationsManagerDurableObjectBase extends DurableObject<Env> {
         if (!providerId.success) {
           return new Response("Invalid provider ID", { status: 400 });
         }
-        const provider = this.providers[providerId.data];
 
+        const provider = this.providers[providerId.data];
         if (!provider) {
           return new Response("Provider not found", { status: 404 });
         }
 
-        c.set("donationProvider", provider);
-
-        return provider.middleware ? provider.middleware(c, next) : next();
-      })
-      .post("/:providerId/live", async (c) => {
-        return c.get("donationProvider").handle(c.req.raw);
+        return provider.handle(c.req.raw);
       });
   }
 

--- a/apps/donations/worker/src/managers/donations.ts
+++ b/apps/donations/worker/src/managers/donations.ts
@@ -6,6 +6,7 @@ import { Hono } from "hono";
 import { logger } from "hono/logger";
 import type { DonationProvider } from "../providers";
 import { PaypalDonationProvider } from "../providers/paypal/paypal";
+import { NeonDonationProvider } from "../providers/neon/neon";
 import {
   createIfNotExistsDonationsTable,
   createIfNotExistsProviderMetadataTable,
@@ -14,6 +15,12 @@ import {
 import { TwitchDonationProvider } from "../providers/twitch/twitch";
 import { setSentryTagsMiddleware } from "../utils/middleware";
 import { getSentryConfig } from "../utils/sentry";
+
+declare module "hono" {
+  interface ContextVariableMap {
+    doantionProvider: DonationProvider;
+  }
+}
 
 class DonationsManagerDurableObjectBase extends DurableObject<Env> {
   private router: Hono;
@@ -33,7 +40,11 @@ class DonationsManagerDurableObjectBase extends DurableObject<Env> {
         await this.ready;
         return next();
       })
-      .post("/:providerId/live", (c) => {
+      .use("/:providerId/live", async (c, next) => {
+        if (c.req.method !== "POST") {
+          return next();
+        }
+
         if (!this.providers) {
           throw new Error(
             "This should be impossible. Init is called in prior middleware.",
@@ -50,7 +61,12 @@ class DonationsManagerDurableObjectBase extends DurableObject<Env> {
           return new Response("Provider not found", { status: 404 });
         }
 
-        return provider.handle(c.req.raw);
+        c.set("doantionProvider", provider);
+
+        return provider.middleware ? provider.middleware(c, next) : next();
+      })
+      .post("/:providerId/live", async (c) => {
+        return c.get("doantionProvider").handle(c.req.raw);
       });
   }
 
@@ -63,14 +79,16 @@ class DonationsManagerDurableObjectBase extends DurableObject<Env> {
       this.env.DONATION_QUEUE,
     );
 
-    const [twitchProvider, paypalProvider] = await Promise.all([
+    const [twitchProvider, paypalProvider, neonProvider] = await Promise.all([
       TwitchDonationProvider.init(storage, this.env),
       PaypalDonationProvider.init(storage, this.env),
+      NeonDonationProvider.init(storage, this.env),
     ]);
 
     this.providers = {
       twitch: twitchProvider,
       paypal: paypalProvider,
+      neon: neonProvider,
     };
   }
 

--- a/apps/donations/worker/src/managers/donations.ts
+++ b/apps/donations/worker/src/managers/donations.ts
@@ -18,7 +18,7 @@ import { getSentryConfig } from "../utils/sentry";
 
 declare module "hono" {
   interface ContextVariableMap {
-    doantionProvider: DonationProvider;
+    donationProvider: DonationProvider;
   }
 }
 
@@ -61,12 +61,12 @@ class DonationsManagerDurableObjectBase extends DurableObject<Env> {
           return new Response("Provider not found", { status: 404 });
         }
 
-        c.set("doantionProvider", provider);
+        c.set("donationProvider", provider);
 
         return provider.middleware ? provider.middleware(c, next) : next();
       })
       .post("/:providerId/live", async (c) => {
-        return c.get("doantionProvider").handle(c.req.raw);
+        return c.get("donationProvider").handle(c.req.raw);
       });
   }
 

--- a/apps/donations/worker/src/managers/pixels.ts
+++ b/apps/donations/worker/src/managers/pixels.ts
@@ -159,6 +159,18 @@ class PixelsManagerDurableObjectBase extends DurableObject<Env> {
     }
   }
 
+  private filterDonation(donation: Donation) {
+    switch (donation.provider) {
+      case "neon":
+        return (
+          donation.providerMetadata.neonCampaignId ===
+          this.env.NEON_PIXEL_CAMPAIGN_ID
+        );
+      default:
+        return true;
+    }
+  }
+
   async process(donations: Donation[]) {
     await this.ctx.blockConcurrencyWhile(async () => {
       await this.ready();
@@ -173,6 +185,10 @@ class PixelsManagerDurableObjectBase extends DurableObject<Env> {
       // New pixels
       const pixels: Record<string, Pixel[]> = {};
       for (const donation of donations) {
+        if (!this.filterDonation(donation)) {
+          continue;
+        }
+
         // Use the primary property of the donatedBy object to get the identifier or default to "Anonymous"
         let identifier =
           donation.donatedBy[donation.donatedBy.primary] ?? "Anonymous";

--- a/apps/donations/worker/src/providers/index.ts
+++ b/apps/donations/worker/src/providers/index.ts
@@ -1,7 +1,9 @@
+import type { MiddlewareHandler } from "hono";
 import type { Providers } from "@alveusgg/donations-core";
 
 export abstract class DonationProvider {
   abstract name: Providers;
+  middleware?: MiddlewareHandler = undefined;
   static init: () => Promise<void>;
   abstract handle: (request: Request) => Promise<Response>;
 }

--- a/apps/donations/worker/src/providers/index.ts
+++ b/apps/donations/worker/src/providers/index.ts
@@ -1,9 +1,7 @@
-import type { MiddlewareHandler } from "hono";
 import type { Providers } from "@alveusgg/donations-core";
 
 export abstract class DonationProvider {
   abstract name: Providers;
-  middleware?: MiddlewareHandler = undefined;
   static init: () => Promise<void>;
   abstract handle: (request: Request) => Promise<Response>;
 }

--- a/apps/donations/worker/src/providers/neon/neon.ts
+++ b/apps/donations/worker/src/providers/neon/neon.ts
@@ -1,4 +1,3 @@
-import { basicAuth } from "hono/basic-auth";
 import type { NeonDonation, Providers } from "@alveusgg/donations-core";
 import { type AccountResponse, getAccount } from "@alveusgg/neon-crm-api";
 import { type Options, envToOptions } from "@alveusgg/neon-crm-api/env";
@@ -9,6 +8,7 @@ import {
 } from "@alveusgg/neon-crm-api/webhooks";
 import type { DonationProvider } from "..";
 import type { DonationStorage } from "../storage";
+import timingSafeCompareString from "../../utils/timing-safe-compare-string";
 
 type NeonDonationProviderOptions = Options & {
   donationDisplayNameCustomFieldId?: string;
@@ -16,7 +16,6 @@ type NeonDonationProviderOptions = Options & {
 
 export class NeonDonationProvider implements DonationProvider {
   name: Providers = "neon";
-  middleware;
 
   constructor(
     private options: NeonDonationProviderOptions,
@@ -27,11 +26,6 @@ export class NeonDonationProvider implements DonationProvider {
         "Neon donation providers require basic auth credentials. Please provide basicAuthUsername and basicAuthPassword .",
       );
     }
-
-    this.middleware = basicAuth({
-      username: options.basicAuthUsername,
-      password: options.basicAuthPassword,
-    });
   }
 
   static async init(
@@ -63,6 +57,17 @@ export class NeonDonationProvider implements DonationProvider {
   }
 
   async handle(request: Request): Promise<Response> {
+    const expectedAuth = btoa(
+      `${this.options.basicAuthUsername}:${this.options.basicAuthPassword}`,
+    );
+    const authHeader = request.headers.get("authorization");
+    if (
+      !authHeader ||
+      !timingSafeCompareString(authHeader, `Basic ${expectedAuth}`)
+    ) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
     const body = await request.json();
     const payload = await parseDonationWebhook(this.options, body);
     if (!payload) {
@@ -81,7 +86,6 @@ export class NeonDonationProvider implements DonationProvider {
           { status: 400 },
         );
 
-      // TODO: Should this retry when the API is temporarily unavailable?
       return new Response("Failed to fetch account data for this donation.", {
         status: 500,
       });

--- a/apps/donations/worker/src/providers/neon/neon.ts
+++ b/apps/donations/worker/src/providers/neon/neon.ts
@@ -44,11 +44,16 @@ export class NeonDonationProvider implements DonationProvider {
         env.NEON_DONATION_DISPLAY_NAME_CUSTOM_FIELD_ID,
     };
 
-    await setupWebhook(
-      `${env.SELF_URL}/donations/${this.name}/live`,
-      "CREATE_DONATION",
-      options,
-    );
+    try {
+      await setupWebhook(
+        `${env.SELF_URL}/donations/${this.name}/live`,
+        "CREATE_DONATION",
+        options,
+      );
+    } catch (e) {
+      console.error("Failed to set up Neon webhook", e);
+      throw e;
+    }
 
     return new NeonDonationProvider(options, service);
   }
@@ -68,13 +73,21 @@ export class NeonDonationProvider implements DonationProvider {
 
     const { data } = payload;
 
-    const account = await getAccount(this.options, data.accountId);
-    if (!account) {
-      return new Response(
-        "Failed to fetch account data for this donation. Rejecting.",
-        { status: 400 },
-      );
+    const accountRes = await getAccount(this.options, data.accountId);
+    if (!accountRes.ok) {
+      if (accountRes.errorType === "request")
+        return new Response(
+          "Failed to fetch account data for this donation. Rejecting.",
+          { status: 400 },
+        );
+
+      // TODO: Should this retry when the API is temporarily unavailable?
+      return new Response("Failed to fetch account data for this donation.", {
+        status: 500,
+      });
     }
+
+    const account = accountRes.data;
     const displayName = this.extractDisplayName(data, account);
 
     const donation = {

--- a/apps/donations/worker/src/providers/neon/neon.ts
+++ b/apps/donations/worker/src/providers/neon/neon.ts
@@ -1,0 +1,165 @@
+import { basicAuth } from "hono/basic-auth";
+import type { NeonDonation, Providers } from "@alveusgg/donations-core";
+import { type AccountResponse, getAccount } from "@alveusgg/neon-crm-api";
+import { type Options, envToOptions } from "@alveusgg/neon-crm-api/env";
+import {
+  type DonationWebhookPayload,
+  parseDonationWebhook,
+  setupWebhook,
+} from "@alveusgg/neon-crm-api/webhooks";
+import type { DonationProvider } from "..";
+import type { DonationStorage } from "../storage";
+
+type NeonDonationProviderOptions = Options & {
+  donationDisplayNameCustomFieldId?: string;
+};
+
+export class NeonDonationProvider implements DonationProvider {
+  name: Providers = "neon";
+  middleware;
+
+  constructor(
+    private options: NeonDonationProviderOptions,
+    private service: DonationStorage,
+  ) {
+    if (!options.basicAuthUsername || !options.basicAuthPassword) {
+      throw new Error(
+        "Neon donation providers require basic auth credentials. Please provide basicAuthUsername and basicAuthPassword .",
+      );
+    }
+
+    this.middleware = basicAuth({
+      username: options.basicAuthUsername,
+      password: options.basicAuthPassword,
+    });
+  }
+
+  static async init(
+    service: DonationStorage,
+    env: Env,
+  ): Promise<NeonDonationProvider> {
+    const options: NeonDonationProviderOptions = {
+      ...envToOptions(env),
+      donationDisplayNameCustomFieldId:
+        env.NEON_DONATION_DISPLAY_NAME_CUSTOM_FIELD_ID,
+    };
+
+    await setupWebhook(
+      `${env.SELF_URL}/donations/${this.name}/live`,
+      "CREATE_DONATION",
+      options,
+    );
+
+    return new NeonDonationProvider(options, service);
+  }
+
+  async clear() {
+    this.service.config.set(this.name, undefined);
+  }
+
+  async handle(request: Request): Promise<Response> {
+    const body = await request.json();
+    const payload = await parseDonationWebhook(this.options, body);
+    if (!payload) {
+      return new Response(`The donation payload was unexpected`, {
+        status: 400,
+      });
+    }
+
+    const { data } = payload;
+
+    const account = await getAccount(this.options, data.accountId);
+    if (!account) {
+      return new Response(
+        "Failed to fetch account data for this donation. Rejecting.",
+        { status: 400 },
+      );
+    }
+    const displayName = this.extractDisplayName(data, account);
+
+    const donation = {
+      id: crypto.randomUUID(),
+      provider: "neon",
+      providerUniqueId: `${payload.organizationId}-${data.id}`,
+      providerMetadata: {
+        neonCampaignId: data.campaign.id ?? undefined,
+        neonCampaignName: data.campaign.name ?? undefined,
+        neonFundId: data.fund.id ?? undefined,
+        neonFundName: data.fund.name ?? undefined,
+      },
+      amount: data.amount * 100,
+      receivedAt: new Date(data.timestamps.createdDateTime),
+      donatedBy: {
+        primary: "displayName",
+        displayName: displayName,
+        firstName:
+          account.individualAccount?.primaryContact.firstName ?? undefined,
+        lastName:
+          account.individualAccount?.primaryContact.lastName ?? undefined,
+        username:
+          account.individualAccount?.login?.username ??
+          account.companyAccount?.login?.username ??
+          undefined,
+      },
+      tags: {
+        fund: String(data.fund.id),
+        campaign: String(data.campaign.id),
+        donorCoveredFee: data.donorCoveredFeeFlag ? "yes" : "no",
+        anonymous: data.anonymousType ? "yes" : "no",
+        payLater: data.payLater ? "yes" : "no",
+      },
+    } satisfies NeonDonation;
+
+    this.service.add(donation);
+    return new Response("OK", { status: 200 });
+  }
+
+  private extractDisplayName(
+    data: DonationWebhookPayload["data"],
+    account: AccountResponse,
+  ) {
+    if (data.anonymousType) {
+      return "Anonymous";
+    }
+
+    const customFieldId = this.options.donationDisplayNameCustomFieldId;
+    if (customFieldId) {
+      const displayNameField = data.donationCustomFields?.find(
+        ({ id }) => id === customFieldId,
+      );
+      if (
+        displayNameField &&
+        "value" in displayNameField &&
+        displayNameField.value.trim() !== ""
+      ) {
+        return displayNameField.value.trim();
+      }
+    }
+
+    if (account.individualAccount) {
+      if (account.individualAccount.primaryContact.preferredName) {
+        return account.individualAccount.primaryContact.preferredName;
+      }
+
+      if (account.individualAccount.primaryContact.firstName) {
+        return account.individualAccount.primaryContact.firstName;
+      }
+    }
+
+    if (account.companyAccount) {
+      if (account.companyAccount.name) {
+        return account.companyAccount.name;
+      }
+
+      if (account.companyAccount.primaryContact.preferredName) {
+        return account.companyAccount.primaryContact.preferredName;
+      }
+
+      if (account.companyAccount.primaryContact.firstName) {
+        return account.companyAccount.primaryContact.firstName;
+      }
+    }
+
+    return "Anonymous";
+  }
+}

--- a/apps/donations/worker/src/providers/neon/neon.ts
+++ b/apps/donations/worker/src/providers/neon/neon.ts
@@ -104,7 +104,7 @@ export class NeonDonationProvider implements DonationProvider {
         neonFundId: data.fund.id ?? undefined,
         neonFundName: data.fund.name ?? undefined,
       },
-      amount: data.amount * 100,
+      amount: toCents(data.amount),
       receivedAt: new Date(data.timestamps.createdDateTime),
       donatedBy: {
         primary: "displayName",
@@ -180,3 +180,6 @@ export class NeonDonationProvider implements DonationProvider {
     return "Anonymous";
   }
 }
+
+const toCents = (val: number): number =>
+  Number.parseInt(val.toFixed(2).replace(".", ""), 10);

--- a/apps/donations/worker/src/utils/timing-safe-compare-string.ts
+++ b/apps/donations/worker/src/utils/timing-safe-compare-string.ts
@@ -1,0 +1,13 @@
+import { timingSafeEqual } from "node:crypto";
+
+// Perform a timing-safe string comparison
+export default function timingSafeCompareString(a: string, b: string) {
+  const arrayA = new TextEncoder().encode(a);
+  const arrayB = new TextEncoder().encode(b);
+  if (arrayA.length !== arrayB.length) {
+    timingSafeEqual(arrayA, arrayA);
+    return false;
+  }
+
+  return timingSafeEqual(arrayA, arrayB);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,40 @@ importers:
         specifier: ^8.58.2
         version: 8.59.0(eslint@9.39.2)(typescript@6.0.3)
 
+  apps/donations/neon-crm-api:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.2
+        version: 9.39.2
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.12.2
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.2(jiti@2.6.1)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@9.39.2)
+      eslint-import-resolver-typescript:
+        specifier: ^4.4.4
+        version: 4.4.4(eslint-plugin-import-x@4.16.2)(eslint@9.39.2)
+      eslint-plugin-import-x:
+        specifier: ^4.16.2
+        version: 4.16.2(@typescript-eslint/utils@8.59.0)(eslint-import-resolver-node@0.3.9)(eslint@9.39.2)
+      globals:
+        specifier: ^17.5.0
+        version: 17.5.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.59.0
+        version: 8.59.0(eslint@9.39.2)(typescript@6.0.3)
+
   apps/donations/worker:
     dependencies:
       '@alveusgg/alveusgg-website':
@@ -141,6 +175,9 @@ importers:
       '@alveusgg/donations-core':
         specifier: workspace:*
         version: link:../core
+      '@alveusgg/neon-crm-api':
+        specifier: workspace:*
+        version: link:../neon-crm-api
       '@sentry/cloudflare':
         specifier: ^10.50.0
         version: 10.50.0
@@ -515,6 +552,9 @@ packages:
     peerDependencies:
       tailwindcss: ^4.0.0
       zod: ^4.0.0
+    peerDependenciesMeta:
+      tailwindcss:
+        optional: true
 
   '@ark/schema@0.46.0':
     resolution: {integrity: sha512-c2UQdKgP2eqqDArfBqQIJppxJHvNNXuQPeuSPlDML4rjw+f1cu0qAlzOG4b8ujgm9ctIDWwhpyw6gjG5ledIVQ==}
@@ -6532,8 +6572,9 @@ snapshots:
 
   '@alveusgg/data@0.72.0(tailwindcss@4.2.4)(zod@4.3.6)':
     dependencies:
-      tailwindcss: 4.2.4
       zod: 4.3.6
+    optionalDependencies:
+      tailwindcss: 4.2.4
 
   '@ark/schema@0.46.0':
     dependencies:


### PR DESCRIPTION
## Describe your changes

This PR adds support for Neon CRM donations to the Alveus donation system. It introduces a new `@alveusgg/neon-crm-api` package that handles API interactions with Neon CRM, integrates a new `NeonDonationProvider` into the donation manager, and enables filtering of Neon donations for the pixel system. The implementation uses webhook-based donation notifications and extracts donor information from Neon CRM accounts.

## Notes for testing your change

...
