### PR TITLE
Escape Excel formula in CSV exports

### DIFF
--- a/apps/website/src/pages/api/admin/bingo/[bingoId]/export-entries.ts
+++ b/apps/website/src/pages/api/admin/bingo/[bingoId]/export-entries.ts
@@ -80,13 +80,17 @@ const exportBingoEntries = async (
     "claimedAt",
   ]);
 
-  const csv = stringify(rows);
+  const csv = stringify(rows, {
+    bom: true,
+    escape_formulas: true,
+    quoted_string: true,
+  });
 
   res
     .status(200)
     .setHeader("Content-Type", "text/csv")
     .setHeader("Content-Disposition", `attachment; filename=bingo-entries.csv`)
-    .send("\ufeff" + csv); // add utf-8 BOM for Excel to correctly open the CSV
+    .send(csv);
 };
 
 export default exportBingoEntries;

--- a/apps/website/src/pages/api/admin/forms/[formId]/export-entries.ts
+++ b/apps/website/src/pages/api/admin/forms/[formId]/export-entries.ts
@@ -58,13 +58,17 @@ const exportFormEntries = async (req: NextApiRequest, res: NextApiResponse) => {
     "country",
   ]);
 
-  const csv = stringify(rows);
+  const csv = stringify(rows, {
+    bom: true,
+    escape_formulas: true,
+    quoted_string: true,
+  });
 
   res
     .status(200)
     .setHeader("Content-Type", "text/csv")
     .setHeader("Content-Disposition", `attachment; filename=form-entries.csv`)
-    .send("\ufeff" + csv); // add utf-8 BOM for Excel to correctly open the CSV
+    .send(csv);
 };
 
 export default exportFormEntries;


### PR DESCRIPTION
## Describe your changes

If a user were to, for some reason, set their name to `=1+1` or some other formula, the generated CSV would contain this value unescaped. If someone were to then open that CSV in Excel etc., the formula would be evaluated. Given we know we're always wanting to generate plain CSVs with no formula, we can set the CSV library's flag for escaping all formulas, and while we're here, we can also tell it to always quote strings for a bit of additional safety.

_Also, the CSV library has a built-in flag for the BOM marker, so we don't need to inject it manually!_

## Notes for testing your change

All strings in CSV output are now quoted, and any formula-like values are escaped.