### PR TITLE
sticky header scroll up button

### DIFF
--- a/apps/website/src/components/content/SubNav.tsx
+++ b/apps/website/src/components/content/SubNav.tsx
@@ -55,7 +55,7 @@ const SubNavInner = ({ links, className }: SubNavProps) => {
 const SubNav = ({ links, className }: SubNavProps) => (
   <nav
     className={classes(
-      "sticky inset-x-0 top-0 bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl",
+      "sticky inset-x-0 top-[var(--alveus-nav-h,0px)] bg-alveus-green-100/50 text-xl font-bold shadow-md backdrop-blur-2xl transition-[top] duration-200 ease-out motion-reduce:transition-none lg:top-[var(--alveus-nav-h-lg,0px)]",
       className,
     )}
   >

--- a/apps/website/src/components/layout/Layout.tsx
+++ b/apps/website/src/components/layout/Layout.tsx
@@ -9,6 +9,7 @@ import Meta from "@/components/content/Meta";
 
 import IconArrowRight from "@/icons/IconArrowRight";
 
+import { ScrollToTop } from "./ScrollToTop";
 import { Footer } from "./footer/Footer";
 import { Navbar } from "./navbar/Navbar";
 
@@ -80,6 +81,7 @@ const Layout = ({ children }: LayoutProps) => {
           {children}
         </main>
         <Footer />
+        <ScrollToTop />
       </div>
     </>
   );

--- a/apps/website/src/components/layout/ScrollToTop.tsx
+++ b/apps/website/src/components/layout/ScrollToTop.tsx
@@ -1,0 +1,61 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+import { classes } from "@/utils/classes";
+
+import IconChevronDown from "@/icons/IconChevronDown";
+
+const SHOW_AFTER = 400;
+
+// Pages that own their bottom-right corner (e.g. Show and Tell's
+// presentation-mode floating panels) opt out of the sitewide button.
+const isSuppressed = (pathname: string) =>
+  pathname.startsWith("/show-and-tell");
+
+export const ScrollToTop = () => {
+  const { pathname } = useRouter();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (isSuppressed(pathname)) {
+      setVisible(false);
+      return;
+    }
+
+    let frame = 0;
+
+    const update = () => {
+      frame = 0;
+      setVisible(window.scrollY > SHOW_AFTER);
+    };
+
+    const onScroll = () => {
+      frame ||= window.requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (frame) window.cancelAnimationFrame(frame);
+    };
+  }, [pathname]);
+
+  if (isSuppressed(pathname)) return null;
+
+  return (
+    <button
+      type="button"
+      aria-label="Scroll to top"
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      className={classes(
+        "fixed right-4 bottom-4 z-40 flex size-12 items-center justify-center rounded-full bg-alveus-green-900 text-white shadow-lg transition-opacity duration-200 hover:bg-alveus-green-800 focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-alveus-green-900 focus:outline-none motion-reduce:transition-none",
+        visible ? "opacity-90" : "pointer-events-none opacity-0",
+      )}
+    >
+      <IconChevronDown className="size-6 rotate-180" />
+    </button>
+  );
+};

--- a/apps/website/src/components/layout/navbar/Navbar.tsx
+++ b/apps/website/src/components/layout/navbar/Navbar.tsx
@@ -1,6 +1,9 @@
 import { Disclosure, DisclosureButton } from "@headlessui/react";
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+import { classes } from "@/utils/classes";
 
 import { DesktopMenu } from "@/components/layout/navbar/DesktopMenu";
 import { MobileMenu } from "@/components/layout/navbar/MobileMenu";
@@ -10,6 +13,43 @@ import IconMenu from "@/icons/IconMenu";
 import IconX from "@/icons/IconX";
 
 import logoImage from "@/assets/logo.png";
