### PR TITLE
Prevent layout shift on donate page from Giving Block widget

### DIFF
--- a/apps/website/src/components/content/TheGivingBlockEmbed.tsx
+++ b/apps/website/src/components/content/TheGivingBlockEmbed.tsx
@@ -37,12 +37,14 @@ const TheGivingBlockEmbed = ({
     div.appendChild(script);
 
     return () => {
-      div.innerHTML = "";
+      div.replaceChildren();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, JSON.stringify(props)]);
 
-  return <div ref={ref} className={className} />;
+  // Reserve the widget's final rendered height up-front to avoid layout shift
+  // once the widget script finishes loading.
+  return <div ref={ref} className={`min-h-[820px] ${className ?? ""}`} />;
 };
 
 export default TheGivingBlockEmbed;

--- a/apps/website/src/pages/donate.tsx
+++ b/apps/website/src/pages/donate.tsx
@@ -16,7 +16,7 @@ import TheGivingBlockEmbed from "@/components/content/TheGivingBlockEmbed";
 import IconArrowRight from "@/icons/IconArrowRight";
 
 const DonatePage: NextPage = () => {
-  const { consent } = useConsent();
+  const { consent, loaded } = useConsent();
 
   return (
     <>
@@ -68,7 +68,7 @@ const DonatePage: NextPage = () => {
 
       {/* Grow the last section to cover the page */}
       <Section className="grow" containerClassName="flex flex-wrap">
-        <div className="flex basis-full flex-col gap-8 py-4 lg:basis-1/2 lg:px-4">
+        <div className="flex basis-full flex-col gap-8 py-4 lg:min-h-[820px] lg:basis-1/2 lg:px-4">
           {types.map(
             (key) =>
               key !== "givingBlock" && (
@@ -77,8 +77,8 @@ const DonatePage: NextPage = () => {
           )}
         </div>
 
-        <div className="flex basis-full flex-col gap-8 py-4 lg:basis-1/2 lg:px-4">
-          {!consent.givingBlock && <Donate type="givingBlock" />}
+        <div className="flex basis-full flex-col gap-8 py-4 lg:min-h-[820px] lg:basis-1/2 lg:px-4">
+          {loaded && !consent.givingBlock && <Donate type="givingBlock" />}
 
           <Consent item="donation widget" consent="givingBlock">
             <TheGivingBlockEmbed className="flex w-full justify-center" />


### PR DESCRIPTION
## Describe your changes

- Reserve min-h-[820px] on the embed column (and its sibling) to stop the Giving Block widget from pushing content down when it loads
- Gate the fallback Giving Block card on loaded from useConsent so it doesn't flash before consent is read from localStorage

...

## Notes for testing your change

- [ ] go to /donate with no prior consent: no layout shift when granting consent and the widget loads
- [ ] go to /donate with prior consent: no fallback card flash

...
