### PR TITLE
Bump pnpm from 11.3.0 to 11.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   },
   "engines": {
     "node": ">=24.11.0",
-    "pnpm": "^11.3.0"
+    "pnpm": "^11.5.1"
   },
-  "packageManager": "pnpm@11.3.0",
+  "packageManager": "pnpm@11.5.1",
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",


### PR DESCRIPTION
Generated via `pnpm self-update`.

Check this workflow's logs at https://github.com/alveusgg/alveusgg/actions/runs/26955085272.