### PR TITLE
Fix calender event title wrapping with long words

### DIFF
--- a/apps/website/src/components/calendar/CalendarItem.tsx
+++ b/apps/website/src/components/calendar/CalendarItem.tsx
@@ -36,7 +36,7 @@ export function CalendarItem({
       custom
       {...props}
     >
-      <p className="font-semibold">{event.title}</p>
+      <p className="font-semibold wrap-break-word">{event.title}</p>
       {event.hasTime && (
         <p className="text-sm tabular-nums">
           {event.startAt.toLocaleTimeString(


### PR DESCRIPTION
## Describe your changes

fix this text wrapping
<img width="323" height="234" alt="screenshot showing overflowed text" src="https://github.com/user-attachments/assets/c937ef54-74b0-4cde-b848-ab85dae6d215" />


...

## Notes for testing your change

...
