### PR TITLE
Add Give an Hour campaign statistics

### DIFF
--- a/apps/website/__tests__/give-an-hour.test.ts
+++ b/apps/website/__tests__/give-an-hour.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type GiveAnHourEntry,
+  summarizeGiveAnHourEntries,
+} from "@/utils/give-an-hour";
+
+const entry = (
+  id: string,
+  overrides: Partial<GiveAnHourEntry> = {},
+): GiveAnHourEntry => ({
+  id,
+  userId: null,
+  displayName: null,
+  location: null,
+  volunteeringMinutes: 60,
+  ...overrides,
+});
+
+describe("summarizeGiveAnHourEntries", () => {
+  it("counts campaign totals and geographic reach", () => {
+    const stats = summarizeGiveAnHourEntries(
+      [
+        entry("one", {
+          userId: "user-one",
+          displayName: "Alice",
+          location: "Austin, Texas, United States",
+        }),
+        entry("two", {
+          userId: "user-one",
+          displayName: "Alice Again",
+          location: "Austin, Texas, United States",
+          volunteeringMinutes: 30,
+        }),
+        entry("three", {
+          displayName: "Bob",
+          location: "Toronto, Ontario, Canada",
+          volunteeringMinutes: 90,
+        }),
+        entry("four"),
+      ],
+      [],
+    );
+
+    expect(stats).toEqual({
+      minutes: 240,
+      hours: 4,
+      posts: 4,
+      participants: 2,
+      firstTimeParticipants: 2,
+      averageHoursPerParticipant: 2,
+      locations: 2,
+      countries: 2,
+    });
+  });
+
+  it("recognizes returning participants by user ID or display name", () => {
+    const stats = summarizeGiveAnHourEntries(
+      [
+        entry("returning-user", {
+          userId: "returning-user",
+          displayName: "A new display name",
+        }),
+        entry("returning-name", { displayName: "Returning Name" }),
+        entry("new-user", {
+          userId: "new-user",
+          displayName: "New Participant",
+        }),
+      ],
+      [
+        { userId: "returning-user", displayName: "Old display name" },
+        { userId: null, displayName: "Returning Name" },
+      ],
+    );
+
+    expect(stats.participants).toBe(3);
+    expect(stats.firstTimeParticipants).toBe(1);
+  });
+
+  it("does not mark a participant as new when any campaign post matches prior history", () => {
+    const stats = summarizeGiveAnHourEntries(
+      [
+        entry("matched-name", {
+          userId: "same-current-user",
+          displayName: "Prior Name",
+        }),
+        entry("different-name", {
+          userId: "same-current-user",
+          displayName: "Different Name",
+        }),
+      ],
+      [{ userId: null, displayName: "Prior Name" }],
+    );
+
+    expect(stats.participants).toBe(1);
+    expect(stats.firstTimeParticipants).toBe(0);
+  });
+});

--- a/apps/website/__tests__/give-an-hour.test.ts
+++ b/apps/website/__tests__/give-an-hour.test.ts
@@ -1,71 +1,32 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  type GiveAnHourEntry,
-  summarizeGiveAnHourEntries,
-} from "@/utils/give-an-hour";
+import { getGiveAnHourStats } from "@/server/db/show-and-tell";
 
-const entry = (
-  id: string,
-  overrides: Partial<GiveAnHourEntry> = {},
-): GiveAnHourEntry => ({
-  id,
-  userId: null,
-  displayName: null,
-  location: null,
-  volunteeringMinutes: 60,
-  ...overrides,
-});
+import { countFirstTimeGiveAnHourParticipants } from "@/utils/give-an-hour";
 
