### PR TITLE
Pause lightbox videos when they scroll out of view

### DIFF
--- a/apps/website/src/components/content/Carousel.tsx
+++ b/apps/website/src/components/content/Carousel.tsx
@@ -30,6 +30,8 @@ type CarouselProps = {
   // only via the arrows or programmatic scrolling. Useful when items capture
   // their own pointer gestures (e.g. a pannable canvas).
   draggable?: boolean;
+  // Tells you which item is currently visible, by its key
+  onActiveKeyChange?: (key: string | undefined) => void;
 };
 
 const overlayButtonClassName =
@@ -47,6 +49,7 @@ const Carousel = ({
   variant = "default",
   overlayClassName = "",
   draggable = true,
+  onActiveKeyChange,
 }: CarouselProps) => {
   const reducedMotion = usePrefersReducedMotion();
 
@@ -141,7 +144,18 @@ const Carousel = ({
     else if (nearLeft) setState("start");
     else if (nearRight) setState("end");
     else setState("scrolling");
-  }, [interacted]);
+
+    // Work out which item is currently scrolled into view
+    if (onActiveKeyChange) {
+      const gap =
+        Number.parseFloat(getComputedStyle(current).columnGap) ||
+        Number.parseFloat(getComputedStyle(current).gap) ||
+        0;
+      const keys = Object.keys(items);
+      const index = Math.round(current.scrollLeft / (width + gap));
+      onActiveKeyChange(keys[Math.max(0, Math.min(index, keys.length - 1))]);
+    }
+  }, [interacted, items, onActiveKeyChange]);
 
   // Run the scroll handler on load to check our current state
   // Run it on any window resize to check our state

--- a/apps/website/src/components/content/Lightbox.tsx
+++ b/apps/website/src/components/content/Lightbox.tsx
@@ -29,9 +29,15 @@ const Lightbox = ({ open, onClose, items, className }: LightboxProps) => {
     setScrollTo(open);
   }, [open]);
 
+  // Track which item is currently scrolled into view
+  const [activeKey, setActiveKey] = useState<string>();
+  const itemRefs = useRef<Record<string, HTMLDivElement>>({});
+
   // When items render in the carousel, scroll to the item that was opened
   const itemsRef = useCallback(
     (refs: Record<string, HTMLDivElement>) => {
+      itemRefs.current = refs;
+
       if (!scrollTo) return;
 
       const item = refs[scrollTo];
@@ -42,6 +48,32 @@ const Lightbox = ({ open, onClose, items, className }: LightboxProps) => {
     },
     [scrollTo],
   );
+
+  // Pause any video iframes that aren't in the item currently scrolled into view
+  useEffect(() => {
+    if (!activeKey) return;
+
+    Object.entries(itemRefs.current).forEach(([key, el]) => {
+      if (key === activeKey) return;
+
+      el.querySelectorAll("iframe").forEach((iframe) => {
+        if (!iframe.src) return;
+        const { hostname } = new URL(iframe.src);
+
+        if (hostname.endsWith("youtube-nocookie.com")) {
+          iframe.contentWindow?.postMessage(
+            JSON.stringify({ event: "command", func: "pauseVideo", args: [] }),
+            "*",
+          );
+        } else if (hostname.endsWith("streamable.com")) {
+          iframe.contentWindow?.postMessage(
+            JSON.stringify({ context: "player.js", method: "pause" }),
+            "*",
+          );
+        }
+      });
+    });
+  }, [activeKey]);
 
   // Allow clicks that go through to the backdrop to close the lightbox
   // Except when the click is part of a drag operation
@@ -112,6 +144,7 @@ const Lightbox = ({ open, onClose, items, className }: LightboxProps) => {
             buttonClassName="px-0 py-6 my-auto text-alveus-tan [&>svg]:size-8 lg:[&>svg]:size-12 hover:text-alveus-green-400"
             itemClassName="basis-full max-w-full"
             itemsRef={itemsRef}
+            onActiveKeyChange={setActiveKey}
           />
 
           <button

--- a/apps/website/src/components/content/Streamable.tsx
+++ b/apps/website/src/components/content/Streamable.tsx
@@ -60,7 +60,7 @@ export const StreamableEmbed = ({ videoId, caption }: EmbedProps) => (
       <iframe
         src={iframeSrc(videoId)}
         title="Video embed"
-        referrerPolicy="no-referrer"
+        referrerPolicy="strict-origin-when-cross-origin"
         allow="fullscreen; encrypted-media"
         sandbox="allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox"
         loading="lazy"

--- a/apps/website/src/components/content/YouTube.tsx
+++ b/apps/website/src/components/content/YouTube.tsx
@@ -74,7 +74,7 @@ type EmbedProps = {
 const iframeSrc = (id: string, params?: Record<string, string>) =>
   `https://www.youtube-nocookie.com/embed/${encodeURIComponent(
     id,
-  )}?${new URLSearchParams({ ...params, modestbranding: "1", rel: "0" }).toString()}`;
+  )}?${new URLSearchParams({ ...params, modestbranding: "1", rel: "0", enablejsapi: "1" }).toString()}`;
 
 export const YouTubeEmbed = ({ videoId, videoParams, caption }: EmbedProps) => (
   <div className="flex h-full flex-col">


### PR DESCRIPTION
## Describe your changes

Video embeds kept playing in the background after scrolling to another item in the lightbox. This fixes it in the lightbox/carousel implementation itself, so it covers every page that uses the lightbox for videos (collaborations, ambassador clips, about pages, etc.)

Carousel now reports which item is currently scrolled into view. Lightbox uses that to tell any video iframe that's no longer active to pause.

Resolves #2316

This PR replaces #2339. This addresses the feedback there to fix it at the lightbox level instead. Let me know of any other issues with this fix.

## Notes for testing your change

Tested with both YouTube and Streamable embeds. Verified working on both Chrome and Firefox. Videos below show before/after on Chrome.

**Before:**

https://github.com/user-attachments/assets/8a29102c-90a2-4d01-b0be-f1c42ba77350


**After:**


https://github.com/user-attachments/assets/9aed9281-2bae-4391-b232-a85b712b67a7