+
+const useAutoHideOnScroll = (disabled: boolean) => {
+  const [state, setState] = useState({ hidden: false, scrolled: false });
+  const lastY = useRef(0);
+
+  useEffect(() => {
+    if (disabled) {
+      setState((s) => ({ ...s, hidden: false }));
+      return;
+    }
+
+    lastY.current = window.scrollY;
+    let frame = 0;
+
+    const update = () => {
+      frame = 0;
+      const y = window.scrollY;
+      const delta = y - lastY.current;
+      if (Math.abs(delta) < 8) return;
+
+      setState({ hidden: y >= 80 && delta > 0, scrolled: y > 0 });
+      lastY.current = y;
+    };
+
+    const onScroll = () => {
+      frame ||= window.requestAnimationFrame(update);
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (frame) window.cancelAnimationFrame(frame);
+    };
+  }, [disabled]);
+
+  return state;
+};
 
 const MobileMenuToggle = ({ open }: { open: boolean }) => (
   <div className="flex items-center lg:hidden">
@@ -45,29 +85,40 @@ const Logo = () => (
 
 export const Navbar = () => {
   return (
-    <Disclosure
-      as="header"
-      className="relative z-50 bg-alveus-green-900 text-white lg:bg-transparent"
-    >
-      {({ open }) => (
-        <>
-          <h2 className="sr-only">Page header</h2>
-
-          <div className="container mx-auto flex gap-4 p-2">
-            <Logo />
-            <DesktopMenu />
-
-            <div className="flex grow items-center justify-center text-center lg:hidden">
-              <Link href="/" className="font-serif text-3xl font-bold">
-                Alveus Sanctuary
-              </Link>
-            </div>
-            <MobileMenuToggle open={open} />
-          </div>
-
-          <MobileMenu />
-        </>
-      )}
+    <Disclosure as="header" className="sticky top-0 z-50">
+      {({ open }) => <NavbarInner open={open} />}
     </Disclosure>
+  );
+};
+
+const NavbarInner = ({ open }: { open: boolean }) => {
+  const { hidden, scrolled } = useAutoHideOnScroll(open);
+
+  return (
+    <div
+      className={classes(
+        "bg-alveus-green-900 text-white transition-transform duration-200 ease-out motion-reduce:transition-none",
+        // Desktop pages (e.g. homepage) bleed hero content under the navbar at
+        // the top, so the background only kicks in once we're scrolled.
+        scrolled || open ? "lg:bg-alveus-green-900" : "lg:bg-transparent",
+        hidden ? "-translate-y-full" : "translate-y-0",
+      )}
+    >
+      <h2 className="sr-only">Page header</h2>
+
+      <div className="container mx-auto flex gap-4 p-2">
+        <Logo />
+        <DesktopMenu />
+
+        <div className="flex grow items-center justify-center text-center lg:hidden">
+          <Link href="/" className="font-serif text-3xl font-bold">
+            Alveus Sanctuary
+          </Link>
+        </div>
+        <MobileMenuToggle open={open} />
+      </div>
+
+      <MobileMenu />
+    </div>
   );
 };

--- a/apps/website/src/components/layout/navbar/Navbar.tsx
+++ b/apps/website/src/components/layout/navbar/Navbar.tsx
@@ -83,6 +83,27 @@ const Logo = () => (
   </Link>
 );
 
+const NAV_H_MOBILE = 71;
+const NAV_H_DESKTOP = 152;
+
+const useNavHeightVar = (hidden: boolean) => {
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty(
+      "--alveus-nav-h",
+      hidden ? "0px" : `${NAV_H_MOBILE}px`,
+    );
+    root.style.setProperty(
+      "--alveus-nav-h-lg",
+      hidden ? "0px" : `${NAV_H_DESKTOP}px`,
+    );
+    return () => {
+      root.style.removeProperty("--alveus-nav-h");
+      root.style.removeProperty("--alveus-nav-h-lg");
+    };
+  }, [hidden]);
+};
+
 export const Navbar = () => {
   return (
     <Disclosure as="header" className="sticky top-0 z-50">
@@ -93,6 +114,7 @@ export const Navbar = () => {
 
 const NavbarInner = ({ open }: { open: boolean }) => {
   const { hidden, scrolled } = useAutoHideOnScroll(open);
+  useNavHeightVar(hidden);
 
   return (
     <div

--- a/apps/website/src/styles/tailwind.css
+++ b/apps/website/src/styles/tailwind.css
@@ -77,6 +77,14 @@
 
 @layer utilities {
   html {
+    /* Offset anchor-link landings by the sticky navbar height
+       (set by Navbar.tsx); falls back to 0 on pages without a navbar. */
+    scroll-padding-top: var(--alveus-nav-h, 0px);
+
+    @variant lg {
+      scroll-padding-top: var(--alveus-nav-h-lg, 0px);
+    }
+
     &:has(.html\:transparent) {
       @apply bg-transparent bg-none;
     }


### PR DESCRIPTION
## Describe your changes
#1817 

- Navbar is now sticky and auto-hides on scroll down and shows when going up
- SubNav stacks below the navbar when it's visible, sits at the top of the viewport when it's hidden. Anchor links offset by navbar height.
- Sitewide scroll-to-top button at bottom right corner. Not visible on show and tell page due to the controls used there.


## Notes for testing your change
- Scroll up/down on a long page (`/about`, `/ambassadors`) and check functionality
- Pages with `SubNav` should stack below the navbar when visible, at top when hidden.
- Click an anchor link and check if target isnt under nav
- Homepage hero should still bleed under a transparent navbar at the top.