-describe("summarizeGiveAnHourEntries", () => {
-  it("counts campaign totals and geographic reach", () => {
-    const stats = summarizeGiveAnHourEntries(
-      [
-        entry("one", {
-          userId: "user-one",
-          displayName: "Alice",
-          location: "Austin, Texas, United States",
-        }),
-        entry("two", {
-          userId: "user-one",
-          displayName: "Alice Again",
-          location: "Austin, Texas, United States",
-          volunteeringMinutes: 30,
-        }),
-        entry("three", {
-          displayName: "Bob",
-          location: "Toronto, Ontario, Canada",
-          volunteeringMinutes: 90,
-        }),
-        entry("four"),
-      ],
-      [],
-    );
+const { mockAggregate, mockFindMany, updatedAtField } = vi.hoisted(() => ({
+  mockAggregate: vi.fn(),
+  mockFindMany: vi.fn(),
+  updatedAtField: Symbol("updatedAt"),
+}));
 
-    expect(stats).toEqual({
-      minutes: 240,
-      hours: 4,
-      posts: 4,
-      participants: 2,
-      firstTimeParticipants: 2,
-      averageHoursPerParticipant: 2,
-      locations: 2,
-      countries: 2,
-    });
-  });
+vi.mock("@alveusgg/database", () => ({
+  prisma: {
+    showAndTellEntry: {
+      aggregate: mockAggregate,
+      fields: { updatedAt: updatedAtField },
+      findMany: mockFindMany,
+    },
+  },
+}));
 
+describe("countFirstTimeGiveAnHourParticipants", () => {
   it("recognizes returning participants by user ID or display name", () => {
-    const stats = summarizeGiveAnHourEntries(
+    const firstTimeParticipants = countFirstTimeGiveAnHourParticipants(
       [
-        entry("returning-user", {
-          userId: "returning-user",
-          displayName: "A new display name",
-        }),
-        entry("returning-name", { displayName: "Returning Name" }),
-        entry("new-user", {
-          userId: "new-user",
-          displayName: "New Participant",
-        }),
+        { userId: "returning-user", displayName: "A new display name" },
+        { userId: null, displayName: "Returning Name" },
+        { userId: "new-user", displayName: "New Participant" },
       ],
       [
         { userId: "returning-user", displayName: "Old display name" },
@@ -73,26 +34,119 @@ describe("summarizeGiveAnHourEntries", () => {
       ],
     );
 
-    expect(stats.participants).toBe(3);
-    expect(stats.firstTimeParticipants).toBe(1);
+    expect(firstTimeParticipants).toBe(1);
   });
 
-  it("does not mark a participant as new when any campaign post matches prior history", () => {
-    const stats = summarizeGiveAnHourEntries(
+  it("matches prior anonymous history to a logged-in display name", () => {
+    const firstTimeParticipants = countFirstTimeGiveAnHourParticipants(
       [
-        entry("matched-name", {
-          userId: "same-current-user",
-          displayName: "Prior Name",
-        }),
-        entry("different-name", {
-          userId: "same-current-user",
-          displayName: "Different Name",
-        }),
+        { userId: "same-current-user", displayName: "Prior Name" },
+        { userId: "same-current-user", displayName: "Different Name" },
       ],
       [{ userId: null, displayName: "Prior Name" }],
     );
 
-    expect(stats.participants).toBe(1);
-    expect(stats.firstTimeParticipants).toBe(0);
+    expect(firstTimeParticipants).toBe(0);
+  });
+});
+
+describe("getGiveAnHourStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses Prisma aggregates and skinny distinct identity/location queries", async () => {
+    const start = new Date("2024-03-01T05:00:00.000Z");
+    const end = new Date("2024-04-23T04:00:00.000Z");
+    const aggregateResult = {
+      _sum: { volunteeringMinutes: 180 },
+      _count: { _all: 2 },
+    };
+
+    mockAggregate
+      .mockResolvedValueOnce(aggregateResult)
+      .mockResolvedValueOnce(aggregateResult);
+    mockFindMany
+      .mockResolvedValueOnce([{ userId: "user-one" }])
+      .mockResolvedValueOnce([{ displayName: "Anonymous" }])
+      .mockResolvedValueOnce([{ location: "Austin, Texas, United States" }])
+      .mockResolvedValueOnce([
+        { userId: "user-one", displayName: "Prior Name" },
+        { userId: null, displayName: "Anonymous" },
+      ])
+      .mockResolvedValueOnce([{ userId: null, displayName: "Prior Name" }]);
+
+    const result = await getGiveAnHourStats({ ranges: [{ start, end }] });
+    const approvedFilter = { approvedAt: { gte: updatedAtField } };
+    const campaignWhere = {
+      AND: [
+        approvedFilter,
+        { volunteeringMinutes: { gt: 0 } },
+        { OR: [{ createdAt: { gte: start, lt: end } }] },
+      ],
+    };
+
+    expect(mockAggregate).toHaveBeenNthCalledWith(1, {
+      _sum: { volunteeringMinutes: true },
+      _count: { _all: true },
+      where: campaignWhere,
+    });
+    expect(mockAggregate).toHaveBeenNthCalledWith(2, {
+      _sum: { volunteeringMinutes: true },
+      _count: { _all: true },
+      where: campaignWhere,
+    });
+    expect(mockFindMany).toHaveBeenNthCalledWith(1, {
+      select: { userId: true },
+      where: { AND: [campaignWhere, { userId: { not: null } }] },
+      distinct: ["userId"],
+    });
+    expect(mockFindMany).toHaveBeenNthCalledWith(2, {
+      select: { displayName: true },
+      where: {
+        AND: [campaignWhere, { userId: null }, { displayName: { not: null } }],
+      },
+      distinct: ["displayName"],
+    });
+    expect(mockFindMany).toHaveBeenNthCalledWith(3, {
+      select: { location: true },
+      where: { AND: [campaignWhere, { location: { not: null } }] },
+      distinct: ["location"],
+    });
+    expect(mockFindMany).toHaveBeenNthCalledWith(4, {
+      select: { userId: true, displayName: true },
+      where: campaignWhere,
+      distinct: ["userId", "displayName"],
+    });
+    expect(mockFindMany).toHaveBeenNthCalledWith(5, {
+      select: { userId: true, displayName: true },
+      where: {
+        AND: [
+          approvedFilter,
+          { createdAt: { lt: start } },
+          {
+            OR: [
+              { userId: { in: ["user-one"] } },
+              { displayName: { in: ["Prior Name", "Anonymous"] } },
+            ],
+          },
+        ],
+      },
+      distinct: ["userId", "displayName"],
+    });
+    expect(result).toEqual({
+      hours: 3,
+      posts: 2,
+      participants: 2,
+      averageHoursPerParticipant: 2,
+      locations: 1,
+      countries: 1,
+      averagePostsPerCampaign: 2,
+      averageFirstTimeParticipantsPerCampaign: 1,
+      averageCommunityHoursPerCampaign: 3,
+      recordHighCampaignYear: 2024,
+      recordHighCampaignHours: 3,
+      campaigns: [{ year: 2024, firstTimeParticipants: 1, hours: 3 }],
+    });
   });
 });

--- a/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourProgress.tsx
@@ -74,18 +74,18 @@ const GiveAnHourProgressText = ({
   );
 };
 
-export const GiveAnHourProgress = ({
-  target,
-  start,
-  end,
-  text = "after",
-}: {
+type GiveAnHourProgressProps = {
   target?:
     number | ((hours: number, ended: boolean, computed: number) => number);
   start?: DateString;
   end?: DateString;
   text?: "after" | "before";
-}) => {
+  providedHours?: { data: number | undefined; isPending: boolean };
+};
+
+export const GiveAnHourProgress = (props: GiveAnHourProgressProps) => {
+  const { target, start, end, text = "after" } = props;
+  const hasProvidedHours = props.providedHours !== undefined;
   const startDate = useDateString(start);
   const endDate = useDateString(end, 1); // `end` is exclusive in the API, but treated as inclusive as a prop here
   const ended = useMemo(() => {
@@ -100,10 +100,16 @@ export const GiveAnHourProgress = ({
       end: endDate,
     },
     {
-      refetchInterval: 5 * 60 * 1000,
+      enabled: !hasProvidedHours,
+      refetchInterval: hasProvidedHours ? false : 5 * 60 * 1000,
     },
   );
-  const hours = hoursQuery.data ?? 0;
+  const hours = hasProvidedHours
+    ? (props.providedHours?.data ?? 0)
+    : (hoursQuery.data ?? 0);
+  const isLoading = hasProvidedHours
+    ? (props.providedHours?.isPending ?? false)
+    : hoursQuery.isPending;
 
   const computedTarget = useMemo(() => {
     if (typeof target === "number") return target;
@@ -121,7 +127,7 @@ export const GiveAnHourProgress = ({
         <GiveAnHourProgressText
           hours={hours}
           target={computedTarget}
-          isLoading={hoursQuery.isPending}
+          isLoading={isLoading}
           ended={ended}
         />
       )}
@@ -132,7 +138,7 @@ export const GiveAnHourProgress = ({
         <GiveAnHourProgressText
           hours={hours}
           target={computedTarget}
-          isLoading={hoursQuery.isPending}
+          isLoading={isLoading}
           ended={ended}
         />
       )}

--- a/apps/website/src/components/show-and-tell/GiveAnHourStats.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourStats.tsx
@@ -120,7 +120,8 @@ export const GiveAnHourStats = ({
         Since 2024, <strong>{membersFormatted} members</strong> of the Alveus
         community have given{" "}
         <strong>
-          {hoursFormatted} hours (~{daysFormatted} days)
+          {hoursFormatted} {stats.hours === 1 ? "hour" : "hours"} (~{daysFormatted}{" "}
+          {Math.floor(stats.hours / 24) === 1 ? "day" : "days"})
         </strong>
         {" during WWF's Give an Hour for Earth campaigns."}
       </p>

--- a/apps/website/src/components/show-and-tell/GiveAnHourStats.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourStats.tsx
@@ -1,0 +1,191 @@
+import { type ComponentType, Fragment } from "react";
+
+import { trpc } from "@/utils/trpc";
+
+import useLocaleString from "@/hooks/locale";
+
+import {
+  type DateString,
+  parseDateString,
+} from "@/components/show-and-tell/GiveAnHourProgress";
+
+import type { IconProps } from "@/icons/BaseIcon";
+import IconCalendar from "@/icons/IconCalendar";
+import IconMapPin from "@/icons/IconMapPin";
+import IconPencil from "@/icons/IconPencil";
+import IconUserGroup from "@/icons/IconUserGroup";
+
+interface MetricItem {
+  id: string;
+  label: string;
+  value: number;
+  detail?: string;
+}
+
+type GiveAnHourCampaignRange = {
+  start: DateString;
+  end: DateString;
+};
+
+export const useGiveAnHourStats = (ranges: GiveAnHourCampaignRange[]) =>
+  trpc.showAndTell.getGiveAnHourStats.useQuery(
+    {
+      ranges: ranges.map(({ start, end }) => ({
+        start: parseDateString(start),
+        end: parseDateString(end, 1),
+      })),
+    },
+    { refetchInterval: 5 * 60 * 1000 },
+  );
+
+type GiveAnHourStatsQuery = ReturnType<typeof useGiveAnHourStats>;
+
+const MetricRow = ({ label, value, detail }: MetricItem) => {
+  const formattedValue = useLocaleString(Math.round(value));
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-0.5 px-2 leading-tight">
+      <span className="text-lg leading-none font-semibold tabular-nums md:text-xl">
+        {formattedValue}
+      </span>
+      <span className="text-xs md:text-sm">{label}</span>
+      {detail && <span className="text-xs opacity-75">{detail}</span>}
+    </div>
+  );
+};
+
+const MetricCard = ({
+  icon: Icon,
+  items,
+}: {
+  icon: ComponentType<IconProps>;
+  items: MetricItem[];
+}) => (
+  <div className="flex min-h-44 min-w-0 flex-col rounded-xl bg-white/75 p-3 text-center text-alveus-green-900 shadow-lg backdrop-blur-sm sm:aspect-square sm:min-h-0 md:p-2 md:text-lg lg:aspect-auto lg:h-[270px]">
+    <div className="mx-auto size-8 shrink-0">
+      <Icon className="size-full" />
+    </div>
+    <div className="flex min-h-0 flex-1 flex-col">
+      {items.map((item, index) => (
+        <Fragment key={item.id}>
+          {index > 0 && (
+            <div className="h-3 flex-none border-t border-alveus-green-900/15" />
+          )}
+          <MetricRow {...item} />
+        </Fragment>
+      ))}
+    </div>
+  </div>
+);
+
+export const GiveAnHourStats = ({
+  statsQuery,
+}: {
+  statsQuery: GiveAnHourStatsQuery;
+}) => {
+  const stats = statsQuery.data;
+  const hoursFormatted = useLocaleString(stats?.hours ?? 0);
+  const daysFormatted = useLocaleString(Math.floor((stats?.hours ?? 0) / 24));
+  const membersFormatted = useLocaleString(stats?.participants ?? 0);
+
+  if (statsQuery.isPending) {
+    return (
+      <div
+        className="mt-4 w-full animate-pulse"
+        aria-label="Loading campaign statistics"
+      >
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+          {Array.from({ length: 4 }, (_, index) => (
+            <div
+              key={index}
+              className="min-h-44 rounded-xl bg-alveus-green/10 sm:aspect-square sm:min-h-0 lg:aspect-auto lg:h-[270px]"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!stats || statsQuery.isError) {
+    return (
+      <p className="mt-3 text-sm opacity-75">
+        Campaign statistics are unavailable right now.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-4">
+      <p className="mb-4 w-full text-left text-lg">
+        Since 2024, <strong>{membersFormatted} members</strong> of the Alveus
+        community have given{" "}
+        <strong>
+          {hoursFormatted} hours (~{daysFormatted} days)
+        </strong>
+        {" during WWF's Give an Hour for Earth campaigns."}
+      </p>
+
+      <div className="grid w-full grid-cols-2 gap-4 lg:grid-cols-4">
+        <MetricCard
+          icon={IconCalendar}
+          items={[
+            {
+              id: "average-hours",
+              label: "average hours per campaign",
+              value: stats.averageCommunityHoursPerCampaign,
+            },
+            {
+              id: "record-hours",
+              label: "most hours in a campaign",
+              value: stats.recordHighCampaignHours,
+              detail: stats.recordHighCampaignYear
+                ? `${stats.recordHighCampaignYear}`
+                : undefined,
+            },
+          ]}
+        />
+        <MetricCard
+          icon={IconUserGroup}
+          items={[
+            {
+              id: "average-new-participants",
+              label: "average first-time participants per campaign",
+              value: stats.averageFirstTimeParticipantsPerCampaign,
+            },
+            {
+              id: "hours-per-participant",
+              label: "average hours per participant",
+              value: stats.averageHoursPerParticipant,
+            },
+          ]}
+        />
+        <MetricCard
+          icon={IconPencil}
+          items={[
+            { id: "posts", label: "total posts", value: stats.posts },
+            {
+              id: "average-posts",
+              label: "average posts per campaign",
+              value: stats.averagePostsPerCampaign,
+            },
+          ]}
+        />
+        <MetricCard
+          icon={IconMapPin}
+          items={[
+            {
+              id: "locations",
+              label: "locations",
+              value: stats.locations,
+            },
+            {
+              id: "countries",
+              label: "countries",
+              value: stats.countries,
+            },
+          ]}
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/website/src/components/show-and-tell/GiveAnHourStats.tsx
+++ b/apps/website/src/components/show-and-tell/GiveAnHourStats.tsx
@@ -86,7 +86,7 @@ export const GiveAnHourStats = ({
   const stats = statsQuery.data;
   const hoursFormatted = useLocaleString(stats?.hours ?? 0);
   const daysFormatted = useLocaleString(Math.floor((stats?.hours ?? 0) / 24));
-  const membersFormatted = useLocaleString(stats?.participants ?? 0);
+  const participantsFormatted = useLocaleString(stats?.participants ?? 0);
 
   if (statsQuery.isPending) {
     return (
@@ -117,11 +117,15 @@ export const GiveAnHourStats = ({
   return (
     <div className="mt-4">
       <p className="mb-4 w-full text-left text-lg">
-        Since 2024, <strong>{membersFormatted} members</strong> of the Alveus
-        community have given{" "}
+        Since 2024,{" "}
         <strong>
-          {hoursFormatted} {stats.hours === 1 ? "hour" : "hours"} (~{daysFormatted}{" "}
-          {Math.floor(stats.hours / 24) === 1 ? "day" : "days"})
+          {participantsFormatted}{" "}
+          {stats.participants === 1 ? "participant" : "participants"}
+        </strong>{" "}
+        in the Alveus community have given{" "}
+        <strong>
+          {hoursFormatted} {stats.hours === 1 ? "hour" : "hours"} (~
+          {daysFormatted} {Math.floor(stats.hours / 24) === 1 ? "day" : "days"})
         </strong>
         {" during WWF's Give an Hour for Earth campaigns."}
       </p>

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -17,6 +17,10 @@ import {
   GiveAnHourProgress,
   parseDateString,
 } from "@/components/show-and-tell/GiveAnHourProgress";
+import {
+  GiveAnHourStats,
+  useGiveAnHourStats,
+} from "@/components/show-and-tell/GiveAnHourStats";
 
 import IconPlus from "@/icons/IconPlus";
 
@@ -146,6 +150,7 @@ const GiveAnHourPage: NextPage<
 > = ({ wwfStart }) => {
   const { locale } = useLocale();
   const wwf = useWWfGiveAnHourCampaign(wwfStart);
+  const giveAnHourStatsQuery = useGiveAnHourStats(wwfGiveAnHourCampaigns);
 
   // Sync the targets of all the campaigns to the max target for them
   const [wwfMaxTarget, setWwfMaxTarget] = useState(0);
@@ -451,11 +456,17 @@ const GiveAnHourPage: NextPage<
             </p>
 
             {wwf?.cta && <p className="mt-2 text-lg">{wwf.cta(false)}</p>}
+
+            <GiveAnHourStats statsQuery={giveAnHourStatsQuery} />
           </div>
 
           <div className="flex w-full flex-col divide-y divide-alveus-green/25 lg:order-first lg:w-1/2 xl:w-2/5">
             {wwfGiveAnHourCampaigns.map(({ start, end }) => {
               const year = start.split("-")[0]!;
+              const firstTimeParticipants =
+                giveAnHourStatsQuery.data?.campaigns.find(
+                  ({ year: campaignYear }) => campaignYear === Number(year),
+                )?.firstTimeParticipants;
               return (
                 <div key={year} className="pt-4 pb-6">
                   <div className="flex flex-wrap items-baseline justify-between">
@@ -484,6 +495,18 @@ const GiveAnHourPage: NextPage<
                     end={end}
                     target={wwfGiveAnHourSyncTarget}
                   />
+                  {giveAnHourStatsQuery.isPending ? (
+                    <p className="px-2 text-sm opacity-75">
+                      Loading first-time participants&hellip;
+                    </p>
+                  ) : firstTimeParticipants !== undefined ? (
+                    <p className="px-2 text-sm opacity-75">
+                      {firstTimeParticipants.toLocaleString(locale)} first-time{" "}
+                      {firstTimeParticipants === 1
+                        ? "participant"
+                        : "participants"}
+                    </p>
+                  ) : null}
                 </div>
               );
             })}

--- a/apps/website/src/pages/show-and-tell/give-an-hour.tsx
+++ b/apps/website/src/pages/show-and-tell/give-an-hour.tsx
@@ -463,10 +463,11 @@ const GiveAnHourPage: NextPage<
           <div className="flex w-full flex-col divide-y divide-alveus-green/25 lg:order-first lg:w-1/2 xl:w-2/5">
             {wwfGiveAnHourCampaigns.map(({ start, end }) => {
               const year = start.split("-")[0]!;
+              const campaignStats = giveAnHourStatsQuery.data?.campaigns.find(
+                ({ year: campaignYear }) => campaignYear === Number(year),
+              );
               const firstTimeParticipants =
-                giveAnHourStatsQuery.data?.campaigns.find(
-                  ({ year: campaignYear }) => campaignYear === Number(year),
-                )?.firstTimeParticipants;
+                campaignStats?.firstTimeParticipants;
               return (
                 <div key={year} className="pt-4 pb-6">
                   <div className="flex flex-wrap items-baseline justify-between">
@@ -494,6 +495,14 @@ const GiveAnHourPage: NextPage<
                     start={start}
                     end={end}
                     target={wwfGiveAnHourSyncTarget}
+                    providedHours={
+                      giveAnHourStatsQuery.isError
+                        ? undefined
+                        : {
+                            data: campaignStats?.hours,
+                            isPending: giveAnHourStatsQuery.isPending,
+                          }
+                    }
                   />
                   {giveAnHourStatsQuery.isPending ? (
                     <p className="px-2 text-sm opacity-75">

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -446,35 +446,58 @@ export async function getGiveAnHourStats({
     Math.max(...ranges.map(({ start }) => start.getTime())),
   );
 
-  const [entries, previousEntries] = await Promise.all([
-    prisma.showAndTellEntry.findMany({
-      select: {
-        id: true,
-        userId: true,
-        displayName: true,
-        location: true,
-        volunteeringMinutes: true,
-        createdAt: true,
-      },
-      where: {
-        AND: [
-          getPostFilter("approved"),
-          { volunteeringMinutes: { gt: 0 } },
-          {
-            OR: ranges.map(({ start, end }) => ({
-              createdAt: { gte: start, lt: end },
-            })),
+  const entries = await prisma.showAndTellEntry.findMany({
+    select: {
+      id: true,
+      userId: true,
+      displayName: true,
+      location: true,
+      volunteeringMinutes: true,
+      createdAt: true,
+    },
+    where: {
+      AND: [
+        getPostFilter("approved"),
+        { volunteeringMinutes: { gt: 0 } },
+        {
+          OR: ranges.map(({ start, end }) => ({
+            createdAt: { gte: start, lt: end },
+          })),
+        },
+      ],
+    },
+  });
+
+  const participantUserIds = [
+    ...new Set(entries.flatMap(({ userId }) => (userId ? [userId] : []))),
+  ];
+  const participantDisplayNames = [
+    ...new Set(
+      entries.flatMap(({ displayName }) => (displayName ? [displayName] : [])),
+    ),
+  ];
+  const previousEntries =
+    participantUserIds.length === 0 && participantDisplayNames.length === 0
+      ? []
+      : await prisma.showAndTellEntry.findMany({
+          select: { userId: true, displayName: true, createdAt: true },
+          where: {
+            AND: [
+              getPostFilter("approved"),
+              { createdAt: { lt: latestStart } },
+              {
+                OR: [
+                  ...(participantUserIds.length > 0
+                    ? [{ userId: { in: participantUserIds } }]
+                    : []),
+                  ...(participantDisplayNames.length > 0
+                    ? [{ displayName: { in: participantDisplayNames } }]
+                    : []),
+                ],
+              },
+            ],
           },
-        ],
-      },
-    }),
-    prisma.showAndTellEntry.findMany({
-      select: { userId: true, displayName: true, createdAt: true },
-      where: {
-        AND: [getPostFilter("approved"), { createdAt: { lt: latestStart } }],
-      },
-    }),
-  ] as const);
+        });
 
   const previousEntriesBeforeEarliestStart = previousEntries.filter(
     ({ createdAt }) => createdAt < earliestStart,

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -25,6 +25,7 @@ import {
 } from "@/data/show-and-tell";
 
 import { getEntityStatus } from "@/utils/entity-helpers";
+import { summarizeGiveAnHourEntries } from "@/utils/give-an-hour";
 import { notEmpty } from "@/utils/helpers";
 import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 
@@ -431,6 +432,114 @@ export async function getVolunteeringMinutes({
   });
 
   return res._sum.volunteeringMinutes ?? 0;
+}
+
+export async function getGiveAnHourStats({
+  ranges,
+}: {
+  ranges: Array<{ start: Date; end: Date }>;
+}) {
+  const earliestStart = new Date(
+    Math.min(...ranges.map(({ start }) => start.getTime())),
+  );
+  const latestStart = new Date(
+    Math.max(...ranges.map(({ start }) => start.getTime())),
+  );
+
+  const [entries, previousEntries] = await Promise.all([
+    prisma.showAndTellEntry.findMany({
+      select: {
+        id: true,
+        userId: true,
+        displayName: true,
+        location: true,
+        volunteeringMinutes: true,
+        createdAt: true,
+      },
+      where: {
+        AND: [
+          getPostFilter("approved"),
+          { volunteeringMinutes: { gt: 0 } },
+          {
+            OR: ranges.map(({ start, end }) => ({
+              createdAt: { gte: start, lt: end },
+            })),
+          },
+        ],
+      },
+    }),
+    prisma.showAndTellEntry.findMany({
+      select: { userId: true, displayName: true, createdAt: true },
+      where: {
+        AND: [getPostFilter("approved"), { createdAt: { lt: latestStart } }],
+      },
+    }),
+  ] as const);
+
+  const previousEntriesBeforeEarliestStart = previousEntries.filter(
+    ({ createdAt }) => createdAt < earliestStart,
+  );
+  const stats = summarizeGiveAnHourEntries(
+    entries,
+    previousEntriesBeforeEarliestStart,
+  );
+  const campaignSummaries = ranges.map((range) => {
+    const campaignEntries = entries.filter(
+      ({ createdAt }) => createdAt >= range.start && createdAt < range.end,
+    );
+    const campaignPreviousEntries = previousEntries.filter(
+      ({ createdAt }) => createdAt < range.start,
+    );
+    const campaignStats = summarizeGiveAnHourEntries(
+      campaignEntries,
+      campaignPreviousEntries,
+    );
+
+    return {
+      hours: campaignStats.hours,
+      minutes: campaignStats.minutes,
+      posts: campaignStats.posts,
+      firstTimeParticipants: campaignStats.firstTimeParticipants,
+      year: range.start.getUTCFullYear(),
+    };
+  });
+  const campaignCount = campaignSummaries.length;
+  const averageFirstTimeParticipantsPerCampaign = Math.round(
+    campaignSummaries.reduce(
+      (total, { firstTimeParticipants }) => total + firstTimeParticipants,
+      0,
+    ) / campaignCount,
+  );
+  const averageCommunityHoursPerCampaign = Math.round(
+    campaignSummaries.reduce((total, { minutes }) => total + minutes, 0) /
+      60 /
+      campaignCount,
+  );
+  const averagePostsPerCampaign = Math.round(
+    campaignSummaries.reduce((total, { posts }) => total + posts, 0) /
+      campaignCount,
+  );
+  const recordHighCampaign = campaignSummaries.reduce((record, campaign) =>
+    campaign.hours > record.hours ? campaign : record,
+  );
+
+  return {
+    hours: stats.hours,
+    posts: stats.posts,
+    participants: stats.participants,
+    averageHoursPerParticipant: stats.averageHoursPerParticipant,
+    locations: stats.locations,
+    countries: stats.countries,
+    averagePostsPerCampaign,
+    averageFirstTimeParticipantsPerCampaign,
+    averageCommunityHoursPerCampaign,
+    recordHighCampaignYear: recordHighCampaign.year,
+    recordHighCampaignHours: recordHighCampaign.hours,
+    campaigns: campaignSummaries.map(({ year, firstTimeParticipants }) => ({
+      year,
+      firstTimeParticipants,
+    })),
+  };
 }
 
 export async function getAdminPosts({

--- a/apps/website/src/server/db/show-and-tell.ts
+++ b/apps/website/src/server/db/show-and-tell.ts
@@ -7,6 +7,7 @@ import {
   type ImageAttachment,
   type ImageMetadata,
   type LinkAttachment,
+  type Prisma,
   type ShowAndTellEntry$attachmentsArgs,
   type ShowAndTellEntryAttachment,
   type ShowAndTellEntryAttachmentCreateWithoutEntryInput,
@@ -25,8 +26,9 @@ import {
 } from "@/data/show-and-tell";
 
 import { getEntityStatus } from "@/utils/entity-helpers";
-import { summarizeGiveAnHourEntries } from "@/utils/give-an-hour";
+import { countFirstTimeGiveAnHourParticipants } from "@/utils/give-an-hour";
 import { notEmpty } from "@/utils/helpers";
+import { extractInfoFromMapFeatures } from "@/utils/locations";
 import { parseVideoUrl, validateNormalizedVideoUrl } from "@/utils/video-urls";
 
 export type ImageAttachmentWithFileStorageObject = ImageAttachment & {
@@ -434,57 +436,51 @@ export async function getVolunteeringMinutes({
   return res._sum.volunteeringMinutes ?? 0;
 }
 
-export async function getGiveAnHourStats({
-  ranges,
-}: {
-  ranges: Array<{ start: Date; end: Date }>;
-}) {
-  const earliestStart = new Date(
-    Math.min(...ranges.map(({ start }) => start.getTime())),
-  );
-  const latestStart = new Date(
-    Math.max(...ranges.map(({ start }) => start.getTime())),
-  );
+type GiveAnHourRange = { start: Date; end: Date };
 
-  const entries = await prisma.showAndTellEntry.findMany({
-    select: {
-      id: true,
-      userId: true,
-      displayName: true,
-      location: true,
-      volunteeringMinutes: true,
-      createdAt: true,
-    },
-    where: {
-      AND: [
-        getPostFilter("approved"),
-        { volunteeringMinutes: { gt: 0 } },
-        {
-          OR: ranges.map(({ start, end }) => ({
-            createdAt: { gte: start, lt: end },
-          })),
-        },
-      ],
-    },
-  });
+const getGiveAnHourEntriesWhere = (ranges: GiveAnHourRange[]) =>
+  ({
+    AND: [
+      getPostFilter("approved"),
+      { volunteeringMinutes: { gt: 0 } },
+      {
+        OR: ranges.map(({ start, end }) => ({
+          createdAt: { gte: start, lt: end },
+        })),
+      },
+    ],
+  }) satisfies Prisma.ShowAndTellEntryWhereInput;
 
-  const participantUserIds = [
-    ...new Set(entries.flatMap(({ userId }) => (userId ? [userId] : []))),
-  ];
-  const participantDisplayNames = [
-    ...new Set(
-      entries.flatMap(({ displayName }) => (displayName ? [displayName] : [])),
-    ),
-  ];
-  const previousEntries =
+async function getGiveAnHourCampaignSummary({ start, end }: GiveAnHourRange) {
+  const where = getGiveAnHourEntriesWhere([{ start, end }]);
+  const [aggregate, participants] = await Promise.all([
+    prisma.showAndTellEntry.aggregate({
+      _sum: { volunteeringMinutes: true },
+      _count: { _all: true },
+      where,
+    }),
+    prisma.showAndTellEntry.findMany({
+      select: { userId: true, displayName: true },
+      where,
+      distinct: ["userId", "displayName"],
+    }),
+  ]);
+
+  const participantUserIds = participants.flatMap(({ userId }) =>
+    userId ? [userId] : [],
+  );
+  const participantDisplayNames = participants.flatMap(({ displayName }) =>
+    displayName ? [displayName] : [],
+  );
+  const previousParticipants =
     participantUserIds.length === 0 && participantDisplayNames.length === 0
       ? []
       : await prisma.showAndTellEntry.findMany({
-          select: { userId: true, displayName: true, createdAt: true },
+          select: { userId: true, displayName: true },
           where: {
             AND: [
               getPostFilter("approved"),
-              { createdAt: { lt: latestStart } },
+              { createdAt: { lt: start } },
               {
                 OR: [
                   ...(participantUserIds.length > 0
@@ -497,35 +493,65 @@ export async function getGiveAnHourStats({
               },
             ],
           },
+          distinct: ["userId", "displayName"],
         });
 
-  const previousEntriesBeforeEarliestStart = previousEntries.filter(
-    ({ createdAt }) => createdAt < earliestStart,
-  );
-  const stats = summarizeGiveAnHourEntries(
-    entries,
-    previousEntriesBeforeEarliestStart,
-  );
-  const campaignSummaries = ranges.map((range) => {
-    const campaignEntries = entries.filter(
-      ({ createdAt }) => createdAt >= range.start && createdAt < range.end,
-    );
-    const campaignPreviousEntries = previousEntries.filter(
-      ({ createdAt }) => createdAt < range.start,
-    );
-    const campaignStats = summarizeGiveAnHourEntries(
-      campaignEntries,
-      campaignPreviousEntries,
-    );
+  const minutes = aggregate._sum.volunteeringMinutes ?? 0;
 
-    return {
-      hours: campaignStats.hours,
-      minutes: campaignStats.minutes,
-      posts: campaignStats.posts,
-      firstTimeParticipants: campaignStats.firstTimeParticipants,
-      year: range.start.getUTCFullYear(),
-    };
-  });
+  return {
+    hours: Math.round(minutes / 60),
+    minutes,
+    posts: aggregate._count._all,
+    firstTimeParticipants: countFirstTimeGiveAnHourParticipants(
+      participants,
+      previousParticipants,
+    ),
+    year: start.getUTCFullYear(),
+  };
+}
+
+export async function getGiveAnHourStats({
+  ranges,
+}: {
+  ranges: GiveAnHourRange[];
+}) {
+  const where = getGiveAnHourEntriesWhere(ranges);
+  const [aggregate, participantsWithUserId, participantsWithoutUserId, places] =
+    await Promise.all([
+      prisma.showAndTellEntry.aggregate({
+        _sum: { volunteeringMinutes: true },
+        _count: { _all: true },
+        where,
+      }),
+      prisma.showAndTellEntry.findMany({
+        select: { userId: true },
+        where: { AND: [where, { userId: { not: null } }] },
+        distinct: ["userId"],
+      }),
+      prisma.showAndTellEntry.findMany({
+        select: { displayName: true },
+        where: {
+          AND: [where, { userId: null }, { displayName: { not: null } }],
+        },
+        distinct: ["displayName"],
+      }),
+      prisma.showAndTellEntry.findMany({
+        select: { location: true },
+        where: { AND: [where, { location: { not: null } }] },
+        distinct: ["location"],
+      }),
+    ]);
+  const campaignSummaries = await Promise.all(
+    ranges.map(getGiveAnHourCampaignSummary),
+  );
+  const minutes = aggregate._sum.volunteeringMinutes ?? 0;
+  const participants =
+    participantsWithUserId.length + participantsWithoutUserId.length;
+  const { locations, countries } = extractInfoFromMapFeatures(
+    places.flatMap(({ location }, index) =>
+      location ? [{ id: String(index), location }] : [],
+    ),
+  );
   const campaignCount = campaignSummaries.length;
   const averageFirstTimeParticipantsPerCampaign = Math.round(
     campaignSummaries.reduce(
@@ -547,21 +573,25 @@ export async function getGiveAnHourStats({
   );
 
   return {
-    hours: stats.hours,
-    posts: stats.posts,
-    participants: stats.participants,
-    averageHoursPerParticipant: stats.averageHoursPerParticipant,
-    locations: stats.locations,
-    countries: stats.countries,
+    hours: Math.round(minutes / 60),
+    posts: aggregate._count._all,
+    participants,
+    averageHoursPerParticipant:
+      participants === 0 ? 0 : Math.round(minutes / 60 / participants),
+    locations: locations.size,
+    countries: countries.size,
     averagePostsPerCampaign,
     averageFirstTimeParticipantsPerCampaign,
     averageCommunityHoursPerCampaign,
     recordHighCampaignYear: recordHighCampaign.year,
     recordHighCampaignHours: recordHighCampaign.hours,
-    campaigns: campaignSummaries.map(({ year, firstTimeParticipants }) => ({
-      year,
-      firstTimeParticipants,
-    })),
+    campaigns: campaignSummaries.map(
+      ({ year, firstTimeParticipants, hours }) => ({
+        year,
+        firstTimeParticipants,
+        hours,
+      }),
+    ),
   };
 }
 

--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -78,7 +78,10 @@ export const showAndTellRouter = router({
   getGiveAnHourStats: publicProcedure
     .input(
       z.object({
-        ranges: z.array(z.object({ start: z.date(), end: z.date() })).min(1),
+        ranges: z
+          .array(z.object({ start: z.date(), end: z.date() }))
+          .min(1)
+          .max(12),
       }),
     )
     .query(({ input }) => getGiveAnHourStats(input)),

--- a/apps/website/src/server/trpc/router/show-and-tell.ts
+++ b/apps/website/src/server/trpc/router/show-and-tell.ts
@@ -6,6 +6,7 @@ import { env } from "@/env";
 import {
   createPost,
   deletePost,
+  getGiveAnHourStats,
   getMapFeatures,
   getPublicPostById,
   getPublicPosts,
@@ -73,6 +74,14 @@ export const showAndTellRouter = router({
       const minutes = await getVolunteeringMinutes(input);
       return Math.round(minutes / 60);
     }),
+
+  getGiveAnHourStats: publicProcedure
+    .input(
+      z.object({
+        ranges: z.array(z.object({ start: z.date(), end: z.date() })).min(1),
+      }),
+    )
+    .query(({ input }) => getGiveAnHourStats(input)),
 
   create: publicProcedure
     .input(showAndTellCreateInputSchema)

--- a/apps/website/src/utils/give-an-hour.ts
+++ b/apps/website/src/utils/give-an-hour.ts
@@ -1,0 +1,85 @@
+import { extractInfoFromMapFeatures } from "./locations";
+
+export type GiveAnHourEntry = {
+  id: string;
+  userId: string | null;
+  displayName: string | null;
+  location: string | null;
+  volunteeringMinutes: number | null;
+};
+
+export type GiveAnHourPreviousEntry = Pick<
+  GiveAnHourEntry,
+  "userId" | "displayName"
+>;
+
+export type GiveAnHourStats = {
+  minutes: number;
+  hours: number;
+  posts: number;
+  participants: number;
+  firstTimeParticipants: number;
+  averageHoursPerParticipant: number;
+  locations: number;
+  countries: number;
+};
+
+const participantKey = ({ userId, displayName }: GiveAnHourPreviousEntry) => {
+  if (userId) return `user:${userId}`;
+  if (displayName) return `name:${displayName}`;
+  return null;
+};
+
+export function summarizeGiveAnHourEntries(
+  entries: GiveAnHourEntry[],
+  previousEntries: GiveAnHourPreviousEntry[],
+): GiveAnHourStats {
+  const previousUserIds = new Set(
+    previousEntries.flatMap(({ userId }) => (userId ? [userId] : [])),
+  );
+  const previousDisplayNames = new Set(
+    previousEntries.flatMap(({ displayName }) =>
+      displayName ? [displayName] : [],
+    ),
+  );
+
+  const participants = new Set<string>();
+  const returningParticipants = new Set<string>();
+
+  for (const entry of entries) {
+    const key = participantKey(entry);
+    if (!key) continue;
+
+    participants.add(key);
+    if (
+      (entry.userId && previousUserIds.has(entry.userId)) ||
+      (entry.displayName && previousDisplayNames.has(entry.displayName))
+    ) {
+      returningParticipants.add(key);
+    }
+  }
+
+  const mapFeatures = entries.flatMap(({ id, location }) =>
+    location ? [{ id, location }] : [],
+  );
+  const { locations, countries } = extractInfoFromMapFeatures(mapFeatures);
+  const minutes = entries.reduce(
+    (total, { volunteeringMinutes }) => total + (volunteeringMinutes ?? 0),
+    0,
+  );
+  const firstTimeParticipants = participants.size - returningParticipants.size;
+
+  return {
+    minutes,
+    hours: Math.round(minutes / 60),
+    posts: entries.length,
+    participants: participants.size,
+    firstTimeParticipants,
+    averageHoursPerParticipant:
+      participants.size === 0
+        ? 0
+        : Math.round(minutes / 60 / participants.size),
+    locations: locations.size,
+    countries: countries.size,
+  };
+}

--- a/apps/website/src/utils/give-an-hour.ts
+++ b/apps/website/src/utils/give-an-hour.ts
@@ -1,39 +1,18 @@
-import { extractInfoFromMapFeatures } from "./locations";
-
-export type GiveAnHourEntry = {
-  id: string;
+export type GiveAnHourParticipant = {
   userId: string | null;
   displayName: string | null;
-  location: string | null;
-  volunteeringMinutes: number | null;
 };
 
-export type GiveAnHourPreviousEntry = Pick<
-  GiveAnHourEntry,
-  "userId" | "displayName"
->;
-
-export type GiveAnHourStats = {
-  minutes: number;
-  hours: number;
-  posts: number;
-  participants: number;
-  firstTimeParticipants: number;
-  averageHoursPerParticipant: number;
-  locations: number;
-  countries: number;
-};
-
-const participantKey = ({ userId, displayName }: GiveAnHourPreviousEntry) => {
+const participantKey = ({ userId, displayName }: GiveAnHourParticipant) => {
   if (userId) return `user:${userId}`;
   if (displayName) return `name:${displayName}`;
   return null;
 };
 
-export function summarizeGiveAnHourEntries(
-  entries: GiveAnHourEntry[],
-  previousEntries: GiveAnHourPreviousEntry[],
-): GiveAnHourStats {
+export function countFirstTimeGiveAnHourParticipants(
+  entries: GiveAnHourParticipant[],
+  previousEntries: GiveAnHourParticipant[],
+) {
   const previousUserIds = new Set(
     previousEntries.flatMap(({ userId }) => (userId ? [userId] : [])),
   );
@@ -59,27 +38,5 @@ export function summarizeGiveAnHourEntries(
     }
   }
 
-  const mapFeatures = entries.flatMap(({ id, location }) =>
-    location ? [{ id, location }] : [],
-  );
-  const { locations, countries } = extractInfoFromMapFeatures(mapFeatures);
-  const minutes = entries.reduce(
-    (total, { volunteeringMinutes }) => total + (volunteeringMinutes ?? 0),
-    0,
-  );
-  const firstTimeParticipants = participants.size - returningParticipants.size;
-
-  return {
-    minutes,
-    hours: Math.round(minutes / 60),
-    posts: entries.length,
-    participants: participants.size,
-    firstTimeParticipants,
-    averageHoursPerParticipant:
-      participants.size === 0
-        ? 0
-        : Math.round(minutes / 60 / participants.size),
-    locations: locations.size,
-    countries: countries.size,
-  };
+  return participants.size - returningParticipants.size;
 }


### PR DESCRIPTION
## Describe your changes

Resolves #1188.

Adds aggregate statistics for WWF's Give an Hour for Earth campaigns to the Show and Tell Give an Hour page.

The new section:

- Summarizes total community hours and approximate days given during campaigns since 2024
- Shows average hours and posts per campaign
- Identifies the campaign with the most hours
- Adds the number of first-time participants beneath each yearly campaign progress bar. A first-time participant is someone who submitted during that campaign and had no approved Show and Tell submission before the campaign began.
- Shows average first-time participants and average hours per participant
- Counts total posts, unique locations, and countries
- Preserves the existing yearly campaign progress bars and styling

The statistics are calculated from approved Show and Tell submissions made during the configured campaign windows. Participants are de-duplicated by user ID, falling back to display name for anonymous submissions.

### Implementation details

- Hours and post counts are aggregated in Prisma using `_sum` and `_count`.
- Unique participants, first-time participant identities, and locations use skinny `distinct` queries rather than loading complete Show & Tell entries into Node.
- Prior-history queries are restricted to identities participating in each campaign.
- Per-campaign hours from the statistics query are reused by the progress bars, avoiding a duplicate aggregate request when that query succeeds.
- Tests exercise `getGiveAnHourStats` directly and verify the Prisma aggregate and distinct-query path.

## Notes for testing your change

1. Start the local website and database services.
2. Navigate to `/show-and-tell/give-an-hour`.
3. Confirm the existing 2024, 2025, and 2026 progress bars retain their existing appearance.
4. Confirm each campaign displays a first-time participant count beneath the existing hours-given text.
5. Confirm the summary displays total participants, hours, and approximate days since 2024.
6. Confirm the four metric cards display:
   - Average hours per campaign and most hours in a campaign
   - Average first-time participants per campaign and average hours per participant
   - Total posts and average posts per campaign
   - Unique locations and countries
7. On desktop:
   - Confirm all four metric cards appear in one horizontal row.
   - Confirm card labels, values, and separators do not overlap.
8. On mobile:
   - Confirm the cards use a readable 2×2 layout.
   - Confirm no text, cards, or progress content overflows horizontally.

Validation completed locally:

- Prettier formatting checks pass
- ESLint checks pass
- TypeScript and Next.js route generation pass
- All 13 website test files and 122 tests pass

<img width=1573 height=526 alt=desktop_layout src=https://github.com/user-attachments/assets/ff1fd068-1df0-44e7-b3c8-321d16d6d534 />
<img width=370 height=632 alt=mobile_layout_1 src=https://github.com/user-attachments/assets/e3010bd6-6d65-4cfc-a6d3-9abf992991bb />
<img width=370 height=419 alt=mobile_layout_2 src=https://github.com/user-attachments/assets/9ee5a481-bea5-4b39-bc25-e81bd9a6fb1a />
