### PR TITLE
Bump pnpm from 11.10.0 to

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   },
   "engines": {
     "node": ">=24.11.0",
-    "pnpm": "^11.10.0"
+    "pnpm": "^11.12.0"
   },
-  "packageManager": "pnpm@11.10.0",
+  "packageManager": "pnpm@11.12.0",
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",


### PR DESCRIPTION
Generated via `pnpm self-update`.

Check this workflow's logs at https://github.com/alveusgg/alveusgg/actions/runs/29215164317.