### PR TITLE
Treat community map locations as plain-text

### DIFF
--- a/apps/website/src/components/show-and-tell/CommunityMap.tsx
+++ b/apps/website/src/components/show-and-tell/CommunityMap.tsx
@@ -173,7 +173,7 @@ export function CommunityMap({
         }
         popup
           .setLngLat(coordinates)
-          .setHTML(feature.properties.name)
+          .setText(feature.properties.name)
           .addTo(map);
       }
     });


### PR DESCRIPTION
## Describe your changes

We were previously rendering the location from the DB as HTML on the map page. This allowed for a potential stored XSS if a moderator approved a post with HTML in the location (this would be unlikely as it renders in plain text in preview, so any HTML would be very obvious there).

## Notes for testing your change

Any HTML included in the location DB payload is rendered in plain text.