### PR TITLE
Update regular calendar events w/ Kayla + FAID streams

### DIFF
--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -162,15 +162,7 @@ export const regularEventsWeekly = [
     },
   ],
   // Saturday
-  [
-    {
-      title: "Connor Stream",
-      description: "Join Connor as he gets up to his usual antics.",
-      category: "Alveus Regular Stream",
-      link: "https://twitch.tv/AlveusSanctuary",
-      startTime: { hour: 13, minute: 0 },
-    },
-  ],
+  [],
   // Sunday
   [],
 ] as RegularEvent[][];

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -144,7 +144,7 @@ export const regularEventsWeekly = [
     {
       title: "FAID Stream",
       description:
-        "Join the Facilities and Infrastructure Department as they gets work done around the sanctuary.",
+        "Join the Facilities and Infrastructure Department as they get work done around the sanctuary.",
       category: "Alveus Regular Stream",
       link: "https://twitch.tv/AlveusSanctuary",
       startTime: { hour: 13, minute: 0 },

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -142,8 +142,9 @@ export const regularEventsWeekly = [
   // Thursday
   [
     {
-      title: "Lukas Stream",
-      description: "Join Lukas as he gets work done around the sanctuary.",
+      title: "FAID Stream",
+      description:
+        "Join the Facilities and Infrastructure Department as they gets work done around the sanctuary.",
       category: "Alveus Regular Stream",
       link: "https://twitch.tv/AlveusSanctuary",
       startTime: { hour: 13, minute: 0 },

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -123,8 +123,9 @@ export const regularEventsWeekly = [
   [
     mayaStream,
     {
-      title: "Dan Stream",
-      description: "Join Dan as he gets work done around the sanctuary.",
+      title: "Kayla Stream",
+      description:
+        "Join Kayla as she covers educational topics and answers all your questions.",
       category: "Alveus Regular Stream",
       link: "https://twitch.tv/AlveusSanctuary",
       startTime: { hour: 13, minute: 0 },


### PR DESCRIPTION
## Describe your changes

Adds new Wednesday + Thursday streams for Kayla's education streams and the FAID team streams. Removes the dedicated Connor stream in favor of the team FAID stream.

## Notes for testing your change

Changes to config match what is described above and in Discord.
