### PR TITLE
Link to notification page from Discord embed

### DIFF
--- a/apps/website/__tests__/discord.test.ts
+++ b/apps/website/__tests__/discord.test.ts
@@ -60,3 +60,14 @@ test("full stop false", async () => {
 
   expect(res).toEqual(expected);
 });
+
+test("wrapping url inside masked markdown link", async () => {
+  const example =
+    "Read this @ [google.com](https://google.com/search?q=alveus)";
+  const expected =
+    "Read this @ [google.com](<https://google.com/search?q=alveus>)";
+
+  const res = escapeLinksForDiscord(example);
+
+  expect(res).toEqual(expected);
+});

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -2,6 +2,8 @@ import { type DateObjectUnits } from "luxon";
 
 import { type CalendarEvent } from "@alveusgg/database";
 
+import { getLinkDisplayText } from "@/utils/link-display";
+
 type StandardCategory = {
   name: string;
   color: string;
@@ -87,7 +89,7 @@ export const getFormattedTitle = (
   const title = length ? truncate(event.title, length) : event.title;
   return channel && new RegExp(`twitch\\.tv\\/${channel}`, "i").test(event.link)
     ? title
-    : `${title} @ ${event.link.toLowerCase().replace(/^(https?:)?\/\/(www\.)?/, "")}`;
+    : `${title} @ ${getLinkDisplayText(event.link)}`;
 };
 
 type RegularEvent = Pick<

--- a/apps/website/src/server/notifications.ts
+++ b/apps/website/src/server/notifications.ts
@@ -14,6 +14,7 @@ import {
 
 import getDiscordTimestamp from "@/utils/discord-timestamp";
 import { escapeLinksForDiscord } from "@/utils/escape-links-for-discord";
+import { getLinkDisplayText } from "@/utils/link-display";
 
 import type { CreatePushesOptions } from "@/pages/api/notifications/batched-create-notification-pushes";
 import type { RetryPushesOptions } from "@/pages/api/notifications/batched-retry-notification-pushes";
@@ -207,6 +208,11 @@ async function sendDiscordNotifications({
   scheduledStartAt,
   scheduledEndAt,
 }: Notification) {
+  const notificationPageLink = new URL(
+    `/notifications/${id}`,
+    env.NEXT_PUBLIC_BASE_URL,
+  ).toString();
+
   let webhookUrls: string[] = [];
   let toEveryone = false;
   switch (tag) {
@@ -227,7 +233,7 @@ async function sendDiscordNotifications({
         }
       }
       if (linkUrl) {
-        message += ` @ ${linkUrl}`;
+        message += ` @ [${getLinkDisplayText(linkUrl)}](${notificationPageLink})`;
       }
       linkUrl = null;
       break;
@@ -242,7 +248,8 @@ async function sendDiscordNotifications({
       triggerDiscordChannelWebhook({
         contentTitle: title ?? undefined,
         contentMessage: message,
-        contentLink: linkUrl ?? undefined,
+        contentLink: linkUrl ? notificationPageLink : undefined,
+        contentLinkLabel: linkUrl ?? undefined,
         imageUrl: imageUrl ?? undefined,
         webhookUrl,
         expiresAt,

--- a/apps/website/src/server/outgoing-webhooks.ts
+++ b/apps/website/src/server/outgoing-webhooks.ts
@@ -2,6 +2,8 @@ import { type OutgoingWebhook, prisma } from "@alveusgg/database";
 
 import { env } from "@/env";
 
+import { getLinkDisplayText } from "@/utils/link-display";
+
 export type OutgoingWebhookType = "form-entry" | "unknown";
 
 type OutgoingWebhookData = Pick<
@@ -178,6 +180,7 @@ export async function triggerDiscordChannelWebhook({
   contentTitle,
   contentMessage,
   contentLink,
+  contentLinkLabel,
   imageUrl,
   botName: username = env.DISCORD_CHANNEL_WEBHOOK_NAME,
   expiresAt,
@@ -187,18 +190,19 @@ export async function triggerDiscordChannelWebhook({
   contentTitle?: string;
   contentMessage?: string;
   contentLink?: string;
+  contentLinkLabel?: string;
   imageUrl?: string;
   botName?: string;
   expiresAt?: Date;
   toEveryone?: boolean;
 }) {
+  const displayLink = getLinkDisplayText(contentLinkLabel || contentLink || "");
+
   const embed = {
     title: contentTitle || "Notification",
     description: (
       (contentMessage || "") +
-      (contentLink
-        ? `\n[${contentLink.replace(/^https?:\/\/(www\.)?/, "")}](${contentLink})`
-        : "")
+      (contentLink ? `\n[${displayLink}](${contentLink})` : "")
     ).trim(),
     color: 0x636a60,
     url: contentLink,

--- a/apps/website/src/utils/link-display.ts
+++ b/apps/website/src/utils/link-display.ts
@@ -1,0 +1,3 @@
+export function getLinkDisplayText(link: string) {
+  return link.replace(/^(https?:)?\/\/(www\.)?/, "");
+}


### PR DESCRIPTION
## Describe your changes

When a notification has a link associated with it, link to the website notification page from the Discord embed rather than the notification link directly, to allow for the VoD logic to kick in if users click on the Discord embed more than an hour after it was sent.

## Notes for testing your change

Links visually still look like the underlying notification link, but are masked links to the website notification page. Website notification page correctly automatically redirects to the underlying notification link.