### PR TITLE
Fix rendering Show and Tell descriptions

### DIFF
--- a/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
+++ b/apps/website/src/components/show-and-tell/ShowAndTellEntry.tsx
@@ -2,7 +2,6 @@ import parse, {
   type DOMNode,
   Element,
   type HTMLReactParserOptions,
-  Text,
   domToReact,
 } from "html-react-parser";
 import Image from "next/image";
@@ -46,7 +45,8 @@ const getTextContentRecursive = (node: DOMNode): string => {
       .join("");
   }
 
-  if (node instanceof Text) {
+  // FIXME: Switch back to `instanceof Text` once https://github.com/remarkablemark/html-react-parser/issues/2256 resolved
+  if (node.type === "text") {
     return node.data || "";
   }
 


### PR DESCRIPTION
## Describe your changes

Workaround to https://github.com/remarkablemark/html-react-parser/issues/2256 for now.

## Notes for testing your change

Show and Tell descriptions render.
