### PR TITLE
Fix nav active when anchor/query used

### DIFF
--- a/apps/website/src/hooks/active.ts
+++ b/apps/website/src/hooks/active.ts
@@ -27,26 +27,27 @@ export const useActiveNav = () => {
   const { asPath } = useRouter();
 
   // Find the path with the most matching segments in the nav structure
-  return useMemo(
-    () =>
-      flatNavStructure.reduce(
-        ({ path, segments }, link) => {
-          const linkSegments = link.split("/").filter(Boolean);
-          const pathSegments = asPath.split("/").filter(Boolean);
+  return useMemo(() => {
+    const pathSegments = asPath
+      .replace(/[#?].*$/, "")
+      .split("/")
+      .filter(Boolean);
+    return flatNavStructure.reduce(
+      ({ path, segments }, link) => {
+        const linkSegments = link.split("/").filter(Boolean);
 
-          const invalidSegment = linkSegments.findIndex(
-            (seg, i) => seg !== pathSegments[i],
-          );
-          const matchSegments =
-            invalidSegment === -1 ? linkSegments.length : invalidSegment;
+        const invalidSegment = linkSegments.findIndex(
+          (seg, i) => seg !== pathSegments[i],
+        );
+        const matchSegments =
+          invalidSegment === -1 ? linkSegments.length : invalidSegment;
 
-          if (matchSegments > segments) {
-            return { path: link, segments: matchSegments };
-          }
-          return { path, segments };
-        },
-        { path: "/", segments: 0 },
-      ).path,
-    [asPath],
-  );
+        if (matchSegments > segments) {
+          return { path: link, segments: matchSegments };
+        }
+        return { path, segments };
+      },
+      { path: "/", segments: 0 },
+    ).path;
+  }, [asPath]);
 };


### PR DESCRIPTION
## Describe your changes

We need to use `asPath` rather than `pathname` as we want the exact URL for dynamic routes. However, that also means that any anchor/query is included, so we need to strip that out before doing anything with `asPath`.

## Notes for testing your change

Access the ambassadors page, observe ambassadors active in nav. Switch grouping dropdown to classification, observe anchor in URL, observe ambassadors still active in nav.
