### PR TITLE
Allow swapping Twitch presets embed w/ YouTube

### DIFF
--- a/apps/website/src/components/content/Select.tsx
+++ b/apps/website/src/components/content/Select.tsx
@@ -13,17 +13,7 @@ import { typeSafeObjectEntries } from "@/utils/helpers";
 import IconCheck from "@/icons/IconCheck";
 import IconChevronVertical from "@/icons/IconChevronVertical";
 
-type SelectProps = {
-  options: Record<string, string | JSX.Element>;
-  value: string;
-  onChange: (value: string) => void;
-  label?: string | JSX.Element;
-  dark?: boolean;
-  align?: "left" | "right";
-  className?: string;
-};
-
-const Select = ({
+const Select = <T extends string>({
   options,
   value,
   onChange,
@@ -31,7 +21,15 @@ const Select = ({
   dark = false,
   align = "left",
   className,
-}: SelectProps) => {
+}: {
+  options: Record<T, string | JSX.Element>;
+  value: T;
+  onChange: (value: T) => void;
+  label?: string | JSX.Element;
+  dark?: boolean;
+  align?: "left" | "right";
+  className?: string;
+}) => {
   return (
     <Listbox value={value} onChange={onChange}>
       <div className={classes("relative mt-1 flex flex-col", className)}>

--- a/apps/website/src/components/content/YouTube.tsx
+++ b/apps/website/src/components/content/YouTube.tsx
@@ -67,19 +67,20 @@ export const YouTubePreview = ({
 
 type EmbedProps = {
   videoId: string;
+  videoParams?: Record<string, string>;
   caption?: string;
 };
 
-const iframeSrc = (id: string) =>
+const iframeSrc = (id: string, params?: Record<string, string>) =>
   `https://www.youtube-nocookie.com/embed/${encodeURIComponent(
     id,
-  )}?modestbranding=1&rel=0`;
+  )}?${new URLSearchParams({ ...params, modestbranding: "1", rel: "0" }).toString()}`;
 
-export const YouTubeEmbed = ({ videoId, caption }: EmbedProps) => (
+export const YouTubeEmbed = ({ videoId, videoParams, caption }: EmbedProps) => (
   <div className="flex h-full flex-col">
     <div className="mx-auto flex aspect-video max-w-full grow">
       <iframe
-        src={iframeSrc(videoId)}
+        src={iframeSrc(videoId, videoParams)}
         title="Video embed"
         referrerPolicy="strict-origin-when-cross-origin"
         allow="fullscreen; encrypted-media"

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -6,6 +6,7 @@ import { z } from "zod";
 
 import cameras, { type Camera } from "@/data/tech/cameras";
 import { channels, scopeGroups } from "@/data/twitch";
+import { channels as youtubeChannels } from "@/data/youtube";
 
 import { classes } from "@/utils/classes";
 import { typeSafeObjectKeys } from "@/utils/helpers";
@@ -18,7 +19,9 @@ import Heading from "@/components/content/Heading";
 import Link from "@/components/content/Link";
 import Meta from "@/components/content/Meta";
 import Section from "@/components/content/Section";
+import Select from "@/components/content/Select";
 import Twitch, { TwitchChat } from "@/components/content/Twitch";
+import { YouTubeEmbed } from "@/components/content/YouTube";
 import { CamListDropdown, CamListFull } from "@/components/ptz/CamList";
 import PresetList from "@/components/ptz/PresetList";
 import ProvideAuth from "@/components/shared/LoginWithExtraScopes";
@@ -127,6 +130,13 @@ const AboutTechPresetsPage: NextPage = () => {
       window.removeEventListener("resize", handleResize);
     };
   }, [setSidebar]);
+
+  // Allow the stream player to be switched to YouTube instead of Twitch
+  const [embed, setEmbed] = useLocalStorage(
+    "presets:embed",
+    useMemo(() => z.enum(["twitch", "youtube"]), []),
+    "twitch",
+  );
 
   const split = subscription.isSuccess && subscription.data && sidebar !== -1;
 
@@ -292,22 +302,38 @@ const AboutTechPresetsPage: NextPage = () => {
                     >
                       <Field className="flex flex-wrap items-center justify-between gap-2">
                         <Label className="flex grow cursor-pointer flex-col leading-tight">
-                          <span>Enable embedded Twitch stream player</span>
+                          <span>Enable embedded stream player sidebar</span>
                           <span className="text-sm text-alveus-green-400 italic">
-                            (also embeds the {channels.alveusgg.username} stream
-                            chat)
+                            (includes the {channels.alveusgg.username} Twitch
+                            chat for commands)
                           </span>
                         </Label>
 
-                        <Switch
-                          checked={sidebar !== -1}
-                          onChange={(val) =>
-                            setSidebar(val ? sidebarDefault() : -1)
+                        <Select
+                          options={{
+                            hidden: "Hidden",
+                            twitch: "Twitch",
+                            youtube: "YouTube",
+                          }}
+                          value={sidebar === -1 ? "hidden" : embed}
+                          onChange={(val) => {
+                            if (val === "hidden") {
+                              setSidebar(-1);
+                            } else {
+                              setEmbed(val);
+                              if (sidebar === -1) {
+                                setSidebar(sidebarDefault());
+                              }
+                            }
+                          }}
+                          label={
+                            <span className="sr-only">
+                              Sidebar stream source
+                            </span>
                           }
-                          className="group inline-flex h-6 w-11 shrink-0 items-center rounded-full bg-alveus-green-300 transition-colors data-checked:bg-alveus-green"
-                        >
-                          <span className="size-4 translate-x-1 rounded-full bg-alveus-tan transition-transform group-data-checked:translate-x-6" />
-                        </Switch>
+                          align="right"
+                          className="shrink-0"
+                        />
                       </Field>
 
                       <Field className="flex flex-wrap items-center justify-between gap-2">
@@ -432,11 +458,34 @@ const AboutTechPresetsPage: NextPage = () => {
               <div className="h-1/3 max-h-full w-1 rounded-sm bg-alveus-green-200 transition-colors group-hover:bg-alveus-green-400 group-active:bg-alveus-green-400" />
             </div>
             <div
-              className="overflow-hidden rounded-l-xl bg-alveus-green-900 text-alveus-tan"
+              className="flex flex-col overflow-hidden rounded-l-xl bg-alveus-green-900 text-alveus-tan"
               style={{ width: sidebar }}
             >
-              <Consent item="stream player" consent="twitch" className="h-full">
-                <Twitch channel="alveussanctuary" />
+              {embed === "twitch" && (
+                <Consent
+                  item="stream player"
+                  consent="twitch"
+                  className="aspect-video"
+                >
+                  <Twitch channel="alveussanctuary" />
+                </Consent>
+              )}
+              {embed === "youtube" && (
+                <Consent
+                  item="stream player"
+                  consent="youtube"
+                  className="aspect-video data-consent:items-stretch"
+                >
+                  <YouTubeEmbed
+                    videoId="live_stream"
+                    videoParams={{
+                      channel: youtubeChannels.alveus.id,
+                      autoplay: "1",
+                    }}
+                  />
+                </Consent>
+              )}
+              <Consent item="stream chat" consent="twitch" className="grow">
                 <TwitchChat channel="alveusgg" dark />
               </Consent>
             </div>

--- a/apps/website/src/pages/about/tech/presets.tsx
+++ b/apps/website/src/pages/about/tech/presets.tsx
@@ -84,8 +84,8 @@ const AboutTechPresetsPage: NextPage = () => {
   const [selectedPosition, setSelectedPosition] = useState<number>();
 
   // Allow the sidebar to be resized with a draggable handle
-  const [twitchEmbed, setTwitchEmbed] = useLocalStorage(
-    "presets:twitch-embed",
+  const [sidebar, setSidebar] = useLocalStorage(
+    "presets:sidebar",
     useMemo(
       () =>
         z.number().transform((val) => (val === -1 ? -1 : sidebarClamp(val))),
@@ -103,7 +103,7 @@ const AboutTechPresetsPage: NextPage = () => {
       if (!container) return;
 
       const rect = container.getBoundingClientRect();
-      setTwitchEmbed(sidebarClamp(rect.right - e.clientX));
+      setSidebar(sidebarClamp(rect.right - e.clientX));
     };
 
     const handleMouseUp = () => {
@@ -113,7 +113,7 @@ const AboutTechPresetsPage: NextPage = () => {
     };
 
     const handleResize = () => {
-      setTwitchEmbed((prev) => (prev === -1 ? -1 : sidebarClamp(prev)));
+      setSidebar((prev) => (prev === -1 ? -1 : sidebarClamp(prev)));
     };
     handleResize();
 
@@ -126,10 +126,9 @@ const AboutTechPresetsPage: NextPage = () => {
       window.removeEventListener("mouseup", handleMouseUp);
       window.removeEventListener("resize", handleResize);
     };
-  }, [setTwitchEmbed]);
+  }, [setSidebar]);
 
-  const sidebar =
-    subscription.isSuccess && subscription.data && twitchEmbed !== -1;
+  const split = subscription.isSuccess && subscription.data && sidebar !== -1;
 
   return (
     <>
@@ -173,7 +172,7 @@ const AboutTechPresetsPage: NextPage = () => {
         <Section
           className={classes(
             "@container z-10 grow py-0 pt-4",
-            sidebar && "rounded-r-xl",
+            split && "rounded-r-xl",
           )}
           containerClassName="h-full flex flex-col"
         >
@@ -301,9 +300,9 @@ const AboutTechPresetsPage: NextPage = () => {
                         </Label>
 
                         <Switch
-                          checked={twitchEmbed !== -1}
+                          checked={sidebar !== -1}
                           onChange={(val) =>
-                            setTwitchEmbed(val ? sidebarDefault() : -1)
+                            setSidebar(val ? sidebarDefault() : -1)
                           }
                           className="group inline-flex h-6 w-11 shrink-0 items-center rounded-full bg-alveus-green-300 transition-colors data-checked:bg-alveus-green"
                         >
@@ -420,7 +419,7 @@ const AboutTechPresetsPage: NextPage = () => {
           </div>
         </Section>
 
-        {sidebar && (
+        {split && (
           <div className="flex" ref={sidebarContainer}>
             <div
               className="group flex cursor-ew-resize items-center justify-center px-2 py-4 select-none"
@@ -434,7 +433,7 @@ const AboutTechPresetsPage: NextPage = () => {
             </div>
             <div
               className="overflow-hidden rounded-l-xl bg-alveus-green-900 text-alveus-tan"
-              style={{ width: twitchEmbed }}
+              style={{ width: sidebar }}
             >
               <Consent item="stream player" consent="twitch" className="h-full">
                 <Twitch channel="alveussanctuary" />


### PR DESCRIPTION
## Describe your changes

With the subathon currently happening on Twitch, the livecams are only on YouTube, but can still be controlled from the AlveusGG chat. So, allowing folks to switch the presets page over to using the YouTube livestream instead.

## Notes for testing your change

Sidebar width can still be changed, sidebar can be hidden or swapped between Twitch + YouTube.
