### PR TITLE
Save twitch subs as donations

### DIFF
--- a/apps/database/src/schema.prisma
+++ b/apps/database/src/schema.prisma
@@ -492,6 +492,7 @@ model Donation {
   pixels Pixel[]
 
   @@index([receivedAt(sort: Desc)], name: "Donation_recent")
+  @@index([provider, receivedAt(sort: Desc)], name: "Donation_providerAndRecent")
 }
 
 model Pixel {

--- a/apps/database/src/schema.prisma
+++ b/apps/database/src/schema.prisma
@@ -491,8 +491,7 @@ model Donation {
 
   pixels Pixel[]
 
-  @@index([receivedAt(sort: Desc)], name: "Donation_recent")
-  @@index([provider, receivedAt(sort: Desc)], name: "Donation_providerAndRecent")
+  @@index([receivedAt(sort: Desc), provider], name: "Donation_recent")
 }
 
 model Pixel {

--- a/apps/donations/core/src/index.ts
+++ b/apps/donations/core/src/index.ts
@@ -51,7 +51,7 @@ export const Providers = z.literal([
   "paypal",
   "thegivingblock",
   "neon",
-  "twitchsubscriber",
+  "twitchsubscription",
 ]);
 export type Providers = z.infer<typeof Providers>;
 
@@ -123,11 +123,15 @@ const TwitchSubscriptionDonationMetadataSchema = z.object({
   twitchDonatorDisplayName: z.string(),
   twitchBroadcasterId: z.string(),
   twitchSubscription: z.object({
-    subType: z.literal(["prime", "sub", "resub", "gift"]),
-    tier: z.string(),
+    type: z.literal(["gift", "resubscription", "subscription"]),
+    isGift: z.boolean().optional(),
+    tier: z.literal(["1000", "2000", "3000"]),
     total: z.number().optional(),
     cumulativeTotal: z.number().optional(),
-    anonymous: z.boolean().optional(),
+    cumulativeMonths: z.number().optional(),
+    streakMonths: z.number().optional(),
+    durationMonths: z.number().optional(),
+    isAnonymous: z.boolean().optional(),
   }),
 });
 

--- a/apps/donations/core/src/index.ts
+++ b/apps/donations/core/src/index.ts
@@ -51,6 +51,7 @@ export const Providers = z.literal([
   "paypal",
   "thegivingblock",
   "neon",
+  "twitchsubscriber",
 ]);
 export type Providers = z.infer<typeof Providers>;
 
@@ -117,11 +118,33 @@ export const NeonDonationSchema = CoreDonationSchema.extend({
 });
 export type NeonDonation = z.infer<typeof NeonDonationSchema>;
 
+const TwitchSubscriptionDonationMetadataSchema = z.object({
+  twitchDonatorId: z.string(),
+  twitchDonatorDisplayName: z.string(),
+  twitchBroadcasterId: z.string(),
+  twitchSubscription: z.object({
+    subType: z.literal(["prime", "sub", "resub", "gift"]),
+    tier: z.string(),
+    total: z.number().optional(),
+    cumulativeTotal: z.number().optional(),
+    anonymous: z.boolean().optional(),
+  }),
+});
+
+export const TwitchSubscriptionDonationSchema = CoreDonationSchema.extend({
+  provider: z.literal("twitchsubscription"),
+  providerMetadata: TwitchSubscriptionDonationMetadataSchema,
+});
+export type TwitchSubscriptionDonation = z.infer<
+  typeof TwitchSubscriptionDonationSchema
+>;
+
 export const DonationSchema = z.discriminatedUnion("provider", [
   TwitchDonationSchema,
   PaypalDonationSchema,
   TheGivingBlockDonationSchema,
   NeonDonationSchema,
+  TwitchSubscriptionDonationSchema,
 ]);
 
 export type Donation = z.infer<typeof DonationSchema>;

--- a/apps/donations/core/src/index.ts
+++ b/apps/donations/core/src/index.ts
@@ -119,19 +119,19 @@ export const NeonDonationSchema = CoreDonationSchema.extend({
 export type NeonDonation = z.infer<typeof NeonDonationSchema>;
 
 const TwitchSubscriptionDonationMetadataSchema = z.object({
-  twitchDonatorId: z.string(),
-  twitchDonatorDisplayName: z.string(),
+  twitchDonatorId: z.string().optional().nullable(),
+  twitchDonatorDisplayName: z.string().optional().nullable(),
   twitchBroadcasterId: z.string(),
   twitchSubscription: z.object({
     type: z.literal(["gift", "resubscription", "subscription"]),
     isGift: z.boolean().optional(),
     tier: z.literal(["1000", "2000", "3000"]),
-    total: z.number().optional(),
-    cumulativeTotal: z.number().optional(),
-    cumulativeMonths: z.number().optional(),
-    streakMonths: z.number().optional(),
-    durationMonths: z.number().optional(),
-    isAnonymous: z.boolean().optional(),
+    total: z.number().optional().nullable(),
+    cumulativeTotal: z.number().optional().nullable(),
+    cumulativeMonths: z.number().optional().nullable(),
+    streakMonths: z.number().optional().nullable(),
+    durationMonths: z.number().optional().nullable(),
+    isAnonymous: z.boolean().optional().nullable(),
   }),
 });
 

--- a/apps/donations/worker/src/managers/donations.ts
+++ b/apps/donations/worker/src/managers/donations.ts
@@ -17,6 +17,7 @@ import {
   createSharedKeyMiddleware,
   setSentryTagsMiddleware,
 } from "../utils/middleware";
+import { TwitchSubscriptionDonationProvider } from "../providers/twitch/subscription";
 import { getSentryConfig } from "../utils/sentry";
 
 type DonationProviders = Partial<
@@ -100,13 +101,20 @@ class DonationsManagerDurableObjectBase extends DurableObject<Env> {
       this.env.DONATION_QUEUE,
     );
 
-    const [twitchProvider, paypalProvider, neonProvider] = await Promise.all([
+    const [
+      twitchSubscriptionProvider,
+      twitchProvider,
+      paypalProvider,
+      neonProvider,
+    ] = await Promise.all([
+      TwitchSubscriptionDonationProvider.init(storage, this.env),
       TwitchDonationProvider.init(storage, this.env),
       PaypalDonationProvider.init(storage, this.env),
       NeonDonationProvider.init(storage, this.env),
     ]);
 
     this.providers = {
+      twitchsubscription: twitchSubscriptionProvider,
       twitch: twitchProvider,
       paypal: paypalProvider,
       neon: neonProvider,

--- a/apps/donations/worker/src/providers/twitch/crypto.ts
+++ b/apps/donations/worker/src/providers/twitch/crypto.ts
@@ -45,9 +45,3 @@ export async function verifySignature(request: Request, secret: string) {
   );
   return signature === expectedSignature;
 }
-
-export async function sha256(message: string): Promise<string> {
-  const data = new TextEncoder().encode(message);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  return arrayBufferToHex(hashBuffer);
-}

--- a/apps/donations/worker/src/providers/twitch/crypto.ts
+++ b/apps/donations/worker/src/providers/twitch/crypto.ts
@@ -45,3 +45,9 @@ export async function verifySignature(request: Request, secret: string) {
   );
   return signature === expectedSignature;
 }
+
+export async function sha256(message: string): Promise<string> {
+  const data = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return arrayBufferToHex(hashBuffer);
+}

--- a/apps/donations/worker/src/providers/twitch/schema.ts
+++ b/apps/donations/worker/src/providers/twitch/schema.ts
@@ -6,8 +6,15 @@ export const TwitchChallengePayload = z.object({
 export const TwitchSubscriptionPayload = z.object({
   id: z.string(),
   type: z
-    .literal("channel.charity_campaign.donate")
-    .describe("Only channel.charity_campaign.donate events are supported."),
+    .literal([
+      "channel.charity_campaign.donate",
+      "channel.subscribe",
+      "channel.subscription.gift",
+      "channel.subscription.message",
+    ])
+    .describe(
+      "Only channel.charity_campaign.donate, channel.subscribe, channel.subscription.gift, and channel.subscription.message events are supported.",
+    ),
   version: z.string(),
   status: z.string(),
   condition: z.object({
@@ -17,6 +24,7 @@ export const TwitchSubscriptionPayload = z.object({
     method: z.string(),
     callback: z.string(),
   }),
+  created_at: z.iso.datetime(),
 });
 
 export const TwitchAmountPayload = z.object({
@@ -31,7 +39,7 @@ export const TwitchAmountPayload = z.object({
     ),
 });
 
-export const TwitchCharityDonationEventPayload = z.object({
+export const TwitchDonationEventPayload = z.object({
   id: z.string(),
   campaign_id: z.string(),
   broadcaster_user_id: z.string(),
@@ -42,52 +50,28 @@ export const TwitchCharityDonationEventPayload = z.object({
   amount: TwitchAmountPayload,
 });
 
-export const TwitchNewSubscriptionEventPayload = z.object({
-  id: z.string(),
-  campaign_id: z.string(),
+export const TwitchSubscriptionDonationEventPayload = z.object({
   broadcaster_user_id: z.string(),
   user_id: z.string(),
   user_login: z.string(),
   user_name: z.string(),
-  tier: z.number(),
-  is_gift: z.boolean(),
-});
-
-export const TwitchReSubscriptionEventPayload = z.object({
-  id: z.string(),
-  campaign_id: z.string(),
-  broadcaster_user_id: z.string(),
-  user_id: z.string(),
-  user_login: z.string(),
-  user_name: z.string(),
-  tier: z.number(),
+  tier: z.literal(["1000", "2000", "3000"]),
+  is_gift: z.boolean().optional(),
+  total: z.number().optional(),
+  cumulative_total: z.number().optional(),
+  cumulative_months: z.number().optional(),
+  is_anonymous: z.boolean().optional(),
   message: z.object().optional(),
-  cumulative_months: z.number(),
-  streak_months: z.number(),
-  duration_months: z.number(),
+  streak_months: z.number().optional(),
+  duration_months: z.number().optional(),
 });
-
-export const TwitchGiftSubscriptionEventPayload = z.object({
-  id: z.string(),
-  campaign_id: z.string(),
-  broadcaster_user_id: z.string(),
-  user_id: z.string(),
-  user_login: z.string(),
-  user_name: z.string(),
-  tier: z.number(),
-  total: z.number(),
-  cumulative_total: z.number(),
-  is_anonymous: z.boolean(),
-});
-
-export const TwitchEventPayload = z.xor([
-  TwitchCharityDonationEventPayload,
-  TwitchNewSubscriptionEventPayload,
-  TwitchReSubscriptionEventPayload,
-  TwitchGiftSubscriptionEventPayload,
-]);
 
 export const TwitchNotificationPayload = z.object({
   subscription: TwitchSubscriptionPayload,
-  event: TwitchEventPayload,
+  event: TwitchDonationEventPayload,
+});
+
+export const TwitchSubscriptionNotificationPayload = z.object({
+  subscription: TwitchSubscriptionPayload,
+  event: TwitchSubscriptionDonationEventPayload,
 });

--- a/apps/donations/worker/src/providers/twitch/schema.ts
+++ b/apps/donations/worker/src/providers/twitch/schema.ts
@@ -31,7 +31,7 @@ export const TwitchAmountPayload = z.object({
     ),
 });
 
-export const TwitchEventPayload = z.object({
+export const TwitchCharityDonationEventPayload = z.object({
   id: z.string(),
   campaign_id: z.string(),
   broadcaster_user_id: z.string(),
@@ -41,6 +41,51 @@ export const TwitchEventPayload = z.object({
   charity_name: z.string(),
   amount: TwitchAmountPayload,
 });
+
+export const TwitchNewSubscriptionEventPayload = z.object({
+  id: z.string(),
+  campaign_id: z.string(),
+  broadcaster_user_id: z.string(),
+  user_id: z.string(),
+  user_login: z.string(),
+  user_name: z.string(),
+  tier: z.number(),
+  is_gift: z.boolean(),
+});
+
+export const TwitchReSubscriptionEventPayload = z.object({
+  id: z.string(),
+  campaign_id: z.string(),
+  broadcaster_user_id: z.string(),
+  user_id: z.string(),
+  user_login: z.string(),
+  user_name: z.string(),
+  tier: z.number(),
+  message: z.object().optional(),
+  cumulative_months: z.number(),
+  streak_months: z.number(),
+  duration_months: z.number(),
+});
+
+export const TwitchGiftSubscriptionEventPayload = z.object({
+  id: z.string(),
+  campaign_id: z.string(),
+  broadcaster_user_id: z.string(),
+  user_id: z.string(),
+  user_login: z.string(),
+  user_name: z.string(),
+  tier: z.number(),
+  total: z.number(),
+  cumulative_total: z.number(),
+  is_anonymous: z.boolean(),
+});
+
+export const TwitchEventPayload = z.xor([
+  TwitchCharityDonationEventPayload,
+  TwitchNewSubscriptionEventPayload,
+  TwitchReSubscriptionEventPayload,
+  TwitchGiftSubscriptionEventPayload,
+]);
 
 export const TwitchNotificationPayload = z.object({
   subscription: TwitchSubscriptionPayload,

--- a/apps/donations/worker/src/providers/twitch/schema.ts
+++ b/apps/donations/worker/src/providers/twitch/schema.ts
@@ -52,18 +52,18 @@ export const TwitchDonationEventPayload = z.object({
 
 export const TwitchSubscriptionDonationEventPayload = z.object({
   broadcaster_user_id: z.string(),
-  user_id: z.string(),
-  user_login: z.string(),
-  user_name: z.string(),
+  user_id: z.string().optional().nullable(),
+  user_login: z.string().optional().nullable(),
+  user_name: z.string().optional().nullable(),
   tier: z.literal(["1000", "2000", "3000"]),
   is_gift: z.boolean().optional(),
-  total: z.number().optional(),
-  cumulative_total: z.number().optional(),
-  cumulative_months: z.number().optional(),
+  total: z.number().optional().nullable(),
+  cumulative_total: z.number().optional().nullable(),
+  cumulative_months: z.number().optional().nullable(),
   is_anonymous: z.boolean().optional(),
-  message: z.object().optional(),
-  streak_months: z.number().optional(),
-  duration_months: z.number().optional(),
+  message: z.record(z.string(), z.unknown()).optional().nullable(),
+  streak_months: z.number().optional().nullable(),
+  duration_months: z.number().optional().nullable(),
 });
 
 export const TwitchNotificationPayload = z.object({

--- a/apps/donations/worker/src/providers/twitch/subscription.ts
+++ b/apps/donations/worker/src/providers/twitch/subscription.ts
@@ -7,7 +7,11 @@ import { createTRPCProxyClient, httpLink } from "@trpc/client";
 import superjson from "superjson";
 import type { DonationProvider } from "..";
 import type { DonationStorage } from "../storage";
-import { TwitchEventHubMessageTypeHeader } from "./const";
+import {
+  TwitchEventHubMessageTypeHeader,
+  TwitchEventHubMessageIdHeader,
+  TwitchEventHubMessageTimestampHeader,
+} from "./const";
 import { verifySignature } from "./crypto";
 import {
   TwitchChallengePayload,
@@ -111,6 +115,12 @@ export class TwitchSubscriptionDonationProvider implements DonationProvider {
       return new Response(null, { status: 201 });
     }
 
+    const uniqueMessageId = request.headers.get(TwitchEventHubMessageIdHeader);
+    if (!uniqueMessageId) {
+      await this.clear();
+      return new Response(null, { status: 400 });
+    }
+
     if (type === "notification") {
       const payload = TwitchSubscriptionNotificationPayload.safeParse(body);
 
@@ -129,10 +139,14 @@ export class TwitchSubscriptionDonationProvider implements DonationProvider {
         return Response.json({ success: true }, { status: 201 });
       }
 
+      const messageTimestamp = request.headers.get(
+        TwitchEventHubMessageTimestampHeader,
+      );
+
       const donation = {
         id: crypto.randomUUID(),
         provider: "twitchsubscription",
-        providerUniqueId: request.headers.get("twitch-eventsub-message-id")!,
+        providerUniqueId: uniqueMessageId,
         providerMetadata: {
           twitchDonatorId: payload.data.event.user_id,
           twitchDonatorDisplayName: payload.data.event.user_name,
@@ -152,9 +166,7 @@ export class TwitchSubscriptionDonationProvider implements DonationProvider {
         // Explicitly set amount to 0 because we have no way of determining the monetary
         // amount of any sub/resub/giftsub
         amount: 0,
-        receivedAt: new Date(
-          request.headers.get("twitch-eventsub-message-timestamp")!,
-        ),
+        receivedAt: messageTimestamp ? new Date(messageTimestamp) : new Date(),
         donatedBy: {
           primary: "username",
           username: payload.data.event.user_login,

--- a/apps/donations/worker/src/providers/twitch/subscription.ts
+++ b/apps/donations/worker/src/providers/twitch/subscription.ts
@@ -1,40 +1,41 @@
 import type { AppRouter } from "@alveusgg/alveusgg-website";
-import type { Providers, TwitchDonation } from "@alveusgg/donations-core";
+import type {
+  Providers,
+  TwitchSubscriptionDonation,
+} from "@alveusgg/donations-core";
 import { createTRPCProxyClient, httpLink } from "@trpc/client";
 import superjson from "superjson";
 import type { DonationProvider } from "..";
 import type { DonationStorage } from "../storage";
 import { TwitchEventHubMessageTypeHeader } from "./const";
-import { verifySignature } from "./crypto";
-import { TwitchChallengePayload, TwitchNotificationPayload } from "./schema";
+import { verifySignature, sha256 } from "./crypto";
+import {
+  TwitchChallengePayload,
+  TwitchSubscriptionNotificationPayload,
+} from "./schema";
+import type { TwitchDonationProviderConfig } from "./twitch.ts";
 
-export interface TwitchDonationProviderConfig {
-  secret: string;
-}
+const subscriptionType = (type: string) => {
+  if (type === "channel.subscription.gift") return "gift";
+  if (type === "channel.subscription.message") return "resubscription";
+  return "subscription";
+};
 
-interface TwitchDonationProviderOptions {
-  sandbox: boolean;
-  allowedCharityName: string;
-}
-
-export class TwitchDonationProvider implements DonationProvider {
-  name: Providers = "twitch";
+export class TwitchSubscriptionDonationProvider implements DonationProvider {
+  name: Providers = "twitchsubscription";
   constructor(
     private config: TwitchDonationProviderConfig,
-    private options: TwitchDonationProviderOptions,
     private service: DonationStorage,
   ) {}
 
   static async init(
     service: DonationStorage,
     env: Env,
-  ): Promise<TwitchDonationProvider> {
-    const options: TwitchDonationProviderOptions = {
-      sandbox: env.SANDBOX === "true",
-      allowedCharityName: env.TWITCH_CHARITY_NAME!,
-    };
+  ): Promise<TwitchSubscriptionDonationProvider> {
     const config =
-      await service.config.get<TwitchDonationProviderConfig>("twitch");
+      await service.config.get<TwitchDonationProviderConfig>(
+        "twitchsubscription",
+      );
     if (!config) {
       const headers: Record<string, string> = {};
       if (env.OPTIONAL_VERCEL_PROTECTION_BYPASS) {
@@ -63,15 +64,15 @@ export class TwitchDonationProvider implements DonationProvider {
       const config = {
         secret: env.TWITCH_SUBSCRIPTION_SECRET,
       } as const satisfies TwitchDonationProviderConfig;
-      await service.config.set("twitch", config);
+      await service.config.set("twitchsubscription", config);
 
-      return new TwitchDonationProvider(config, options, service);
+      return new TwitchSubscriptionDonationProvider(config, service);
     }
-    return new TwitchDonationProvider(config, options, service);
+    return new TwitchSubscriptionDonationProvider(config, service);
   }
 
   async clear() {
-    await this.service.config.set("twitch", undefined);
+    await this.service.config.set("twitchsubscription", undefined);
   }
 
   async handle(request: Request): Promise<Response> {
@@ -111,7 +112,7 @@ export class TwitchDonationProvider implements DonationProvider {
     }
 
     if (type === "notification") {
-      const payload = TwitchNotificationPayload.safeParse(body);
+      const payload = TwitchSubscriptionNotificationPayload.safeParse(body);
 
       if (!payload.success) {
         return new Response(
@@ -122,35 +123,50 @@ export class TwitchDonationProvider implements DonationProvider {
         );
       }
 
-      if (payload.data.event.charity_name !== this.options.allowedCharityName) {
-        // Only Alveus donations are supported. We ignore others.
-        console.log(
-          `Ignoring donation from ${payload.data.event.charity_name} because it is not the allowed charity name (${this.options.allowedCharityName}).`,
-        );
+      if (payload.data.event.is_gift) {
+        // We do not want to store users who were gifted.
+        // We store the original webhook event.
         return Response.json({ success: true }, { status: 201 });
       }
 
       const donation = {
         id: crypto.randomUUID(),
-        provider: "twitch",
-        providerUniqueId: payload.data.event.id,
+        provider: "twitchsubscription",
+        // Twitch subscription messages do not include an id field.
+        // We create a sha256 hash of user_id and when the notification was
+        // created.
+        providerUniqueId: await sha256(
+          `${payload.data.event.user_id}-${payload.data.subscription.created_at}`,
+        ),
         providerMetadata: {
           twitchDonatorId: payload.data.event.user_id,
           twitchDonatorDisplayName: payload.data.event.user_name,
           twitchBroadcasterId: payload.data.event.broadcaster_user_id,
-          twitchCharityCampaignId: payload.data.event.campaign_id,
+          twitchSubscription: {
+            type: subscriptionType(payload.data.subscription.type),
+            cumulativeTotal: payload.data.event.cumulative_total,
+            cumulativeMonths: payload.data.event.cumulative_months,
+            durationMonths: payload.data.event.duration_months,
+            isGift: payload.data.event.is_gift,
+            isAnonymous: payload.data.event.is_anonymous,
+            streakMonths: payload.data.event.streak_months,
+            tier: payload.data.event.tier,
+            total: payload.data.event.total,
+          },
         },
-        amount: payload.data.event.amount.value,
+        // Explicitly set amount to 0 because we have no way of determining the monitary
+        // amount of any sub/resub/giftsub
+        amount: 0,
         receivedAt: new Date(),
+        donatedAt: new Date(),
         donatedBy: {
           primary: "username",
           username: payload.data.event.user_login,
         },
         tags: {
           twitchBroadcasterId: payload.data.event.broadcaster_user_id,
-          twitchCharityCampaignId: payload.data.event.campaign_id,
         },
-      } satisfies TwitchDonation;
+      } satisfies TwitchSubscriptionDonation;
 
       await this.service.add(donation);
 
@@ -184,9 +200,23 @@ async function setupTwitchSubscription(
     ],
   });
 
+  await Promise.all([
+    subscribeToWebhook(api, "channel.subscribe", selfUrl, secret),
+    subscribeToWebhook(api, "channel.subscription.gift", selfUrl, secret),
+    subscribeToWebhook(api, "channel.subscription.message", selfUrl, secret),
+  ]);
+}
+
+async function subscribeToWebhook(
+  api: ReturnType<typeof createTRPCProxyClient<AppRouter>>,
+  type: string,
+  selfUrl: string,
+  secret: string,
+) {
   await api.adminTwitch.setupWebhookSubscription.mutate({
-    event: { type: "channel.charity_campaign.donate", version: "1" },
-    url: `${selfUrl}/donations/twitch/live`,
+    event: { type, version: "1" },
+    url: `${selfUrl}/donations/twitchsubscription/live`,
     secret,
+    alveusOnly: true,
   });
 }

--- a/apps/donations/worker/src/providers/twitch/subscription.ts
+++ b/apps/donations/worker/src/providers/twitch/subscription.ts
@@ -8,12 +8,12 @@ import superjson from "superjson";
 import type { DonationProvider } from "..";
 import type { DonationStorage } from "../storage";
 import { TwitchEventHubMessageTypeHeader } from "./const";
-import { verifySignature, sha256 } from "./crypto";
+import { verifySignature } from "./crypto";
 import {
   TwitchChallengePayload,
   TwitchSubscriptionNotificationPayload,
 } from "./schema";
-import type { TwitchDonationProviderConfig } from "./twitch.ts";
+import type { TwitchDonationProviderConfig } from "./twitch";
 
 const subscriptionType = (type: string) => {
   if (type === "channel.subscription.gift") return "gift";
@@ -132,12 +132,7 @@ export class TwitchSubscriptionDonationProvider implements DonationProvider {
       const donation = {
         id: crypto.randomUUID(),
         provider: "twitchsubscription",
-        // Twitch subscription messages do not include an id field.
-        // We create a sha256 hash of user_id and when the notification was
-        // created.
-        providerUniqueId: await sha256(
-          `${payload.data.event.user_id}-${payload.data.subscription.created_at}`,
-        ),
+        providerUniqueId: request.headers.get("twitch-eventsub-message-id")!,
         providerMetadata: {
           twitchDonatorId: payload.data.event.user_id,
           twitchDonatorDisplayName: payload.data.event.user_name,
@@ -154,11 +149,12 @@ export class TwitchSubscriptionDonationProvider implements DonationProvider {
             total: payload.data.event.total,
           },
         },
-        // Explicitly set amount to 0 because we have no way of determining the monitary
+        // Explicitly set amount to 0 because we have no way of determining the monetary
         // amount of any sub/resub/giftsub
         amount: 0,
-        receivedAt: new Date(),
-        donatedAt: new Date(),
+        receivedAt: new Date(
+          request.headers.get("twitch-eventsub-message-timestamp")!,
+        ),
         donatedBy: {
           primary: "username",
           username: payload.data.event.user_login,

--- a/apps/donations/worker/src/providers/twitch/subscription.ts
+++ b/apps/donations/worker/src/providers/twitch/subscription.ts
@@ -117,7 +117,6 @@ export class TwitchSubscriptionDonationProvider implements DonationProvider {
 
     const uniqueMessageId = request.headers.get(TwitchEventHubMessageIdHeader);
     if (!uniqueMessageId) {
-      await this.clear();
       return new Response(null, { status: 400 });
     }
 
@@ -169,11 +168,17 @@ export class TwitchSubscriptionDonationProvider implements DonationProvider {
         receivedAt: messageTimestamp ? new Date(messageTimestamp) : new Date(),
         donatedBy: {
           primary: "username",
-          username: payload.data.event.user_login,
+          username: payload.data.event.is_anonymous
+            ? "Anonymous"
+            : (payload.data.event.user_login ?? "Anonymous"),
         },
         tags: {
           twitchBroadcasterId: payload.data.event.broadcaster_user_id,
         },
+        note:
+          payload.data.event.message && payload.data.event.message.text
+            ? (payload.data.event.message?.text as string)
+            : undefined,
       } satisfies TwitchSubscriptionDonation;
 
       await this.service.add(donation);

--- a/apps/website/src/components/admin/donations/DonationFeed.tsx
+++ b/apps/website/src/components/admin/donations/DonationFeed.tsx
@@ -36,6 +36,11 @@ export function DonationFeed() {
     boolSchema,
     false,
   );
+  const [includeSubscriptions, setIncludeSubscriptions] = useLocalStorage(
+    "stream/donation-feed/include-subscriptions",
+    boolSchema,
+    false,
+  );
   const [lastSeen, setLastSeen] = useLocalStorage(
     "stream/donation-feed/last-seen",
     nullableDateSchema,
@@ -57,6 +62,7 @@ export function DonationFeed() {
   const donationsQuery = trpc.donations.getDonationFeed.useInfiniteQuery(
     {
       onlyPixels,
+      includeSubscriptions,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -107,15 +113,30 @@ export function DonationFeed() {
           </summary>
           <div className="absolute top-full right-0 z-10 flex w-64 flex-col gap-2 rounded-sm border border-gray-400 bg-white p-4 text-black shadow-lg">
             <form>
-              <input
-                type="checkbox"
-                id="onlyPixels"
-                checked={onlyPixels}
-                onChange={() => setOnlyPixels(!onlyPixels)}
-              />
-              <label htmlFor="onlyPixels" className="ml-2">
-                Only pixel donations
-              </label>
+              <div>
+                <input
+                  type="checkbox"
+                  id="onlyPixels"
+                  checked={onlyPixels}
+                  onChange={() => setOnlyPixels(!onlyPixels)}
+                />
+                <label htmlFor="onlyPixels" className="ml-2">
+                  Only pixel donations
+                </label>
+              </div>
+              <div>
+                <input
+                  type="checkbox"
+                  id="subscriptions"
+                  checked={includeSubscriptions}
+                  onChange={() =>
+                    setIncludeSubscriptions(!includeSubscriptions)
+                  }
+                />
+                <label htmlFor="subscription" className="ml-2">
+                  Include twitch new/resub/gift subscriptions
+                </label>
+              </div>
             </form>
           </div>
         </details>

--- a/apps/website/src/components/admin/donations/DonationFeed.tsx
+++ b/apps/website/src/components/admin/donations/DonationFeed.tsx
@@ -133,7 +133,7 @@ export function DonationFeed() {
                     setIncludeSubscriptions(!includeSubscriptions)
                   }
                 />
-                <label htmlFor="subscription" className="ml-2">
+                <label htmlFor="subscriptions" className="ml-2">
                   Include twitch new/resub/gift subscriptions
                 </label>
               </div>

--- a/apps/website/src/components/admin/donations/DonationFeedItem.tsx
+++ b/apps/website/src/components/admin/donations/DonationFeedItem.tsx
@@ -159,7 +159,7 @@ function DonationFeedItem({
           }
         >
           {donation.provider === "twitchsubscription"
-            ? formatTwitchSub(donation)
+            ? formatTwitchSub(donation as unknown as TwitchSubscriptionDonation)
             : formatDonationAmount(donation.amount)}
         </Badge>
         {donation.pixels > 0 && (

--- a/apps/website/src/components/admin/donations/DonationFeedItem.tsx
+++ b/apps/website/src/components/admin/donations/DonationFeedItem.tsx
@@ -2,6 +2,8 @@ import { DateTime } from "luxon";
 import { motion } from "motion/react";
 import type { ReactNode } from "react";
 
+import { type TwitchSubscriptionDonation } from "@alveusgg/donations-core";
+
 import type { DonationFeed } from "@/server/trpc/router/donations";
 
 import { classes } from "@/utils/classes";
@@ -30,7 +32,7 @@ const formatTwitchSubTier = (tier?: string) => {
   return "";
 };
 
-const formatTwitchSub = (donation: Donation) => {
+const formatTwitchSub = (donation: TwitchSubscriptionDonation) => {
   const metadata = donation.providerMetadata;
 
   if (!metadata.twitchSubscription) return null;

--- a/apps/website/src/components/admin/donations/DonationFeedItem.tsx
+++ b/apps/website/src/components/admin/donations/DonationFeedItem.tsx
@@ -23,6 +23,29 @@ const currencyFormatter = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 2,
 });
 
+const formatTwitchSubTier = (tier?: string) => {
+  if (tier == "1000") return 1;
+  if (tier == "2000") return 2;
+  if (tier == "3000") return 3;
+  return "";
+};
+
+const formatTwitchSub = (donation: Donation) => {
+  const metadata = donation.providerMetadata;
+
+  if (!metadata.twitchSubscription) return null;
+
+  const formattedTier = formatTwitchSubTier(metadata.twitchSubscription.tier);
+
+  if (metadata.twitchSubscription.type === "gift") {
+    return `Gifted ${metadata.twitchSubscription.total} T${formattedTier}`;
+  } else if (metadata.twitchSubscription.type === "resubscription") {
+    return `Resub T${formattedTier} ${metadata.twitchSubscription.durationMonths}X`;
+  } else {
+    return `New T${formattedTier}`;
+  }
+};
+
 const formatDonationAmount = (amount: number) =>
   currencyFormatter.format(Math.round(amount / 100));
 
@@ -133,7 +156,9 @@ function DonationFeedItem({
             />
           }
         >
-          {formatDonationAmount(donation.amount)}
+          {donation.provider === "twitchsubscription"
+            ? formatTwitchSub(donation)
+            : formatDonationAmount(donation.amount)}
         </Badge>
         {donation.pixels > 0 && (
           <Badge

--- a/apps/website/src/components/admin/donations/DonationFeedItem.tsx
+++ b/apps/website/src/components/admin/donations/DonationFeedItem.tsx
@@ -32,19 +32,33 @@ const formatTwitchSubTier = (tier?: string) => {
   return "";
 };
 
-const formatTwitchSub = (donation: TwitchSubscriptionDonation) => {
-  const metadata = donation.providerMetadata;
-
+const formatTwitchSub = (
+  metadata: TwitchSubscriptionDonation["providerMetadata"],
+) => {
   if (!metadata.twitchSubscription) return null;
 
   const formattedTier = formatTwitchSubTier(metadata.twitchSubscription.tier);
 
   if (metadata.twitchSubscription.type === "gift") {
-    return `Gifted ${metadata.twitchSubscription.total} T${formattedTier}`;
+    return `Gifted ${metadata.twitchSubscription.total}x Tier ${formattedTier}`;
   } else if (metadata.twitchSubscription.type === "resubscription") {
-    return `Resub T${formattedTier} ${metadata.twitchSubscription.durationMonths}X`;
+    if (
+      metadata.twitchSubscription.durationMonths &&
+      metadata.twitchSubscription.durationMonths > 1 &&
+      metadata.twitchSubscription.cumulativeMonths &&
+      metadata.twitchSubscription.cumulativeMonths > 0
+    ) {
+      return `Resub · Tier ${formattedTier} · +${metadata.twitchSubscription.durationMonths} mo (${metadata.twitchSubscription.cumulativeMonths} total)`;
+    } else if (
+      metadata.twitchSubscription.cumulativeMonths &&
+      metadata.twitchSubscription.cumulativeMonths > 0
+    ) {
+      return `Resub · Tier ${formattedTier} (${metadata.twitchSubscription.cumulativeMonths} mo)`;
+    } else {
+      return `Resub · Tier ${formattedTier}`;
+    }
   } else {
-    return `New T${formattedTier}`;
+    return `New · Tier ${formattedTier}`;
   }
 };
 
@@ -159,7 +173,9 @@ function DonationFeedItem({
           }
         >
           {donation.provider === "twitchsubscription"
-            ? formatTwitchSub(donation as unknown as TwitchSubscriptionDonation)
+            ? formatTwitchSub(
+                donation.providerMetadata as TwitchSubscriptionDonation["providerMetadata"],
+              )
             : formatDonationAmount(donation.amount)}
         </Badge>
         {donation.pixels > 0 && (

--- a/apps/website/src/components/shared/DonationProviderIcon.tsx
+++ b/apps/website/src/components/shared/DonationProviderIcon.tsx
@@ -10,6 +10,8 @@ function DonationProviderIcon({
   switch (provider) {
     case "twitch":
       return <IconTwitch {...iconProps} />;
+    case "twitchsubscription":
+      return <IconTwitch {...iconProps} />;
     case "paypal":
       return <IconPayPal {...iconProps} />;
     default:

--- a/apps/website/src/server/db/donations.ts
+++ b/apps/website/src/server/db/donations.ts
@@ -83,10 +83,9 @@ export async function getDonationFeed({
     // That can be baked into the database schema in the future
     // with prisma-json-types-generator.
     const donatedBy = donation.donatedBy as Donator;
-    const providerMetadata = donation.providerMetadata as Record<
-      string,
-      unknown
-    >;
+    const providerMetadata = includeSubscriptions
+      ? (donation.providerMetadata as Record<string, unknown>)
+      : {};
     const tags = (donation.tags || {}) as Record<string, string>;
 
     return {

--- a/apps/website/src/server/db/donations.ts
+++ b/apps/website/src/server/db/donations.ts
@@ -72,7 +72,7 @@ export async function getDonationFeed({
         : includeSubscriptions
           ? undefined
           : {
-              provider: { in: ["twitch", "paypal", "thegivingblock", "neon"] },
+              provider: { not: "twitchsubscription" },
             },
       orderBy: {
         receivedAt: "desc",

--- a/apps/website/src/server/db/donations.ts
+++ b/apps/website/src/server/db/donations.ts
@@ -38,10 +38,12 @@ export async function getDonationFeed({
   take,
   cursor,
   onlyPixels = false,
+  includeSubscriptions = false,
 }: {
   take?: number;
   cursor?: string;
   onlyPixels?: boolean;
+  includeSubscriptions?: boolean;
 } = {}) {
   return (
     await prisma.donation.findMany({
@@ -54,6 +56,7 @@ export async function getDonationFeed({
         donatedBy: true,
         tags: true,
         note: true,
+        ...(includeSubscriptions ? { providerMetadata: true } : {}),
         _count: {
           select: { pixels: true },
         },
@@ -66,7 +69,11 @@ export async function getDonationFeed({
               some: {},
             },
           }
-        : undefined,
+        : includeSubscriptions
+          ? undefined
+          : {
+              provider: { in: ["twitch", "paypal", "thegivingblock", "neon"] },
+            },
       orderBy: {
         receivedAt: "desc",
       },
@@ -76,6 +83,10 @@ export async function getDonationFeed({
     // That can be baked into the database schema in the future
     // with prisma-json-types-generator.
     const donatedBy = donation.donatedBy as Donator;
+    const providerMetadata = donation.providerMetadata as Record<
+      string,
+      unknown
+    >;
     const tags = (donation.tags || {}) as Record<string, string>;
 
     return {
@@ -85,6 +96,7 @@ export async function getDonationFeed({
       donatedAt: donation.donatedAt ?? donation.receivedAt,
       provider: donation.provider,
       pixels: donation._count.pixels,
+      providerMetadata: providerMetadata,
       note: donation.note,
       tags: {
         campaign: tags.campaign,

--- a/apps/website/src/server/trpc/router/admin/twitch.ts
+++ b/apps/website/src/server/trpc/router/admin/twitch.ts
@@ -162,17 +162,16 @@ export const adminTwitchRouter = router({
   setupWebhookSubscription: sharedKeyProcedure
     .input(
       z.object({
+        alveusOnly: z.boolean().default(false),
         event: z.object({ type: z.string(), version: z.string() }),
         url: z.string(),
         secret: z.string(),
       }),
     )
     .mutation(async ({ input }) => {
-      const supportedChannels = [
-        channels.alveusgg.id,
-        channels.maya.id,
-        channels.alveus.id,
-      ];
+      const supportedChannels = input.alveusOnly
+        ? [channels.alveus.id]
+        : [channels.alveusgg.id, channels.maya.id, channels.alveus.id];
 
       for (const channel of supportedChannels) {
         try {

--- a/apps/website/src/server/trpc/router/donations.ts
+++ b/apps/website/src/server/trpc/router/donations.ts
@@ -107,6 +107,7 @@ export const donationsRouter = router({
       z.object({
         cursor: z.string().nullish(),
         onlyPixels: z.boolean().default(false),
+        includeSubscriptions: z.boolean().default(false),
       }),
     )
     .query(async ({ input }) => {
@@ -116,6 +117,7 @@ export const donationsRouter = router({
         take: DONATION_FEED_ENTRIES_PER_PAGE + 1,
         cursor: cursor || undefined,
         onlyPixels: input.onlyPixels,
+        includeSubscriptions: input.includeSubscriptions,
       });
 
       let nextCursor: typeof cursor | undefined = undefined;


### PR DESCRIPTION
## Describe your changes

Adds twitch webhook subscriptions for new, gift, and resubscriptions. Added a filter to the donation list page to filter out subscriptions which is off by default.

Updating the `received` donations index to be a multicolumn index to support filtering on provider. This allows us to be more granular with filtering with less of a performance cost. I seeded 1m donations locally and ran queries of recievedAt desc and filtering by neoncrm and paypal providers and it was performant.

<img width="1976" height="279" alt="image" src="https://github.com/user-attachments/assets/2fef5011-7029-4a8b-91e1-0d9edc776c40" />

The `channel.chat.notification` (https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatnotification) event should be the one used for all twitch related webhooks in the future as it has all subscription, charity donation, and bit information. The reasons these changes do NOT implement this webhook are the following,

- It requires a higher level of permissions and that would involve changing the oauth flow and reauthorizing the app with the channels.
- The amounts of events sent would be significantly higher. Especially if subscribed across all three channels.

Using the `channel.chat.notification` webhook would allow us to know the following,

- If a user upgraded from a prime
- Was a prime sub
- Continued after a gift
- Bits
- Charity donations

Resolves #1588 
...

## Notes for testing your change

I was able to test using the Twitch CLI (https://dev.twitch.tv/docs/cli/). Generate your payload using the cli and then add `twitch-eventsub-message-id` as a UUID and `twitch-eventsub-message-timestamp` as a datetime as headers.

- Must turn the filter on the donations page for subs to show up
- If you dont have paypal/neoncrm env keys, I had to comment out those providers in the manager init

...
