### PR TITLE
Bump pnpm from 11.5.1 to 11.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   },
   "engines": {
     "node": ">=24.11.0",
-    "pnpm": "^11.5.1"
+    "pnpm": "^11.5.2"
   },
-  "packageManager": "pnpm@11.5.1",
+  "packageManager": "pnpm@11.5.2",
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",


### PR DESCRIPTION
Generated via `pnpm self-update`.

Check this workflow's logs at https://github.com/alveusgg/alveusgg/actions/runs/27139271485.