### PR TITLE
Grant CI packages: read permission

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   prettier:

--- a/.github/workflows/update-donations-worker.yml
+++ b/.github/workflows/update-donations-worker.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   deploy:
     name: Deploy (${{ (github.ref == 'refs/heads/main' && 'production') || 'preview' }})

--- a/.github/workflows/update-presets.yml
+++ b/.github/workflows/update-presets.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   update:


### PR DESCRIPTION
## Describe your changes

We've been seeing CI failures recently when pnpm attempts to install the `@alveusgg/data` package from GitHub Package Registry. I suspect it might be due to the token not explicitly having the `packages: read` scope, perhaps fallout from #2127 or a change GitHub made to access checks.

## Notes for testing your change

CI works, I cleared the Actions cache before this PR.
