### PR TITLE
Pass GITHUB_TOKEN to Docker build for chatbot deps install

### DIFF
--- a/.github/workflows/update-chatbot.yml
+++ b/.github/workflows/update-chatbot.yml
@@ -16,8 +16,10 @@ env:
   CHATBOT_PATH: ${{ vars.CHATBOT_PATH }}
   REF_NAME: ${{ github.ref_name }}
   REF_SHA: ${{ github.sha }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-permissions: {}
+permissions:
+  packages: read
 
 jobs:
   update-chatbot-production:
@@ -29,7 +31,7 @@ jobs:
       - name: Update Chatbot SSH (Production)
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
-          envs: COMPOSE_PROJECT_NAME,CHATBOT_PATH,REF_NAME,REF_SHA
+          envs: COMPOSE_PROJECT_NAME,CHATBOT_PATH,REF_NAME,REF_SHA,GITHUB_TOKEN
           host: ${{ secrets.CHATBOT_HOST }}
           username: ${{ secrets.CHATBOT_USERNAME }}
           key: ${{ secrets.CHATBOT_KEY }}
@@ -51,7 +53,7 @@ jobs:
       - name: Update Chatbot SSH (Preview)
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
-          envs: COMPOSE_PROJECT_NAME,CHATBOT_PATH,REF_NAME,REF_SHA
+          envs: COMPOSE_PROJECT_NAME,CHATBOT_PATH,REF_NAME,REF_SHA,GITHUB_TOKEN
           host: ${{ secrets.CHATBOT_HOST }}
           username: ${{ secrets.CHATBOT_USERNAME }}
           key: ${{ secrets.CHATBOT_KEY }}

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -25,7 +25,12 @@ COPY ./apps/chatbot/.env .
 
 ## Install dependencies
 RUN npm install -g corepack@latest && corepack enable && corepack install
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --filter "{.}..."
+RUN --mount=type=secret,id=github_token,target=/tmp/github_token \
+		--mount=type=cache,id=pnpm,target=/pnpm/store \
+    set -eu; \
+		printf "//npm.pkg.github.com/:_authToken=%s\\n" "$(cat /tmp/github_token)" > "$HOME/.npmrc"; \
+    pnpm install --frozen-lockfile --filter "{.}..."; \
+    rm -f "$HOME/.npmrc"
 
 ## Copy code
 COPY ./apps/chatbot/src/ src/

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -5,6 +5,7 @@ ENV PATH="$PNPM_HOME:$PATH"
 
 ## Copy root files
 WORKDIR /app
+COPY ./.npmrc .
 COPY ./package.json .
 COPY ./pnpm-lock.yaml .
 COPY ./pnpm-workspace.yaml .

--- a/apps/chatbot/docker-compose.yaml
+++ b/apps/chatbot/docker-compose.yaml
@@ -3,6 +3,12 @@ services:
     build:
       context: ../..
       dockerfile: apps/chatbot/Dockerfile
+      secrets:
+        - github_token
     restart: always
     environment:
       - CHATBOT_REF_SHA=$CHATBOT_REF_SHA
+
+secrets:
+  github_token:
+    environment: GITHUB_TOKEN


### PR DESCRIPTION
## Describe your changes

With #2135 landed, pnpm is now doing additional checks during a frozen installation, so we need to pass in a token for it.

## Notes for testing your change

Chatbot deployment works.