### PR TITLE
Add Chandler Power Hour + update Show and Tell description

### DIFF
--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -155,6 +155,14 @@ export const regularEventsWeekly = [
   // Friday
   [
     {
+      title: "Chandler Power Hour",
+      description:
+        "Join Chandler for an hour of chaos around the sanctuary to start your Friday.",
+      category: "Alveus Regular Stream",
+      link: "https://twitch.tv/AlveusSanctuary",
+      startTime: { hour: 10, minute: 0 },
+    },
+    {
       title: "Show & Tell",
       description:
         "Join us as we look at what the Alveus community has been doing recently.",

--- a/apps/website/src/data/calendar-events.ts
+++ b/apps/website/src/data/calendar-events.ts
@@ -157,7 +157,7 @@ export const regularEventsWeekly = [
     {
       title: "Show & Tell",
       description:
-        "Join Maya as she reviews this week's community submissions for Show and Tell.",
+        "Join us as we look at what the Alveus community has been doing recently.",
       category: "Alveus Regular Stream",
       link: "https://twitch.tv/AlveusSanctuary",
       startTime: { hour: 13, minute: 0 },


### PR DESCRIPTION
## Describe your changes

Adds a new regular calendar event, Chandler Power Hour, at 10 am each Friday.

Also, updates the Show and Tell description as it isn't always Maya that hosts.

## Notes for testing your change

Config matches most recent set of regular streams.
