### PR TITLE
Bump pnpm from 11.22.0 to 11.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   },
   "engines": {
     "node": ">=24.11.0",
-    "pnpm": "^11.22.0"
+    "pnpm": "^11.25.0"
   },
-  "packageManager": "pnpm@11.22.0",
+  "packageManager": "pnpm@11.25.0",
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^17.3.0",


### PR DESCRIPTION
Generated via `pnpm self-update`.

Check this workflow's logs at https://github.com/alveusgg/alveusgg/actions/runs/33473525679.