### PR TITLE
Move Show and Tell to 1.30pm CT

### DIFF
--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -156,7 +156,7 @@ export const regularEventsWeekly = [
         "Join Maya as she reviews this week's community submissions for Show and Tell.",
       category: "Alveus Regular Stream",
       link: "https://twitch.tv/AlveusSanctuary",
-      startTime: { hour: 13, minute: 0 },
+      startTime: { hour: 13, minute: 30 },
     },
   ],
   // Saturday


### PR DESCRIPTION
## Describe your changes

Moving Show and Tell to be 30 minutes later in the regularly generated events.

## Notes for testing your change

Time is correct.
