### PR TITLE
Clarify camera swap behavior on presets page

### DIFF
--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -215,11 +215,7 @@ const AboutTechPresetsPage: NextPage = () => {
                     </span>{" "}
                     button if the camera is in the same enclosure as the
                     currently selected camera. If you&apos;re subscribed, this
-                    lets you swap which of the two cameras is shown &mdash; it
-                    cannot bring a camera on stream that isn&apos;t already
-                    live. The Home preset and the{" "}
-                    <span className="font-mono">!ptzhome</span> command also
-                    won&apos;t swap a camera onto stream, so ask a moderator in
+                    lets you swap which of the two cameras is shown &mdash;
                     you can only swap to a camera if the enclosure is already on
                     stream. Ask a moderator in chat if you wish for a new
                     enclosure to be swapped in.

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -214,13 +214,15 @@ const AboutTechPresetsPage: NextPage = () => {
                       <IconVideoCamera className="mb-0.5 inline-block size-4" />
                     </span>{" "}
                     button if the camera is in the same enclosure as the
-                    currently selected camera. If you&apos;re subscribed,
-                    this lets you swap which of the two cameras is shown &mdash;
-                    it cannot bring a camera on stream that isn&apos;t already
+                    currently selected camera. If you&apos;re subscribed, this
+                    lets you swap which of the two cameras is shown &mdash; it
+                    cannot bring a camera on stream that isn&apos;t already
                     live. The Home preset and the{" "}
                     <span className="font-mono">!ptzhome</span> command also
                     won&apos;t swap a camera onto stream, so ask a moderator in
-                    you can only swap to a camera if the enclosure is already on stream. Ask a moderator in chat if you wish for a new enclosure to be swapped in.
+                    you can only swap to a camera if the enclosure is already on
+                    stream. Ask a moderator in chat if you wish for a new
+                    enclosure to be swapped in.
                   </p>
 
                   <p>

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -213,8 +213,8 @@ const AboutTechPresetsPage: NextPage = () => {
                       Run swap command{" "}
                       <IconVideoCamera className="mb-0.5 inline-block size-4" />
                     </span>{" "}
-                    button when the camera shares an enclosure with one
-                    that&apos;s already on stream. If you&apos;re subscribed,
+                    button if the camera is in the same enclosure as the
+                    currently selected camera. If you&apos;re subscribed,
                     this lets you swap which of the two cameras is shown &mdash;
                     it cannot bring a camera on stream that isn&apos;t already
                     live. The Home preset and the{" "}

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -207,15 +207,20 @@ const AboutTechPresetsPage: NextPage = () => {
                     as if you had typed it in the chat yourself.
                   </p>
 
-                  <p className="hidden lg:block">
+                  <p className="lg:block">
                     Next to each camera in the menu you&apos;ll also find a{" "}
                     <span className="font-semibold text-alveus-green">
                       Run swap command{" "}
                       <IconVideoCamera className="mb-0.5 inline-block size-4" />
                     </span>{" "}
-                    button if the camera is in the same enclosure as the
-                    currently selected camera, allowing you to swap which camera
-                    is shown on stream if you&apos;re subscribed.
+                    button when the camera shares an enclosure with one
+                    that&apos;s already on stream. If you&apos;re subscribed,
+                    this lets you swap which of the two cameras is shown &mdash;
+                    it cannot bring a camera on stream that isn&apos;t already
+                    live. The Home preset and the{" "}
+                    <span className="font-mono">!ptzhome</span> command also
+                    won&apos;t swap a camera onto stream, so ask a moderator in
+                    chat if you need a different camera activated.
                   </p>
 
                   <p>

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -207,7 +207,7 @@ const AboutTechPresetsPage: NextPage = () => {
                     as if you had typed it in the chat yourself.
                   </p>
 
-                  <p className="lg:block">
+                  <p className="hidden lg:block">
                     Next to each camera in the menu you&apos;ll also find a{" "}
                     <span className="font-semibold text-alveus-green">
                       Run swap command{" "}

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -220,7 +220,7 @@ const AboutTechPresetsPage: NextPage = () => {
                     live. The Home preset and the{" "}
                     <span className="font-mono">!ptzhome</span> command also
                     won&apos;t swap a camera onto stream, so ask a moderator in
-                    chat if you need a different camera activated.
+                    you can only swap to a camera if the enclosure is already on stream. Ask a moderator in chat if you wish for a new enclosure to be swapped in.
                   </p>
 
                   <p>

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -215,8 +215,8 @@ const AboutTechPresetsPage: NextPage = () => {
                     </span>{" "}
                     button if the camera is in the same enclosure as the
                     currently selected camera. If you&apos;re subscribed, this
-                    lets you swap which of the two cameras is shown &mdash;
-                    you can only swap to a camera if the enclosure is already on
+                    lets you swap which of the two cameras is shown &mdash; you
+                    can only swap to a camera if the enclosure is already on
                     stream. Ask a moderator in chat if you wish for a new
                     enclosure to be swapped in.
                   </p>


### PR DESCRIPTION
## Describe your changes

Closes #1382

Updates the description under the "Run swap command" button on the camera presets page to clarify that:
- Swap only works when both cameras share an enclosure and the other is already live.
- The Home preset / !ptzhome command will not swap a camera onto stream.
- Users need to ping a mod in chat to activate a different camera.


## Notes for testing your change
Go to `/about/tech/presets` and check the second paragraph under the banner.
<img width="1763" height="698" alt="Screenshot 2026-05-15 at 14 37 36" src="https://github.com/user-attachments/assets/f7be730c-7e2f-48a8-b650-5a45b5c36e71" />
