### PR TITLE
Show more recent notifications w/ searching + pagination + images

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -81,6 +81,11 @@ const config: NextConfig = {
         protocol: "https",
         hostname: "www.alveussanctuary.org",
       },
+      // S3 - Regular Streams
+      {
+        protocol: "https",
+        hostname: "files.alveus.site",
+      },
       // S3 - File Storage
       s3Pattern,
     ],

--- a/apps/website/src/components/admin/notifications/NotificationsLive.tsx
+++ b/apps/website/src/components/admin/notifications/NotificationsLive.tsx
@@ -97,7 +97,7 @@ export function NotificationsLive() {
                     />
                   )}
                   <div className="flex-1 pl-2">
-                    <NotificationEntry notification={notification} />
+                    <NotificationEntry notification={notification} inline />
                   </div>
                   <div className="flex w-28 justify-end gap-1 border-l border-gray-400">
                     <Button

--- a/apps/website/src/components/calendar/Schedule.tsx
+++ b/apps/website/src/components/calendar/Schedule.tsx
@@ -46,7 +46,7 @@ const webcalUrls = typeSafeObjectKeys(channels)
     {} as Record<string, string>,
   );
 
-const selectionButtonClasses =
+export const selectionButtonClasses =
   "flex items-center gap-2 p-1 text-sm leading-none text-alveus-green-500 transition-colors hover:text-alveus-green-800";
 
 export function Schedule({ onLoad }: { onLoad?: () => void }) {

--- a/apps/website/src/components/content/Button.tsx
+++ b/apps/website/src/components/content/Button.tsx
@@ -18,14 +18,14 @@ const buttonClassNames = ({
   filled?: boolean;
 }) =>
   classes(
-    "rounded-3xl border-2 transition-colors",
+    "rounded-3xl border-2 transition-colors disabled:cursor-not-allowed disabled:opacity-50",
     dark
       ? filled
-        ? "border-alveus-tan bg-alveus-tan text-alveus-green hover:border-alveus-tan hover:bg-transparent hover:text-alveus-tan"
-        : "border-alveus-tan bg-transparent text-alveus-tan hover:border-alveus-tan hover:bg-alveus-tan hover:text-alveus-green"
+        ? "border-alveus-tan bg-alveus-tan text-alveus-green hover:not-disabled:border-alveus-tan hover:not-disabled:bg-transparent hover:not-disabled:text-alveus-tan"
+        : "border-alveus-tan bg-transparent text-alveus-tan hover:not-disabled:border-alveus-tan hover:not-disabled:bg-alveus-tan hover:not-disabled:text-alveus-green"
       : filled
-        ? "border-alveus-green bg-alveus-green text-alveus-tan hover:border-alveus-green hover:bg-transparent hover:text-alveus-green"
-        : "border-alveus-green bg-transparent text-alveus-green hover:border-alveus-green hover:bg-alveus-green hover:text-alveus-tan",
+        ? "border-alveus-green bg-alveus-green text-alveus-tan hover:not-disabled:border-alveus-green hover:not-disabled:bg-transparent hover:not-disabled:text-alveus-green"
+        : "border-alveus-green bg-transparent text-alveus-green hover:not-disabled:border-alveus-green hover:not-disabled:bg-alveus-green hover:not-disabled:text-alveus-tan",
     !/(^|\s)text-(xs|sm|base|lg|[2-6]?xl)(\s|$)/.test(className || "") &&
       "text-lg",
     !/(^|\s)((inline-)?(block|flex|grid|table)|inline|contents)(\s|$)/.test(

--- a/apps/website/src/components/notifications/NotificationEntry.tsx
+++ b/apps/website/src/components/notifications/NotificationEntry.tsx
@@ -1,6 +1,7 @@
 import { DateTime } from "luxon";
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
 import type { Notification } from "@alveusgg/database";
@@ -21,6 +22,11 @@ export function NotificationEntry({
   notification: Notification;
   inline?: boolean;
 }) {
+  const [showImage, setShowImage] = useState(!!notification.imageUrl);
+  useEffect(() => {
+    setShowImage(!!notification.imageUrl);
+  }, [notification.imageUrl]);
+
   const showVod = !!getNotificationVod(notification);
 
   const content = (
@@ -31,16 +37,16 @@ export function NotificationEntry({
           inline ? "my-auto w-32" : "mb-2 w-full",
         )}
       >
-        {notification.imageUrl ? (
-          <ErrorBoundary
-            fallback={<NotificationIcon notification={notification} />}
-          >
+        {showImage && notification.imageUrl ? (
+          // Use an error boundary to catch errors from non-permitted remote image patterns
+          <ErrorBoundary onError={() => setShowImage(false)} fallback={null}>
             <Image
               src={notification.imageUrl}
               alt=""
               width={512}
               height={288}
               className="aspect-video w-full object-cover"
+              onError={() => setShowImage(false)}
             />
           </ErrorBoundary>
         ) : (

--- a/apps/website/src/components/notifications/NotificationEntry.tsx
+++ b/apps/website/src/components/notifications/NotificationEntry.tsx
@@ -1,10 +1,11 @@
 import { DateTime } from "luxon";
+import Image from "next/image";
 import Link from "next/link";
+import { ErrorBoundary } from "react-error-boundary";
 
 import type { Notification } from "@alveusgg/database";
 
-import { getNotificationCategory } from "@/data/notifications";
-
+import { classes } from "@/utils/classes";
 import { formatDateTime } from "@/utils/datetime";
 import {
   checkUserAgentIsInstalledAsPWA,
@@ -15,21 +16,43 @@ import { NotificationIcon } from "@/components/notifications/NotificationIcon";
 
 export function NotificationEntry({
   notification,
+  inline = false,
 }: {
   notification: Notification;
+  inline?: boolean;
 }) {
   const showVod = !!getNotificationVod(notification);
 
-  const categoryLabel =
-    notification.tag && getNotificationCategory(notification.tag)?.label;
-
   const content = (
-    <div className="flex w-full items-center gap-3">
-      <div className="flex flex-1 flex-col">
+    <div className={classes("flex", inline ? "gap-2" : "h-full flex-col")}>
+      <div
+        className={classes(
+          "flex aspect-video shrink-0 items-center justify-center overflow-hidden rounded-lg bg-alveus-green/30",
+          inline ? "my-auto w-32" : "mb-2 w-full",
+        )}
+      >
+        {notification.imageUrl ? (
+          <ErrorBoundary
+            fallback={<NotificationIcon notification={notification} />}
+          >
+            <Image
+              src={notification.imageUrl}
+              alt=""
+              width={512}
+              height={288}
+              className="aspect-video w-full object-cover"
+            />
+          </ErrorBoundary>
+        ) : (
+          <NotificationIcon notification={notification} />
+        )}
+      </div>
+
+      <div className="flex grow flex-col">
         <p className="font-bold">{notification.title}</p>
         {notification.message && <p>{notification.message}</p>}
 
-        <div className="flex items-center gap-2 text-sm opacity-70">
+        <div className="mt-auto flex items-center gap-2 text-sm opacity-70">
           <time
             dateTime={notification.createdAt.toISOString()}
             title={formatDateTime(notification.createdAt)}
@@ -46,9 +69,6 @@ export function NotificationEntry({
             </>
           )}
         </div>
-      </div>
-      <div title={categoryLabel || undefined}>
-        <NotificationIcon notification={notification} />
       </div>
     </div>
   );

--- a/apps/website/src/components/notifications/RecentNotifications.tsx
+++ b/apps/website/src/components/notifications/RecentNotifications.tsx
@@ -1,21 +1,6 @@
-import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
 
 import { NotificationEntry } from "@/components/notifications/NotificationEntry";
-
-const styles = [
-  "opacity-100",
-  "opacity-95",
-  "opacity-90",
-  "opacity-85",
-  "opacity-80",
-  "opacity-75",
-  "opacity-70",
-  "opacity-65",
-  "opacity-60",
-  "opacity-55",
-  "opacity-50",
-];
 
 export function RecentNotifications({ tags }: { tags: Array<string> }) {
   const recentNotifications =
@@ -27,13 +12,10 @@ export function RecentNotifications({ tags }: { tags: Array<string> }) {
 
   return (
     <ul className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
-      {recentNotifications.data?.map((notification, idx) => (
+      {recentNotifications.data?.map((notification) => (
         <li
           key={notification.id}
-          className={classes(
-            styles[idx] ?? "opacity-50",
-            "flex items-center gap-3 rounded-xl bg-alveus-green/30 px-4 py-2 transition-transform hover:scale-102 hover:bg-alveus-green/40",
-          )}
+          className="flex items-center gap-3 rounded-xl bg-alveus-green/30 px-4 py-2 transition-transform hover:scale-102 hover:bg-alveus-green/40"
         >
           <NotificationEntry notification={notification} />
         </li>

--- a/apps/website/src/components/notifications/RecentNotifications.tsx
+++ b/apps/website/src/components/notifications/RecentNotifications.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 
 import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
@@ -17,6 +17,17 @@ const notificationClasses =
 
 export function RecentNotifications({ tags }: { tags: Array<string> }) {
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 250);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [search]);
 
   return (
     <>
@@ -36,6 +47,7 @@ export function RecentNotifications({ tags }: { tags: Array<string> }) {
             type="search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
+            onBlur={(e) => setDebouncedSearch(e.target.value)}
             placeholder="Search notifications"
             aria-label="Search notifications"
             className="min-w-0 bg-transparent text-sm outline-none placeholder:text-inherit not-focus:placeholder-shown:cursor-pointer focus:placeholder:text-alveus-green-800/50"
@@ -43,7 +55,7 @@ export function RecentNotifications({ tags }: { tags: Array<string> }) {
         </label>
       </div>
 
-      <RecentNotificationsList tags={tags} search={search} />
+      <RecentNotificationsList tags={tags} search={debouncedSearch} />
     </>
   );
 }

--- a/apps/website/src/components/notifications/RecentNotifications.tsx
+++ b/apps/website/src/components/notifications/RecentNotifications.tsx
@@ -1,25 +1,75 @@
+import { Fragment } from "react";
+
+import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
 
 import { NotificationEntry } from "@/components/notifications/NotificationEntry";
 
+import IconLoading from "@/icons/IconLoading";
+
+import Button from "../content/Button";
+
 export function RecentNotifications({ tags }: { tags: Array<string> }) {
   const recentNotifications =
-    trpc.notifications.getRecentNotificationsForTags.useQuery({ tags });
+    trpc.notifications.getRecentNotificationsForTags.useInfiniteQuery(
+      { tags },
+      {
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      },
+    );
 
   if (recentNotifications.isPending) {
-    return <p className="">Loading recent notifications...</p>;
+    return <p>Loading recent notifications...</p>;
+  }
+
+  if (recentNotifications.status === "error") {
+    return <p>Error loading recent notifications.</p>;
+  }
+
+  const hasNotifications = recentNotifications.data?.pages.some(
+    (page) => page.items.length > 0,
+  );
+
+  if (!hasNotifications) {
+    return <p>No recent notifications.</p>;
   }
 
   return (
-    <ul className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
-      {recentNotifications.data?.map((notification) => (
-        <li
-          key={notification.id}
-          className="flex items-center gap-3 rounded-xl bg-alveus-green/30 px-4 py-2 transition-transform hover:scale-102 hover:bg-alveus-green/40"
+    <>
+      <ul className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+        {recentNotifications.data?.pages.map((page, i) => (
+          <Fragment
+            key={page.nextCursor || `page-${page.items[0]?.id || "empty"}`}
+          >
+            {page.items.map((notification) => (
+              <li
+                key={notification.id}
+                className={classes(
+                  "flex items-center gap-3 rounded-xl bg-alveus-green/30 px-4 py-2 transition-all hover:scale-102 hover:bg-alveus-green/40",
+                  i !== 0 && "starting:opacity-0",
+                )}
+              >
+                <NotificationEntry notification={notification} />
+              </li>
+            ))}
+          </Fragment>
+        ))}
+      </ul>
+
+      {recentNotifications.hasNextPage && (
+        <Button
+          as="button"
+          className="mt-4 flex w-full items-center justify-center"
+          onClick={() => recentNotifications.fetchNextPage()}
+          disabled={recentNotifications.isFetchingNextPage}
         >
-          <NotificationEntry notification={notification} />
-        </li>
-      ))}
-    </ul>
+          {recentNotifications.isFetchingNextPage ? (
+            <IconLoading size={20} />
+          ) : (
+            "Load more"
+          )}
+        </Button>
+      )}
+    </>
   );
 }

--- a/apps/website/src/components/notifications/RecentNotifications.tsx
+++ b/apps/website/src/components/notifications/RecentNotifications.tsx
@@ -1,18 +1,60 @@
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 
 import { classes } from "@/utils/classes";
 import { trpc } from "@/utils/trpc";
 
+import Heading from "@/components/content/Heading";
 import { NotificationEntry } from "@/components/notifications/NotificationEntry";
 
 import IconLoading from "@/icons/IconLoading";
+import IconSearch from "@/icons/IconSearch";
 
+import { selectionButtonClasses } from "../calendar/Schedule";
 import Button from "../content/Button";
 
 export function RecentNotifications({ tags }: { tags: Array<string> }) {
+  const [search, setSearch] = useState("");
+
+  return (
+    <>
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <Heading level={3} id="recent" link>
+          Recent Notifications
+        </Heading>
+
+        <label
+          className={classes(
+            selectionButtonClasses,
+            "rounded-md border border-transparent px-2 py-1 not-has-placeholder-shown:border-alveus-green-700 not-has-placeholder-shown:bg-alveus-tan focus-within:border-alveus-green-700 focus-within:bg-alveus-tan",
+          )}
+        >
+          <IconSearch size={16} className="shrink-0" />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search notifications"
+            aria-label="Search notifications"
+            className="min-w-0 bg-transparent text-sm outline-none placeholder:text-inherit not-focus:placeholder-shown:cursor-pointer focus:placeholder:text-alveus-green-800/50"
+          />
+        </label>
+      </div>
+
+      <RecentNotificationsList tags={tags} search={search} />
+    </>
+  );
+}
+
+function RecentNotificationsList({
+  tags,
+  search,
+}: {
+  tags: Array<string>;
+  search: string;
+}) {
   const recentNotifications =
     trpc.notifications.getRecentNotificationsForTags.useInfiniteQuery(
-      { tags },
+      { tags, search },
       {
         getNextPageParam: (lastPage) => lastPage.nextCursor,
       },

--- a/apps/website/src/components/notifications/RecentNotifications.tsx
+++ b/apps/website/src/components/notifications/RecentNotifications.tsx
@@ -13,7 +13,7 @@ import { selectionButtonClasses } from "../calendar/Schedule";
 import Button from "../content/Button";
 
 const notificationClasses =
-  "flex items-center gap-3 rounded-xl bg-alveus-green/30 px-4 py-2 transition-all hover:scale-102 hover:bg-alveus-green/40";
+  "rounded-xl bg-alveus-green/30 p-2 transition-all hover:scale-102 hover:bg-alveus-green/40";
 
 export function RecentNotifications({ tags }: { tags: Array<string> }) {
   const [search, setSearch] = useState("");
@@ -76,14 +76,14 @@ function RecentNotificationsList({
 
   return (
     <>
-      <ul className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+      <ul className="grid grid-cols-2 gap-2 lg:grid-cols-5">
         {recentNotifications.isPending
-          ? Array.from({ length: 9 }).map((_, i) => (
+          ? Array.from({ length: 10 }).map((_, i) => (
               <li
                 key={i}
                 className={classes(notificationClasses, "animate-pulse")}
               >
-                <div className="h-22" />
+                <div className="h-64" />
               </li>
             ))
           : recentNotifications.data?.pages.map((page, i) => (

--- a/apps/website/src/components/notifications/RecentNotifications.tsx
+++ b/apps/website/src/components/notifications/RecentNotifications.tsx
@@ -12,6 +12,9 @@ import IconSearch from "@/icons/IconSearch";
 import { selectionButtonClasses } from "../calendar/Schedule";
 import Button from "../content/Button";
 
+const notificationClasses =
+  "flex items-center gap-3 rounded-xl bg-alveus-green/30 px-4 py-2 transition-all hover:scale-102 hover:bg-alveus-green/40";
+
 export function RecentNotifications({ tags }: { tags: Array<string> }) {
   const [search, setSearch] = useState("");
 
@@ -60,42 +63,46 @@ function RecentNotificationsList({
       },
     );
 
-  if (recentNotifications.isPending) {
-    return <p>Loading recent notifications...</p>;
-  }
-
-  if (recentNotifications.status === "error") {
+  if (recentNotifications.isError) {
     return <p>Error loading recent notifications.</p>;
   }
 
-  const hasNotifications = recentNotifications.data?.pages.some(
-    (page) => page.items.length > 0,
-  );
-
-  if (!hasNotifications) {
+  if (
+    recentNotifications.isSuccess &&
+    !recentNotifications.data?.pages.some((page) => page.items.length > 0)
+  ) {
     return <p>No recent notifications.</p>;
   }
 
   return (
     <>
       <ul className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
-        {recentNotifications.data?.pages.map((page, i) => (
-          <Fragment
-            key={page.nextCursor || `page-${page.items[0]?.id || "empty"}`}
-          >
-            {page.items.map((notification) => (
+        {recentNotifications.isPending
+          ? Array.from({ length: 9 }).map((_, i) => (
               <li
-                key={notification.id}
-                className={classes(
-                  "flex items-center gap-3 rounded-xl bg-alveus-green/30 px-4 py-2 transition-all hover:scale-102 hover:bg-alveus-green/40",
-                  i !== 0 && "starting:opacity-0",
-                )}
+                key={i}
+                className={classes(notificationClasses, "animate-pulse")}
               >
-                <NotificationEntry notification={notification} />
+                <div className="h-22" />
               </li>
+            ))
+          : recentNotifications.data?.pages.map((page, i) => (
+              <Fragment
+                key={page.nextCursor || `page-${page.items[0]?.id || "empty"}`}
+              >
+                {page.items.map((notification) => (
+                  <li
+                    key={notification.id}
+                    className={classes(
+                      notificationClasses,
+                      i !== 0 && "starting:opacity-0",
+                    )}
+                  >
+                    <NotificationEntry notification={notification} />
+                  </li>
+                ))}
+              </Fragment>
             ))}
-          </Fragment>
-        ))}
       </ul>
 
       {recentNotifications.hasNextPage && (

--- a/apps/website/src/pages/updates.tsx
+++ b/apps/website/src/pages/updates.tsx
@@ -132,9 +132,6 @@ const UpdatesPage: NextPage = () => {
           </section>
 
           <section>
-            <Heading level={3} id="recent" link>
-              Recent Notifications
-            </Heading>
             <RecentNotifications tags={notificationTags} />
           </section>
 

--- a/apps/website/src/server/db/notifications.ts
+++ b/apps/website/src/server/db/notifications.ts
@@ -6,19 +6,30 @@ export async function getRecentNotificationsForTags({
   tags,
   take,
   cursor,
+  search,
 }: {
   tags: string[];
   take: number;
   cursor?: string;
+  search?: string;
 }) {
   // VODs are only stored for 60 days, so we have no reason to ever allow access to older notifications
   const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+  const trimmedSearch = search?.trim();
 
   const items = await prisma.notification.findMany({
     where: {
       tag: { in: tags },
       canceledAt: null,
       createdAt: { gte: sixtyDaysAgo },
+      ...(trimmedSearch
+        ? {
+            OR: [
+              { title: { contains: trimmedSearch } },
+              { message: { contains: trimmedSearch } },
+            ],
+          }
+        : {}),
     },
     orderBy: { createdAt: "desc" },
     take: take + 1,

--- a/apps/website/src/server/db/notifications.ts
+++ b/apps/website/src/server/db/notifications.ts
@@ -31,7 +31,7 @@ export async function getRecentNotificationsForTags({
           }
         : {}),
     },
-    orderBy: { createdAt: "desc" },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     take: take + 1,
     cursor: cursor ? { id: cursor } : undefined,
   });

--- a/apps/website/src/server/db/notifications.ts
+++ b/apps/website/src/server/db/notifications.ts
@@ -5,15 +5,33 @@ import { env } from "@/env";
 export async function getRecentNotificationsForTags({
   tags,
   take,
+  cursor,
 }: {
   tags: string[];
   take: number;
+  cursor?: string;
 }) {
-  return prisma.notification.findMany({
-    where: { tag: { in: tags }, canceledAt: null },
+  // VODs are only stored for 60 days, so we have no reason to ever allow access to older notifications
+  const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+
+  const items = await prisma.notification.findMany({
+    where: {
+      tag: { in: tags },
+      canceledAt: null,
+      createdAt: { gte: sixtyDaysAgo },
+    },
     orderBy: { createdAt: "desc" },
-    take,
+    take: take + 1,
+    cursor: cursor ? { id: cursor } : undefined,
   });
+
+  let nextCursor: typeof cursor | undefined = undefined;
+  if (items.length > take) {
+    const nextItem = items.pop();
+    nextCursor = nextItem?.id || undefined;
+  }
+
+  return { items, nextCursor };
 }
 
 export async function getActiveAnnouncements() {

--- a/apps/website/src/server/trpc/router/notifications.ts
+++ b/apps/website/src/server/trpc/router/notifications.ts
@@ -18,7 +18,7 @@ export const notificationsRouter = router({
     .query(async ({ input }) =>
       getRecentNotificationsForTags({
         tags: input.tags,
-        take: 9,
+        take: 10,
         cursor: input.cursor || undefined,
         search: input.search,
       }),

--- a/apps/website/src/server/trpc/router/notifications.ts
+++ b/apps/website/src/server/trpc/router/notifications.ts
@@ -12,6 +12,7 @@ export const notificationsRouter = router({
       z.object({
         tags: z.array(z.string()),
         cursor: z.cuid().nullish(),
+        search: z.string().max(100).default(""),
       }),
     )
     .query(async ({ input }) =>
@@ -19,6 +20,7 @@ export const notificationsRouter = router({
         tags: input.tags,
         take: 9,
         cursor: input.cursor || undefined,
+        search: input.search,
       }),
     ),
 

--- a/apps/website/src/server/trpc/router/notifications.ts
+++ b/apps/website/src/server/trpc/router/notifications.ts
@@ -8,9 +8,18 @@ import { publicProcedure, router } from "@/server/trpc/trpc";
 
 export const notificationsRouter = router({
   getRecentNotificationsForTags: publicProcedure
-    .input(z.object({ tags: z.array(z.string()) }))
+    .input(
+      z.object({
+        tags: z.array(z.string()),
+        cursor: z.cuid().nullish(),
+      }),
+    )
     .query(async ({ input }) =>
-      getRecentNotificationsForTags({ tags: input.tags, take: 9 }),
+      getRecentNotificationsForTags({
+        tags: input.tags,
+        take: 9,
+        cursor: input.cursor || undefined,
+      }),
     ),
 
   getActiveAnnouncements: publicProcedure.query(getActiveAnnouncements),


### PR DESCRIPTION
## Describe your changes

Updates the recent notifications section of the updates page to allow pagnation back through 60 days of history, as well as searching for specific notifications. Also a minor visual update to show the notification images where possible, falling back to the icon as before if not.

<img width="3008" height="1450" alt="image" src="https://github.com/user-attachments/assets/2fe2d4b9-41ea-4e7b-8759-4751a4a0ab23" />

<br />

<img width="3008" height="1322" alt="image" src="https://github.com/user-attachments/assets/6a86a5fb-664e-4803-b109-a33ebbfcc423" />

## Notes for testing your change

Notifications paginate correctly and can be searched correctly.