### PR TITLE
Add link to access existing Neon account

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -407,6 +407,11 @@ const config: NextConfig = {
       permanent: true,
     },
     {
+      source: "/donate/existing",
+      destination: "https://alveussanctuary.app.neoncrm.com",
+      permanent: true,
+    },
+    {
       source: "/github",
       destination: "https://github.com/alveusgg",
       permanent: true,

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -407,7 +407,7 @@ const config: NextConfig = {
       permanent: true,
     },
     {
-      source: "/donate/existing",
+      source: "/donate/manage",
       destination: "https://alveussanctuary.app.neoncrm.com",
       permanent: true,
     },

--- a/apps/website/src/pages/donate.tsx
+++ b/apps/website/src/pages/donate.tsx
@@ -90,7 +90,7 @@ const DonatePage: NextPage = () => {
             />
           </Consent>
 
-          <Link href="/donate/existing" external className="mt-auto text-right">
+          <Link href="/donate/manage" external className="mt-auto text-right">
             Manage your recurring donations and view donation history
           </Link>
         </div>

--- a/apps/website/src/pages/donate.tsx
+++ b/apps/website/src/pages/donate.tsx
@@ -89,6 +89,10 @@ const DonatePage: NextPage = () => {
               className="contents *:w-full *:[&_iframe]:rounded-xl *:[&_iframe]:bg-alveus-tan/50 *:[&_iframe]:backdrop-blur-md *:[&_iframe]:outline-none"
             />
           </Consent>
+
+          <Link href="/donate/existing" external className="mt-auto text-right">
+            Manage your recurring donations and view donation history
+          </Link>
         </div>
 
         <div className="col-span-full mt-6 text-sm text-alveus-green">

--- a/apps/website/src/pages/institute/pixels/[mural]/index.tsx
+++ b/apps/website/src/pages/institute/pixels/[mural]/index.tsx
@@ -247,7 +247,7 @@ const InstitutePixelsPage: NextPage<InstitutePixelsPageProps> = ({
 
                 <NeonDonateEmbed
                   form="arri"
-                  className="-mx-8 -mt-4 -mb-8 *:w-full *:[&_iframe]:outline-none"
+                  className="-mx-8 -mb-8 *:w-full *:[&_iframe]:outline-none"
                 />
               </Box>
             </Consent>


### PR DESCRIPTION
## Describe your changes

Adds a link on the donate page to allow folks to access their existing Neon account to manage recurring donations or view their donation history.

Also, removes the top margin offset on the ARRI form (#2131) as it causes issues for some of the overlays the form shows during the donation process.

## Notes for testing your change

Link works.
