### PR TITLE
Mark nav dropdown active when child active

### DIFF
--- a/apps/website/src/components/layout/navbar/DesktopMenu.tsx
+++ b/apps/website/src/components/layout/navbar/DesktopMenu.tsx
@@ -10,7 +10,11 @@ import { useActiveNav } from "@/hooks/active";
 import IconChevronDown from "@/icons/IconChevronDown";
 
 import { Dropdown, DropdownMenuItems } from "./DropdownMenu";
-import { NavLink, navLinkClassesMain } from "./NavLink";
+import {
+  NavLink,
+  navLinkClassesMain,
+  navLinkClassesMainActive,
+} from "./NavLink";
 import { UtilityMenu } from "./UtilityMenu";
 
 export function DesktopMenu() {
@@ -45,6 +49,17 @@ export function DesktopMenu() {
                   <MenuButton
                     className={classes(
                       navLinkClassesMain,
+                      (("links" in link &&
+                        Object.values(link.links).some(
+                          (l) => l.link === active,
+                        )) ||
+                        ("groups" in link &&
+                          Object.values(link.groups).some((group) =>
+                            Object.values(group.links).some(
+                              (l) => l.link === active,
+                            ),
+                          ))) &&
+                        navLinkClassesMainActive,
                       "group/button flex items-center gap-2",
                     )}
                   >


### PR DESCRIPTION
## Describe your changes

Applies the same active border style to a dropdown with an active link inside that is used for a non-dropdown nav link when it is active.

## Notes for testing your change

When on `/donate`, `Donate` is marked as active. When on `/about`, `About` and `About Alveus` are marked active.
