### PR TITLE
Skip links with extra segments in nav active hook

### DIFF
--- a/apps/website/src/hooks/active.ts
+++ b/apps/website/src/hooks/active.ts
@@ -36,16 +36,24 @@ export const useActiveNav = () => {
       ({ path, segments }, link) => {
         const linkSegments = link.split("/").filter(Boolean);
 
+        // If the link has more segments than the current path, it can't be a match
+        if (linkSegments.length > pathSegments.length) {
+          return { path, segments };
+        }
+
+        // Find the first segment that doesn't match, and get how many segments did match before that
+        // If there were no mismatched segments, findIndex returns -1, so all segments matched
+        // If a segment didn't match, findIndex returns 0-indexed, which is also how many segments matched
         const invalidSegment = linkSegments.findIndex(
           (seg, i) => seg !== pathSegments[i],
         );
         const matchSegments =
           invalidSegment === -1 ? linkSegments.length : invalidSegment;
 
-        if (matchSegments > segments) {
-          return { path: link, segments: matchSegments };
-        }
-        return { path, segments };
+        // If we have more matching segments than the current best match, prefer this link
+        return matchSegments > segments
+          ? { path: link, segments: matchSegments }
+          : { path, segments };
       },
       { path: "/", segments: 0 },
     ).path;


### PR DESCRIPTION
## Describe your changes

Previously, when on `/donate`, `/donate/grants` would be marked as active. This happened before it was in the nav structure before `/donate`, and both had the same number of matching segments.

Now, when on `/donate`, `/donate` will be marked as active. This happens because first we'll see `/donate/grants` but it has more segments than `/donate` so it is skipped. Then, we'll process `/donate` and see that it has more matching segments than `/` (which is the default), so we'll pick that.

## Notes for testing your change

When on `/donate`, `/donate` shows as active. When on `/donate/grants`, `/donate/grants` shows as active. When on `/about/`, `/about` shows as active. When on `/about/tech`, `/about/tech` shows as active. When on `/about/tech/presets`, `/about/tech` shows as active.
