### PR TITLE
Stop show and tell videos playing when scrolled out of view

### DIFF
--- a/apps/website/src/components/show-and-tell/gallery/VideoItem.tsx
+++ b/apps/website/src/components/show-and-tell/gallery/VideoItem.tsx
@@ -1,4 +1,5 @@
 import type { JSX, ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { LinkAttachment } from "@alveusgg/database";
 
@@ -119,9 +120,43 @@ const embeds: Record<
 export const VideoItemEmbed = ({ videoAttachment }: VideoItemEmbedProps) => {
   const parsed = parseVideoUrl(videoAttachment.url);
   const config = parsed && videoPlatformConfigs[parsed.platform];
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    const isScrollable = (el: Element) =>
+      ["auto", "scroll", "hidden"].includes(getComputedStyle(el).overflowX);
+
+    let scrollContainer = node.parentElement;
+    while (scrollContainer && !isScrollable(scrollContainer)) {
+      scrollContainer = scrollContainer.parentElement;
+    }
+    if (!scrollContainer) return;
+
+    const check = () => {
+      const containerRect = scrollContainer.getBoundingClientRect();
+      const nodeRect = node.getBoundingClientRect();
+      setVisible(
+        nodeRect.right > containerRect.left &&
+          nodeRect.left < containerRect.right,
+      );
+    };
+
+    check();
+    scrollContainer.addEventListener("scroll", check);
+    return () => scrollContainer.removeEventListener("scroll", check);
+  }, []);
+
   if (config) {
     const Embed = embeds[config.key];
-    return <Embed videoId={parsed.id} />;
+    return (
+      <div ref={containerRef} className="h-full">
+        {visible && <Embed videoId={parsed.id} />}
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Describe your changes

Video attachments in the show and tell lightbox kept playing in the background after scrolling to another item. This tracks whether a video's container is visible and unmounts the iframe when it isn't.

Resolves #2316

## Notes for testing your change

Tested with both YouTube and Streamable embeds, on Chrome and Firefox. Testing seen below (unmute when watching).

### Before:
- Chrome: 

https://github.com/user-attachments/assets/dba2ad73-e672-4f47-a106-d1d1c27a0fec


- Firefox:

https://github.com/user-attachments/assets/4ca13447-bbae-447e-877f-1f9544f1d24a


### After:
- Chrome:

https://github.com/user-attachments/assets/2b5428b5-4de9-440e-a97d-080ad4327324


- Firefox:

https://github.com/user-attachments/assets/5765ea17-6b6c-43d3-af15-546656c79520

